### PR TITLE
39548 creates image registries section

### DIFF
--- a/docs/enterprise/image-registry-embedded-cluster.md
+++ b/docs/enterprise/image-registry-embedded-cluster.md
@@ -1,0 +1,51 @@
+# About deploying a registry on an embedded cluster
+
+This topic describes using the kURL registry add-on to host application images on embedded clusters.
+
+## About the kURL registry add-on
+
+KOTS can be installed as an add-on on a [kURL](https://kurl.sh/docs/introduction/) cluster, which can also include the [registry add-on](https://kurl.sh/docs/add-ons/registry).
+When installing in [air gap](/kotsadm/installing/installing-embedded-cluster/#airgapped-installations) mode, the embedded registry will be automatically used to host all application images.
+
+## Enable and disable image garbage collection
+
+> Introduced in KOTS 1.48.0
+
+With every application update, new images will be pushed into this registry.
+In order to keep the registry from running out of storage, images that are no longer used will be automatically deleted from the registry.
+
+This feature is currently only supported in embedded kURL clusters when using the Registry add-on.
+Image garbage collection is enabled by default.
+To disable it, execute the following command in the kURL cluster:
+
+```bash
+kubectl patch configmaps kotsadm-confg --type merge -p "{\"data\":{\"enable-image-deletion\":\"false\"}}"
+```
+
+To enable it again, execute the following command:
+```bash
+kubectl patch configmaps kotsadm-confg --type merge -p "{\"data\":{\"enable-image-deletion\":\"false\"}}"
+```
+
+Garbage collection is triggered automatically when a new application version is deployed.
+The [admin-console garbage-collect-images](/kots-cli/admin-console/garbage-collect-images/) command can be used to trigger it manually.
+
+### Restoring deleted images
+Deleted images may be reloaded from application and Admin Console [airgap bundles](/kotsadm/installing/airgap-packages/) using the [admin-console push-images](/kots-cli/admin-console/push-images/) command.
+See [installation instructions](/kotsadm/installing/airgap-packages/#kots-install) for an example of using this command.
+Registry address and namespace can be found on the Registry Settings page in Admin Console.
+Registry username and password can be found in the `registry-creds` secret in the default namespace.
+
+### Limitations
+Currently the image garbage collection feature has following limitations:
+
+#### Shared image registries
+The image garbage collection process assumes that the registry is not shared with any other instances of KOTS nor any external applications.
+If the embedded registry is used by another external application, this feature should be disabled to prevent image loss.
+
+#### Customer supplied registries
+This feature is currently only supported when used with the embedded kURL registry.
+If the Admin Console instance is configured to use a different registry, this feature should be disabled to prevent image loss.
+
+#### Application rollbacks
+Currently image garbage collection has no effect when [application rollback](/reference/v1beta1/application/#allowrollback) is enabled.

--- a/docs/enterprise/image-registry-existing-cluster.md
+++ b/docs/enterprise/image-registry-existing-cluster.md
@@ -1,0 +1,30 @@
+# About deploying a registry on an existing cluster
+
+Kots can be used to download and prepare an application to be installed onto a secured, airgapped Kubernetes cluster.
+When doing this, there are a few additional steps and configuration needed.
+
+## Docker image registry requirements
+
+To install an application into an airgapped network, you must have a docker image registry that’s available inside the network.
+Kots will manage rewriting the application image names in all application manifests to read from the on-prem registry, and it will retag and push the images to the on-prem registry.
+When authenticating to the registry, credentials with `push` permissions are required.
+
+A single Kots application expects to use a single “namespace” in the docker image registry.
+
+The namespace name can be any valid URL-safe string, supplied at installation time.
+Keep in mind that a registry typically expects the namespace to exist before any images can be pushed into it.
+
+NOTE: ECR does not use namespaces.
+
+## Docker image registry compatibility
+
+Kots has been tested for compatibility with the following registries:
+
+- Docker Hub
+
+  **Note**: To avoid the November 20, 2020 Docker Hub rate limits, use the `kots docker ensure-secret` CLI command. For more information, see [Avoiding Docker Hub Rate Limits](image-registry-rate-limits).
+- Quay
+- Amazon Elastic Container Registry (ECR)
+- Google Container Registry (GCR)
+- Harbor
+- Sonatype Nexus

--- a/docs/enterprise/image-registry-rate-limits.md
+++ b/docs/enterprise/image-registry-rate-limits.md
@@ -1,0 +1,18 @@
+# Avoiding Docker Hub Rate Limits
+
+On November 20, 2020, rate limits for anonymous and free authenticated use of Docker Hub went into effect.
+Anonymous and Free Docker Hub users are limited to 100 and 200 container image pull requests per six hours.
+Docker Pro and Docker Team accounts continue to have unlimited access to pull container images from Docker Hub.
+
+For more information on rate limits, see [this article](https://www.docker.com/increase-rate-limits) from Docker.
+
+> Introduced in KOTS v1.44.0
+
+A Docker Hub username and password can be passed to the [kots docker ensure-secret](/kots-cli/docker/ensure-permissions/) CLI command, which will create an image pull secret that the Admin Console can utilize when pulling images to avoid rate limits.
+These credentials are only used to increase limits and do not need access to any private repositories on Docker Hub.
+
+Example:
+
+```bash
+kubectl kots docker ensure-secret --dockerhub-username sentrypro --dockerhub-password password --namespace sentry-pro
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -207,6 +207,15 @@ const sidebars = {
         },
         {
           type: 'category',
+          label: 'Using self-hosted image registries',
+          items: [
+            'enterprise/image-registry-existing-cluster',
+            'enterprise/image-registry-embedded-cluster',
+            'enterprise/image-registry-rate-limits',
+          ],
+        },
+        {
+          type: 'category',
           label: 'Updating',
           items: [
             'enterprise/updating-kots-apps',


### PR DESCRIPTION
Migrates image registries content from kots.io into a new Using self-hosted image registries bucket. 

I updated file names and titles as well as some headings within the topics just to be more descriptive for now. This section (and all image registry content) needs more attention to make it more coherent.

SC: https://app.shortcut.com/replicated/story/39548/content-migration-using-image-registries-admin