### PR TITLE
39497 adds preflight and bundles topic to subnav

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -79,6 +79,10 @@ const sidebars = {
           id: 'vendor/identity-service-configuring',
         },
         {
+          type: 'doc',
+          id: 'vendor/preflight-support-bundle-creating',
+        },
+        {
           type: 'category',
           label: 'Helm',
           items: [


### PR DESCRIPTION
I created a new topic about preflight checks and support bundles that links off to the troubleshoot.sh content as part of: https://app.shortcut.com/replicated/story/40184/determine-what-content-currently-exists-for-the-using-preflight-checks-and-support-bundles-section-of-the-toc-wip

For this story (https://app.shortcut.com/replicated/story/39497/content-migration-using-preflight-checks-support-bundles), I've only added that new topic to the subnav. As it is a standalone topic, we'll need to work together on figuring out the best place for it to go when we give the overall TOC some attention. There wasn't a logical home as of now. 