### PR TITLE
39507 adds kots cli link to TOC

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -90,6 +90,11 @@ const sidebars = {
             'vendor/tutorial-existing-cluster',
           ],
         },
+        {
+          type: 'link',
+          label: 'KOTS CLI Documentation',
+          href: 'https://kots.io/kots-cli/getting-started/'
+        },
       ],
     },
     {
@@ -105,11 +110,6 @@ const sidebars = {
           ],
         },
       ],
-    },
-    {
-      type: 'link',
-      label: 'KOTS CLI Documentation',
-      href: 'https://kots.io/kots-cli/getting-started/'
     },
   ],
 };


### PR DESCRIPTION
Per https://replicated.slack.com/archives/C02BPJQQP28/p1639415935348800, we are not migrating the KOTS CLI content to the new commercial documentation website because the KOTS CLI is an open source tool. I added an external link from the commercial doc TOC to the open source KOTS CLI docs 