### PR TITLE
40333 migrates k8s operator section of toc

### DIFF
--- a/docs/vendor/operator-defining-additional-images.md
+++ b/docs/vendor/operator-defining-additional-images.md
@@ -1,0 +1,30 @@
+# Defining additional images
+
+To ensure that images will be available locally, KOTS finds all images defined in the application manifests and includes them in airgap bundles.
+During the install or update workflow, KOTS will collect these images from the airgap bundle (if airgapped) or from the internet (if online), retag and push all of the images to customer-defined registry.
+
+If there are required images that are not defined in any of the Kubernetes manifests, these should be listed in the `additionalImages` attribute of the [Application](/reference/v1beta1/application/) spec.
+
+```yaml
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: my-operator
+spec:
+  additionalImages:
+    - elasticsearch:7.6.0
+    - registry.replicated.com/my-operator/my-private-image:abd123f
+    - quay.io/orgname/private-image:v1.2.3
+```
+
+KOTS supports additional images that are:
+
+- public images: referenced by the docker pullable image name
+- images pushed to the Replicated Registry: referenced by the `registry.replicated.com` name
+- images pushed to another [private, linked registry](https://kots.io/vendor/packaging/private-images/): referenced by the docker pullable name
+
+## Authentication
+
+When creating the airgap bundle or performing an online install, KOTS will ensure that private images are available, without sharing registry credentials with the installation.
+Airgapped packages include the image layers in the bundle, and online installs will rewrite externally hosted private images to be pulled from `proxy.replicated.com`.
+When the installation sends credentials to `proxy.replicated.com` or `registry.replicated.com`, the credentials are based on the customer license file, and the credentials stop working when the license expires.

--- a/docs/vendor/operator-defining-additional-namespaces.md
+++ b/docs/vendor/operator-defining-additional-namespaces.md
@@ -1,0 +1,48 @@
+# Defining additional namespaces
+
+Operators often need to be able to manage resource in multiple namespaces in the cluster.
+When deploying a KOTS application to an existing cluster, KOTS creates a Kubernetes Role and RoleBinding that are limited to only accessing the namespace that the application is being installed into.
+In addition to RBAC policies, clusters running in airgapped environments or clusters that are configured to use a local registry also need to ensure that image pull secrets exist in all namespaces that the operator will manage resource in.
+
+## Creating additional namespaces
+
+A KOTS application can identify additional namespaces to create during installation time.
+These are defined in the `additionalNamespaces` attribute of the [Application](/reference/v1beta1/application/) spec.
+When these are defined, `kots install` will create the namespaces and ensure that the Admin Console has full access to manage resources in these namespaces.
+This is accomplished by creating a Role and RoleBinding per namespace, and setting the Subject to the Admin Console service account.
+If the current user account does not have access to create these additional namespaces, the installer will show an error and fail.
+
+```yaml
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: my-operator
+spec:
+  additionalNamespaces:
+    - namespace1
+    - namespace2
+```
+
+In addition to creating these namespaces, the Admin Console will ensure that the application pull secret exists in them, and that this secret has access to pull the application images (both images that are used and [additionalImages](/vendor/operators/additional-images/)).
+Pull secret name can be obtained using the [ImagePullSecretName](/reference/template-functions/config-context/#imagepullsecretname) template function.
+An operator can reliably depend on this secret existing in all installs (online and airgapped), and can use this secret name in any created podspec to pull private images.
+
+## Dynamic namespaces
+
+Some applications need access to dynamically created namespaces or even all namespaces.
+In this case, a KOTS application spec can list `"*"` as one of it's `addtionalNamespaces` in the [Application](/reference/v1beta1/application/) spec.
+When KOTS encounters the wildcard, it will not create any namespaces, but it will ensure that the application image pull secret is copied to all namespaces.
+The Admin Console will run an informer internally to watch namespaces in the cluster, and when a new namespace is created, the secret will automatically be copied to it.
+
+```yaml
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: my-operator
+spec:
+  additionalNamespaces:
+    - "*"
+```
+
+When the wildcard (`"*"`) is listed in `additionalNamespaces`, the KOTS installer will use a ClusterRole and ClusterRoleBinding for the Admin Console.
+This will ensure that the Admin Console will continue to have permissions to all newly created namespaces, even after the install has finished.

--- a/docs/vendor/operator-packaging-about.md
+++ b/docs/vendor/operator-packaging-about.md
@@ -1,0 +1,12 @@
+# About packaging a Kubernetes operator application
+
+Kubernetes Operators can be packaged and delivered as a KOTS application using the same methods as other Kubernetes applications.
+Operators are generally defined using one or more `CustomResourceDefinition` manifests, and the controller is often a `StatefulSet`, along with other additional objects.
+These Kubernetes manifests can be included in a KOTS application by adding them to a release and promoting the release to a channel.
+
+Kubernetes Operators differ from traditional applications because they interact with the Kubernetes API to create and manage other objects at runtime.
+When a `CustomResource` is deployed to the cluster that has the operator running, the Operator may need to create new Kubernetes objects to fulfill the request.
+When an Operator creates an object that includes a `PodSpec`, the Operator should use locally-available images in order to remain compatible with airgapped environments and customers who have configured a local registry to push all images to.
+Even non-airgapped enviroments may need access to private images that are included as part of the KOTS application at runtime.
+
+A KOTS application includes a definition for the developer to list the additional images that are required for the application, and by exposing the local registry details (endpoint, namespace and secrets) to the application so that they can be referenced when creating a `PodSpec` at runtime.

--- a/docs/vendor/operator-referencing-images.md
+++ b/docs/vendor/operator-referencing-images.md
@@ -1,0 +1,120 @@
+# Referencing images
+
+KOTS is responsible for delivering and ensuring that all container images (automatically detected and additionalImages) are pushed to the customer's private, internal registry.
+Additionally, KOTS creates Kustomize patches to rewrite image names and inject image pull secrets to all pods.
+
+KOTS cannot modify pods that are created at runtime by the Operator.
+To support this in all environments, the Operator code should use KOTS functionality to determine the image name and image pull secrets for all pods when they are created.
+
+There are several template functions available to assist with this.
+This may require 2 new environment variables to be added to a manager to read these values.
+The steps to ensure that an Operator is using the correct image names and has the correct image pull secrets in dynamically created pods are:
+
+1. Add a new environment variables to the Manager Pod so that the Manager knows the location of the private registry, if one is set.
+2. Add a new environment variable to the Manager Pod so that the Manager also knows the `imagePullSecret` that's needed to pull the local image.
+
+### Adding a reference to the local registry
+
+The manager of an operator is often a `Statefulset`, but could be a `Deployment` or another kind.
+Regardless of where the spec is defined, the location of the private images can be read using the [Replicated template functions](/vendor/packaging/template-functions/).
+
+#### Option 1: Define each image
+If an operator only requires one additional image, the easiest way to determine this location is to use the `LocalImageName` function.
+This will always return the image name to use, whether the customer's environment is configured to use a local registry or not.
+
+**Example:**
+
+```yaml
+env:
+  - name: IMAGE_NAME_ONE
+    value: 'repl{{ LocalImageName "elasticsearch:7.6.0" }}'
+```
+
+For online installations (no local registry), this will be written with no changes -- the variable will contain `elasticsearch:7.6.0`.
+For installations that are airgapped or have a locally-configured registry, this will be rewritten as the locally referencable image name (i.e. `registry.somebigbank.com/my-app/elasticsearch:7.6.0`).
+
+**Example:**
+
+```yaml
+env:
+  - name: IMAGE_NAME_TWO
+    value: 'repl{{ LocalImageName "quay.io/orgname/private-image:v1.2.3" }}'
+```
+
+In the above example, this is a private image, and will always be rewritten. For online installations, this will return `proxy.replicated.com/proxy/app-name/quay.io/orgname/private-image:v1.2.3` and for installations with a locally-configured registry it will return `registry.somebigbank.com/org/my-app-private-image:v.1.2.3`.
+
+#### Option 2: Build image names manually
+
+For applications that have multiple images or dynamically construct the image name at runtime, the Replicated Template functions can also return the elements that make up the local registry endpoint and secrets, and let the application developer construct the locally-referencable image name.
+
+**Example:**
+
+```yaml
+env:
+  - name: REGISTRY_HOST
+    value: 'repl{{ LocalRegistryHost }}'
+  - name: REGISTRY_NAMESPACE
+    value: 'repl{{ LocalRegistryNamespace }}'
+```
+
+### Determining the imagePullSecret
+
+Private, local images will need to reference an image pull secret to be pulled.
+The value of the secret's `.dockerconfigjson` is provided in a template function, and the application can write this pull secret as a new secret to the namespace.
+If the application is deploying the pod to the same namespace as the operator, the pull secret will already exist in the namespace, and the secret name can be obtained using the [ImagePullSecretName](/reference/template-functions/config-context/#imagepullsecretname) template function.
+KOTS will create this secret automatically, but only in the namespace that the operator is running in.
+It's the responsibility of the application developer (the Operator code) to ensure that this secret is present in any namespace that new pods will be deployed to.
+
+This template function returns the base64-encoded, docker auth that can be written directly to a secret, and referenced in the `imagePullSecrets` attribute of the PodSpec.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: myregistrykey
+  namespace: awesomeapps
+data:
+  .dockerconfigjson: '{{repl LocalRegistryImagePullSecret }}'
+type: kubernetes.io/dockerconfigjson
+```
+
+This will return an image pull secret for the locally configured registry.
+Its recommended to pass in the image name to this if your application has both public and private images.
+This will ensure that installs without a local registry can differentiate between private, proxied and public images.
+
+**Example:**
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-pull-secret
+  namespace: awesomeapps
+data:
+  .dockerconfigjson: '{{repl LocalRegistryImagePullSecret }}'
+type: kubernetes.io/dockerconfigjson
+```
+
+In the above example, the `LocalRegistryImagePullSecret()` function will return an empty auth array if the installation is not airgapped, does not have a local registry configured, and the `elasticsearch:7.6.0` image is public.
+If the image is private, the function will return the license-key derived pull secret.
+And finally, if the installation is using a local registry, the image pull secret will contain the credentials needed to pull from the local registry.
+
+**Example:**
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-pull-secret
+  namespace: awesomeapps
+data:
+  .dockerconfigjson: '{{repl LocalRegistryImagePullSecret }}'
+type: kubernetes.io/dockerconfigjson
+```
+
+The above example will always return an image pull secret.
+For installations without a local registry, it will be the Replicated license secret, and for installations with a local regisrtry, it will be the local registry.
+
+## Using the local registry at runtime
+
+The developer of the Operator should use these environment variables to change the `image.name` in any deployed PodSpec to ensure that it will work in airgapped environments.

--- a/sidebars.js
+++ b/sidebars.js
@@ -89,6 +89,16 @@ const sidebars = {
         },
         {
           type: 'category',
+          label: 'Packaging a Kubernetes operator application',
+          items: [
+            'vendor/operator-packaging-about',
+            'vendor/operator-defining-additional-images',
+            'vendor/operator-referencing-images',
+            'vendor/operator-defining-additional-namespaces'
+          ],
+        },
+        {
+          type: 'category',
           label: 'Tutorials',
           items: [
             'vendor/tutorial-existing-cluster',


### PR DESCRIPTION
Migrates the "Operators" section of the kots.io TOC (https://kots.io/vendor/operators/packaging-an-operator/) into a new section of the replicated-docs TOC. 

Shortcut: https://app.shortcut.com/replicated/story/40333/content-migration-operators