### PR TITLE
Adds quickstart section

### DIFF
--- a/docs/vendor/quickstart-cli.md
+++ b/docs/vendor/quickstart-cli.md
@@ -1,9 +1,4 @@
----
-date: "2019-02-20T00:00:00Z"
-lastmod: "2019-02-20T00:00:00Z"
-title: "Quickstart with the Replicated CLI"
-weight: "1003"
----
+# Quickstart with the Replicated CLI
 
 This power-user's guide will help you get set up with a CLI-based workflow for quickly iterating on your Kubernetes application with KOTS.
 If you'd prefer a more conceptual overview before digging into the CLI tools, you can start with the [standard quickstart](/vendor/guides/quickstart).

--- a/docs/vendor/quickstart-existing-cluster.md
+++ b/docs/vendor/quickstart-existing-cluster.md
@@ -1,9 +1,4 @@
----
-date: "2020-02-20T00:00:00Z"
-lastmod: "2020-02-20T00:00:00Z"
-title: "Quickstart with an existing cluster"
-weight: "1003"
----
+# Quickstart with an existing cluster
 
 The KOTS Existing Cluster Guide is one of our simplest guides.
 We'll get running quickly with a simple Nginx application on an existing cluster in GKE (or another cluster you have handy).

--- a/docs/vendor/quickstart-without-existing-cluster.md
+++ b/docs/vendor/quickstart-without-existing-cluster.md
@@ -1,12 +1,4 @@
----
-date: "2020-02-20T00:00:00Z"
-lastmod: "2020-02-20T00:00:00Z"
-title: "Quickstart without an existing cluster"
-weight: "1002"
-aliases:
-  - /vendor/quickstart
-  - /vendor/quickstart/create-release
----
+# Quickstart without an existing cluster
 
 The KOTS Quickstart is our simplest guide, we'll get running quickly with a simple Nginx application in Kubernetes using a single VM.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -28,9 +28,9 @@ const sidebars = {
           type: 'category',
           label: 'Quickstarts',
           items: [
-            'vendor/quickstart',
-            'vendor/existing-cluster',
-            'vendor/cli-quickstart',
+            'vendor/quickstart-without-existing-cluster',
+            'vendor/quickstart-existing-cluster',
+            'vendor/quickstart-cli',
           ],
         },
         {


### PR DESCRIPTION
This PR does the following: 
- Adds a Quickstarts section to the top of the Vendor TOC
- Adds quickstart.md, existing-cluster.md, and cli-quickstart.md to this section
- Updates the topic titles to: Quickstart with an existing cluster, Quickstart without an existing cluster, Quickstart with the Replicated CLI.

@samantha-replicated, let me know what you think here with the titles--I revised them from the sample TOC a bit. I thought "without an existing cluster" might be more meaningful to users just getting started than "embedded cluster". Also wanted to clarify that we are talking about a quickstart procedure for the Replicated CLI specifically. Started with "Quickstart" for the CLI title to keep consistent with the other topic titles in this section.
