### PR TITLE
40339 migrate admin console customization

### DIFF
--- a/docs/vendor/admin-console-customize-app-icon.md
+++ b/docs/vendor/admin-console-customize-app-icon.md
@@ -1,0 +1,30 @@
+# Customizing the application icon
+
+Selecting the right logo is important to making sure that brands are reflected properly in the Kots Admin Console.
+Here we will go over some tips for adding a 'proper' logo to an application YAML file.
+
+To add a custom icon for an application, include an `icons` key under the `descriptor` where a src url and an image type will be specified.
+
+```yaml
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: my-application
+spec:
+  title: My Application
+  icon: https://kots.io/images/kotsadm-logo-large@2x.png
+```
+
+## Proper logo size
+For logos to look best in the Kots Admin Console, use a PNG or JPG that is square, at least 250x250 pixels, and exported at 2x. Logo's will be contained to a bounding box so although a logo with a rectangular shape will work, the logo may be small and hard to see. The next section will show an example.
+
+Here is the full Admin Console wordmark logo shown on the the login screen.
+Although the entire logo is visible because it's being contained to the circle, it's a little small and will appear even smaller, about half of this size, in some parts of the Admin Console.
+
+![Kotsadm logo](/images/login-icon-large.png)
+
+Instead it is recommended to use the smaller lettermark logo as the application logo which will appear larger in the bounding boxes.
+
+![Kotsadm lettermark logo](/images/login-icon-small.png)
+
+When possible it's best to use an icon or lettermark as the application icon rather than the full wordmark logo.

--- a/docs/vendor/admin-console-customize-config-screen.md
+++ b/docs/vendor/admin-console-customize-config-screen.md
@@ -1,0 +1,57 @@
+# Customizing the admin console configuration screen
+
+KOTS applications can include a robust, custom configuration page.
+This is a dynamic form that can be used to prompt for, validate and generate inputs that are needed to start the application. During installation, the customer will be directed to this page after uploading a license if there are required fields.
+For applications that don't have any required fields, this page will be accessible from the Config tab of the Admin Console.
+
+To add a configuration page to your application, add a new Kubernetes manifest to a release that contains the field definitions. Below is a short example of a config screen definition.
+The API reference docs contain the [full Config language syntax](/reference/v1beta1/config/).
+
+```yaml
+apiVersion: kots.io/v1beta1
+kind: Config
+metadata:
+  name: my-application
+spec:
+  groups:
+    - name: smtp_settings
+      title: Mail Server (SMTP)
+      description: Configuration to use an external mail server
+      items:
+        - name: enable_smtp
+          type: bool
+          default: "0"
+        - name: smtp_hostname
+          title: SMTP Server Hostname
+          type: text
+          required: true
+        - name: smtp_username
+          title: SMTP Username
+          type: text
+          required: true
+        - name: smtp_password
+          title: SMTP Password
+          type: password
+          required: true
+```
+
+## Template Functions
+Customer supplied values can be used when generating the YAML by using the `{{repl ConfigOption <item_name>}}` syntax.
+For example, to set the `smtp_hostname` value in the above YAML as the value of an environment variable in a PodSpec:
+
+```yaml
+env:
+  name: SMTP_USERNAME
+  value: '{{repl ConfigOption "smtp_username"}}'
+```
+
+## Defaults and Values
+Config options can receive their default values through two different keys: `default` and `value`.
+If a value is provided in the `value` key, this is treated the same as a user-supplied value, and will not be overwritten on application update.
+The user will see this value on the Config screen in the Admin Console, and it's indistinguishable from other values they provided.
+If a value is only provided in the `default` key, this value will be used when rendering the application YAML, but the value will show up as a placeholder on the Config screen in the Admin Console.
+The default value will only be used if the user doesn't provide a different value.
+
+## Required Fields
+Fields can optionally be set to `required`.
+When there are required fields, the user will see the config screen during installation, and will not be permitted to save the Config values without providing a value for require fields.

