### PR TITLE
SC40481: Added topic "Creating a customer and downloading a license"

### DIFF
--- a/docs/vendor/entitlements-creating-new.md
+++ b/docs/vendor/entitlements-creating-new.md
@@ -108,6 +108,10 @@ rp({
 });
 ```
 
+## Next steps
+
+[Creating customers and downloading licenses](https://replicated-docs.netlify.app/docs/vendor/releases-creating-customer)
+
 ## Additional resources
 
-[How to use the Replicated product](http://localhost:3000/docs/vendor/getting-started-how-to-use-replicated)
+[How to release a packaged application](https://replicated-docs.netlify.app/docs/vendor/releases-workflow)

--- a/docs/vendor/releases-configuring-download-portal.md
+++ b/docs/vendor/releases-configuring-download-portal.md
@@ -1,3 +1,7 @@
 # Configuring the download portal
 
 Configuring the download portal and making the release available on this portal. Need more info from Amber.
+
+## Additional resources
+
+[How to release a packaged application](https://replicated-docs.netlify.app/docs/vendor/releases-workflow)

--- a/docs/vendor/releases-creating-channels.md
+++ b/docs/vendor/releases-creating-channels.md
@@ -37,7 +37,10 @@ To edit an existing channel:
 
 1. Click **Save**.
 
+## Next steps
+
+[Creating a release](https://replicated-docs.netlify.app/docs/vendor/releases-creating-releases)
 
 ## Additional resources
 
-[How to use the Replicated product](http://localhost:3000/docs/vendor/getting-started-how-to-use-replicated)
+[How to release a packaged application](https://replicated-docs.netlify.app/docs/vendor/releases-workflow)

--- a/docs/vendor/releases-creating-customer.md
+++ b/docs/vendor/releases-creating-customer.md
@@ -1,1 +1,31 @@
 # Creating a customer and downloading a license
+
+After you promote a release, create a customer and download the license.
+
+1. From the [vendor portal](https://vendor.replicated.com), select Customers from the left menu.
+1. Click **Create Customer**.
+
+  The Create a new customer page opens.
+
+1. Enter a customer name and assign a channel in the corresponding fields.
+1. Edit the remaining options or accept the defaults:
+
+    | Field                  | Description           |
+    |-----------------------|------------------------|
+    | Expiration policy | Defines how long the customer’s license will be valid and how to handle expired licenses. **Default:** Cusomer's license does not expire |
+    | Customer type| The type of customer is used solely for reporting purposes. Their access to your app is not affected by the type you assign to them. **Options:** Development, Trial, Paid, Community **Default:** Trial|
+    | License options | Enables the options that you have added to the application package. **Options:** Airgap, Gitops, Identity Service, Support Bundle Upload, Allow Snapshots|
+    | Customer fields | Lets you securely deliver customer-specific values or entitlements to the installation. The custom fields you create  apply to all customers. |
+
+1. Click **Save Changes**.
+1. From the Customer page, click the download license icon on the right side of the row.
+1. In the Opening _filename_ dialog, use the Save File default and click **OK**.
+    The file is saved to your Downloads folder by default.
+
+## Next steps
+
+Share the download and license with your customer either by email or by [configuring the download portal](http://localhost:3000/docs/vendor/releases-configuring-download-portal).
+
+## Additional resources
+
+[How to release a packaged application](https://replicated-docs.netlify.app/docs/vendor/releases-workflow)

--- a/docs/vendor/releases-creating-releases.md
+++ b/docs/vendor/releases-creating-releases.md
@@ -29,8 +29,8 @@ For additional information about deploying releases, see our [community](https:/
 
 ## Next steps
 
-Promote the release to a channel.
+[Promoting releases](https://replicated-docs.netlify.app/docs/vendor/releases-promoting)
 
 ## Additional resources
 
-[How to use the Replicated product](http://localhost:3000/docs/vendor/getting-started-how-to-use-replicated)
+[How to release a packaged application](https://replicated-docs.netlify.app/docs/vendor/releases-workflow)

--- a/docs/vendor/releases-promoting.md
+++ b/docs/vendor/releases-promoting.md
@@ -32,12 +32,9 @@ To promote a release:
 
 ## Next steps
 
-Create customers and download licenses.
+[Creating customers and downloading licenses](https://replicated-docs.netlify.app/docs/vendor/releases-creating-customer)
 
 ## Additional resources
 
-* ## Additional resources
-
-[How to use the Replicated product](http://localhost:3000/docs/vendor/getting-started-how-to-use-replicated)
-* [Checking for Updates](/kotsadm/updating/updating-kots-apps/#checking-for-updates)
-* Understanding releases and channels
+* [Understanding channels and releases](https://replicated-docs.netlify.app/docs/vendor/releases-understanding)
+* [How to release a packaged application](https://replicated-docs.netlify.app/docs/vendor/releases-workflow)

--- a/docs/vendor/releases-updating.md
+++ b/docs/vendor/releases-updating.md
@@ -27,3 +27,7 @@ To update a release:
   ![View Update](/images/guides/kots/view-update.png)
 
 1. Click **Deploy** to apply the new YAML files. This should only take a few seconds to deploy.
+
+## Additional resources
+
+[How to release a packaged application](https://replicated-docs.netlify.app/docs/vendor/releases-workflow)

--- a/docs/vendor/releases-workflow.md
+++ b/docs/vendor/releases-workflow.md
@@ -1,10 +1,10 @@
-# How to release a packaged applications
+# How to release a packaged application
 
 After you package an application, use Replicated to release it:
 
 1. Optional: [Create a custom channel or edit the default channels](https://replicated-docs.netlify.app/docs/vendor/releases-creating-channels).
-1. [Create a release](http://localhost:3000/docs/vendor/releases-creating-releases).
-1. [Promote the release to a channel](http://localhost:3000/docs/vendor/releases-promoting).
-1. Optional: [Create a custom entitlement](http://localhost:3000/docs/vendor/entitlements-creating-new).
-1. [Create a customer and download the license]**We have a content gap here - there is no existing procedure for creating a customer and downloading a license**.
-1. Share the release and license with customers using either the download portal or by email.
+1. [Create a release](https://replicated-docs.netlify.app/docs/vendor/releases-creating-releases).
+1. [Promote the release to a channel](https://replicated-docs.netlify.app/docs/vendor/releases-promoting).
+1. Optional: [Create a custom entitlement](https://replicated-docs.netlify.app/docs/vendor/entitlements-creating-new).
+1. [Create a customer and download the license](https://replicated-docs.netlify.app/docs/vendor/releases-creating-customer).
+1. Share the release and license with customers using either [the download portal](https://replicated-docs.netlify.app/docs/vendor/releases-configuring-download-portal) or by email.


### PR DESCRIPTION
Added topic "Creating a customer and downloading a license". Also fixed hyperlinks in the Releases workflow. under "Next steps" and under "Additional resources"

Note: This does not attempt to fix the hyperlinks that were part of the kots.io content migration. That will happen in another iteration.

Shortcut: https://app.shortcut.com/replicated/story/40481/content-gap-create-a-customer-and-download-a-license

**Preview:** https://deploy-preview-42--replicated-docs.netlify.app/docs/vendor/releases-workflow