### PR TITLE
41940: Make Enterprise Snapshots adjacent to Monitoring in the TOC

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -285,15 +285,6 @@ const sidebars = {
         },
         {
           type: 'category',
-          label: 'GitOps',
-          items: [
-            'enterprise/gitops-single-app-workflow',
-            'enterprise/gitops-multi-app-workflow',
-            'enterprise/gitops-managing-secrets',
-          ],
-        },
-        {
-          type: 'category',
           label: 'Snapshots',
           items: [
             'enterprise/snapshots-understanding',
@@ -304,6 +295,15 @@ const sidebars = {
             'enterprise/snapshots-restoring-partial',
             'enterprise/snapshots-configuring-disaster-recovery',
             'enterprise/snapshots-troubleshooting-backup-restore',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'GitOps',
+          items: [
+            'enterprise/gitops-single-app-workflow',
+            'enterprise/gitops-multi-app-workflow',
+            'enterprise/gitops-managing-secrets',
           ],
         },
         {


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/replicated/story/41940/move-snapshots-next-to-monitoring

Preview: https://deploy-preview-81--replicated-docs.netlify.app/docs/enterprise/snapshots-understanding