--- a/docs/vendor/admin-console-display-app-status.md
+++ b/docs/vendor/admin-console-display-app-status.md
@@ -1,0 +1,49 @@
+# Displaying application status
+
+With minimal additional configuration to the kots.io Application YAML, it is possible to display application status on the dashboard of the Admin Console.
+
+![Application Status](/images/kotsadm-dashboard-appstatus.png)
+
+It is necessary to target specific Kubernetes resources for the dashboard to accurately report status.
+We suggest at least one resource be added.
+Resources that are currently supported are Deployments, StatefulSets, Services, Ingresses and PersistentVolumeClaims.
+
+## Kots Application Spec
+
+To add an informer, simply include the `statusInformers` property in the kots.io Application spec.
+Status informers are in the format `[namespace/]type/name` where namespace is optional and will default to the current namespace.
+
+```yaml
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: my-application
+spec:
+  statusInformers:
+    - deployment/my-web-svc
+    - deployment/my-worker
+```
+
+Entries also support template functions.
+For example, a specific status informer can be excluded based on an application config value like so:
+
+```yaml
+statusInformers:
+    - deployment/my-web-svc
+    - '{{repl if ConfigOptionEquals "option" "value"}}deployment/my-worker{{repl else}}{{repl end}}'
+```
+
+## Resource Statuses
+
+Possible application statuses are "Missing", "Unavailable", "Degraded" and "Ready". "Missing" is a special status that indicates that informers have yet to report back status.
+A [support bundle](/kotsadm/troubleshooting/support-bundle/) will include diagnostic information when state "Missing" is encountered.
+
+Below is a table of resources that are supported and conditions that contribute to each status:
+
+| | Unavailable | Degraded | Ready |
+|---|---|---|---|
+| **Deployment** | No replicas are ready | At least 1 replica is ready and less than desired | Ready replicas equals desired replicas |
+| **StatefulSet** | No replicas are ready | At least 1 replica is ready and less than desired | Ready replicas equals desired replicas |
+| **Service** | No endpoints are ready, no load balancer has been assigned | At least one endpoint is ready and less than desired | All desired endpoints are ready, any load balancers have been assigned |
+| **Ingress** | No backend service endpoints are ready, no load balancer has been assigned | At least one backend service endpoint is ready and less than desired | All desired backend service endpoints are ready, any load balancers have been assigned |
+| **PersistentVolumeClaim** | Claim is pending or lost | n/a | Claim is bound |

--- a/docs/vendor/admin-console-port-forwarding.md
+++ b/docs/vendor/admin-console-port-forwarding.md
@@ -1,0 +1,78 @@
+# Enabling port forwarding
+
+When distributing an application, it’s helpful to make sure that the person or process performing the installation can easily verify that the application is running.
+Networking and ingress is handled differently in each cluster and this makes it difficult to provide a consistent URL at application packaging time, and even likely requires that the cluster operator creates firewall rules before they can test the application installation.
+
+KOTS and the Admin Console can provide a port-forward tunnel that will work more consistently to provide an easy way for the cluster operator to open one or more links directly to the application before ingress and firewalls are configured.
+
+To export a port and a button on the Admin Console dashboard to the application, a couple of additional steps are necessary.
+
+## Add a button to the dashboard
+
+It’s recommended that every KOTS application include an application custom resource as defined by https://github.com/kubernetes-sigs/application.
+KOTS uses this as metadata and will not require or use an in-cluster controller to handle this custom resource.
+A KOTS application that follows best practices will never require cluster admin privileges or any cluster-wide components to be installed.
+
+The Application custom resource includes many fields, but the one that we are going to examine in this document is the links:
+
+The `spec.descriptor.links` field is an array of links that reference the application, once it’s deployed.
+
+Each link contains two fields, description and url.
+
+The description field is the title of the button that will be added to the admin console.
+The url field should be the url of your application.
+
+You can use the service name in place of the host name and KOTS will rewrite the URL with hostname in the browser.
+
+#### Example
+
+```yaml
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: "my-application"
+  labels:
+    app.kubernetes.io/name: "my-application"
+    app.kubernetes.io/version: "1.0.0"
+spec:
+  selector:
+    matchLabels:
+     app.kubernetes.io/name: "my-application"
+  descriptor:
+    links:
+      - description: "Open My Application"
+        url: https://my-application-url
+```
+
+## Additional ports and port forwarding
+
+When running the KOTS kubectl plugin, KOTS can add additional ports that are defined in the application to the port-forward tunnel.
+This is useful for internal services such as application admin controls and other services that should not be exposed to all users.
+It's also recommended to list the primary application port(s) here to make verification of the installation possible before ingress is installed.
+
+In order to define additional ports, add a `ports` key to the `kots.io/v1beta1, kind: Application` manifest.
+
+#### Example
+
+```yaml
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: my-application
+spec:
+  title: My Application
+  icon: my-application-logo-uri
+  ports:
+    - serviceName: "myapplication-service"
+      servicePort: 9000
+      localPort: 9000
+      applicationUrl: "http://myapplication-service"
+ ```
+
+Given the above example, when the application starts and the service is ready, the KOTS CLI will run the equivalent of `kubectl port-forward svc/myapplication-service 9000:9000` and print a message in the terminal.
+Service should reference the service name that the application deployed without the namespace.
+
+## Using dashboard buttons with port forward
+
+Finally, it's possible to combine these two features and use a dashboard button that links to a port-forwarded service.
+When doing this, it's recommended to not use https but instead use http, unless TLS termination is happening in the application pod.

