### PR TITLE
39553 migrates troubleshooting content

### DIFF
--- a/docs/enterprise/troubleshooting-an-app.md
+++ b/docs/enterprise/troubleshooting-an-app.md
@@ -1,0 +1,20 @@
+# Troubleshooting an application
+
+When using the Admin Console to manage an application, a Troubleshoot tab is available to generate, analyze, manage, and provide remediation suggestions when an application isn't running optimally.
+
+To start, click on the Troubleshoot tab in the Admin Console.
+
+![Troubleshoot](/images/troubleshoot.png)
+
+The green button will start analyzing the application.
+No data will leave the cluster -- the analysis works by the `Admin Console Operator` executing the [Support Bundle plugin](https://troubleshoot.sh), and sending the collected bundle directly to the admin console api.
+It's never sent across the internet, or to anyone else.
+
+![Troubleshooting](/images/troubleshooting.png)
+
+The collected bundle is then run through various analyzers, and the results are shown.
+If any known issues are detected, they will be highlighted, with possible remediation suggestions.
+
+![Analysis](/images/analysis.png)
+
+For additional help, the collected and redacted Support Bundle can be downloaded using the "Download bundle" button and sent to the application developer for assistance.

--- a/sidebars.js
+++ b/sidebars.js
@@ -230,6 +230,10 @@ const sidebars = {
           type: 'doc',
           id: 'enterprise/monitoring-prometheus'
         },
+        {
+          type: 'doc',
+          id: 'enterprise/troubleshooting-an-app'
+        },
       ],
     },
   ],


### PR DESCRIPTION
Migrates the Troubleshooting content from Admin Console. Similar situation as Monitoring where there is only one topic in this section, so I pulled it out of the bucket to avoid the extra click.