### PR TITLE
40687 adds links to api docs under Reference

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -165,13 +165,24 @@ const sidebars = {
                 'vendor/template-functions-static-context',
               ],
             },
+            {
+              type: 'link',
+              label: 'KOTS CLI Documentation',
+              href: 'https://kots.io/kots-cli/getting-started/'
+            },
+            {
+              type: 'link',
+              label: 'Vendor API v3 Documentation',
+              href: 'https://replicated-vendor-api.readme.io/v3/'
+            },
+            {
+              type: 'link',
+              label: 'Vendor API v3 Spec',
+              href: 'https://api.replicated.com/vendor/v3/spec/vendor-api-v3.json'
+            },
           ],
         },
-        {
-          type: 'link',
-          label: 'KOTS CLI Documentation',
-          href: 'https://kots.io/kots-cli/getting-started/'
-        },
+
         {
           type: 'category',
           label: 'Policies',


### PR DESCRIPTION
This PR:
- Adds a link to the v3 API docs in the subnav
- Adds a link to the v3 API spec in the subnav. (Included the spec because AA had called it out specifically in her comment. Can also remove it if you all think it's better not include)
- Nests the API (and CLI docs link) under the Reference section in the subnav. 