--- a/docs/vendor/admin-console-prometheus-monitoring.md
+++ b/docs/vendor/admin-console-prometheus-monitoring.md
@@ -1,0 +1,51 @@
+# Adding custom graphs
+
+By default, when installing a Kots application into an embedded cluster, the Prometheus monitoring system will be included alongside the Kots application.
+This will collect valuable metrics about the cluster as well as the application and expose graphs with key metrics on the dashboard of the Admin Console.
+When running in an existing cluster, it is possible to configure the address of the Prometheus service in the Admin Console.
+
+![Graphs](/images/kotsadm-dashboard-graph.png)
+
+By default, metrics graphs that are included monitor cluster disk usage, pod cpu usage, pod memory usage and pod health.
+
+### Kots Application Spec
+
+To add custom graphs, use the `graphs` property of the kots.io Application spec.
+A minimal graph includes only a title and a Prometheus query:
+
+```yaml
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: my-application
+spec:
+  graphs:
+    - title: User Signups
+      query: 'sum(user_signup_events_total)'
+```
+
+See below for a more robust example:
+
+```yaml
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: my-application
+spec:
+  graphs:
+    - title: Disk Usage
+      queries:
+        - query: 'sum((node_filesystem_size_bytes{job="node-exporter",fstype!="",instance!=""} - node_filesystem_avail_bytes{job="node-exporter", fstype!=""})) by (instance)'
+          legend: 'Used: {{ instance }}'
+        - query: 'sum((node_filesystem_avail_bytes{job="node-exporter",fstype!="",instance!=""})) by (instance)'
+          legend: 'Available: {{ instance }}'
+      yAxisFormat: bytes
+```
+
+### Prometheus Query
+
+A valid PromQL prometheus query is required in the `query` property.
+By default an [Embedded Cluster](/vendor/embedded-kubernetes/embedded-kubernetes/) exposes the Prometheus [Expression Browser](https://prometheus.io/docs/visualization/browser/) at NodePort 30900.
+This can be used to aid in constructing queries.
+
+More information on querying Prometheus with PromQL can be found [here](https://prometheus.io/docs/prometheus/latest/querying/basics/).

--- a/sidebars.js
+++ b/sidebars.js
@@ -89,12 +89,23 @@ const sidebars = {
         },
         {
           type: 'category',
+          label: 'Customizing the admin console',
+          items: [
+            'vendor/admin-console-customize-config-screen',
+            'vendor/admin-console-customize-app-icon',
+            'vendor/admin-console-display-app-status',
+            'vendor/admin-console-port-forwarding',
+            'vendor/admin-console-prometheus-monitoring',
+          ],
+        },
+        {
+          type: 'category',
           label: 'Packaging a Kubernetes operator application',
           items: [
             'vendor/operator-packaging-about',
             'vendor/operator-defining-additional-images',
             'vendor/operator-referencing-images',
-            'vendor/operator-defining-additional-namespaces'
+            'vendor/operator-defining-additional-namespaces',
           ],
         },
         {


### PR DESCRIPTION
Migrates content from Admin Console Customization https://kots.io/vendor/config/config-screen/ to a new Admin console customization section.

Shortcut: [40339](https://app.shortcut.com/replicated/story/40339/content-migration-admin-console-customization)