### PR TITLE
42509: Changed TOC title and intro sentence for Understanding Packaging topi

### DIFF
--- a/docs/vendor/packaging-an-app.md
+++ b/docs/vendor/packaging-an-app.md
@@ -1,6 +1,6 @@
 # Understanding packaging with the app manager
 
-Software vendors can use Replicated to package their application for distribution to enterprise customers as an multi-prem, private instance.
+Software vendors can use Replicated to package their application for distribution to enterprise customers as an on-premises, private instance.
 
 The Replicated app manager is the component that packages applications for distribution. The app manager is based on the open source KOTS project, which is maintained by Replicated. The packaging process leverages several open source KOTS components (some optional, some required).
 


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/replicated/story/42509/change-title-and-planning-packaging-your-app-topic

Changed title of top level section from "Planning and packaging an application" to "Planning your deployment"

Also, in the topic "Understanding packaging...", the intro sentence was not quite right. It said "on-premises" when it should say "multi-prem", which is our Replicated terminology, as we serve cloud environments too.

Preview: https://deploy-preview-107--replicated-docs.netlify.app/docs/vendor/packaging-an-app