### PR TITLE
42487 removes incorrect refs to the application manifest

### DIFF
--- a/docs/vendor/admin-console-adding-buttons-links.md
+++ b/docs/vendor/admin-console-adding-buttons-links.md
@@ -50,7 +50,7 @@ When running the `kubectl` plugin for the kots CLI, the app manager can add addi
 This is useful for internal services such as application admin controls and other services that should not be exposed to all users.
 It's also recommended to list the primary application port(s) here to make verification of the installation possible before ingress is installed.
 
-In order to define additional ports, add a `ports` key to the `application.yaml` manifest file.
+In order to define additional ports, add a `ports` key to the Application custom resource manifest file.
 
 #### Example
 

--- a/docs/vendor/admin-console-customize-app-icon.md
+++ b/docs/vendor/admin-console-customize-app-icon.md
@@ -5,8 +5,8 @@ console and the download portal. Adding a custom icon helps ensure that your
 brand is reflected for your customers.
 
 To add a custom application icon for the admin console and the download portal,
-create  an `application.yaml` file and include an `icons` key under the `descriptor`.
-In the `icons` key, specify a src url and an image type.
+create an Application custom resource manifest file and include an `icons` key under the `descriptor`.
+In the `icons` key, specify a source URL and an image type.
 
 ```yaml
 apiVersion: kots.io/v1beta1

--- a/docs/vendor/admin-console-customize-config-screen.md
+++ b/docs/vendor/admin-console-customize-config-screen.md
@@ -36,7 +36,7 @@ spec:
 ```
 
 ## Template Functions
-Customer supplied values can be used when generating the YAML by using the `{{repl ConfigOption <item_name>}}` syntax.
+Customer supplied values can be used when generating the YAML for the manifest file by using the `{{repl ConfigOption <item_name>}}` syntax.
 For example, to set the `smtp_hostname` value in the above YAML as the value of an environment variable in a PodSpec:
 
 ```yaml
@@ -49,7 +49,7 @@ env:
 Config options can receive their default values through two different keys: `default` and `value`.
 If a value is provided in the `value` key, this is treated the same as a user-supplied value, and will not be overwritten on application update.
 The user will see this value on the Config screen in the admin console, and it's indistinguishable from other values they provided.
-If a value is only provided in the `default` key, this value will be used when rendering the application YAML, but the value will show up as a placeholder on the Config screen in the admin console.
+If a value is only provided in the `default` key, this value will be used when rendering the manifest files for the application, but the value will show up as a placeholder on the Config screen in the admin console.
 The default value will only be used if the user doesn't provide a different value.
 
 ## Required Fields

--- a/docs/vendor/admin-console-display-app-status.md
+++ b/docs/vendor/admin-console-display-app-status.md
@@ -10,7 +10,7 @@ Resources that are currently supported are Deployments, StatefulSets, Services, 
 
 ## Application manifest file
 
-To add an informer, include the `statusInformers` property in the `application.yaml` manifest file.
+To add an informer, include the `statusInformers` property in the Application custom resource manifest file.
 Status informers are in the format `[namespace/]type/name` where namespace is optional and will default to the current namespace.
 
 ```yaml

--- a/docs/vendor/admin-console-prometheus-monitoring.md
+++ b/docs/vendor/admin-console-prometheus-monitoring.md
@@ -10,7 +10,7 @@ By default, metrics graphs that are included monitor cluster disk usage, pod cpu
 
 ### Application manifest
 
-To add custom graphs, use the `graphs` property of the `application.yaml` manifest file.
+To add custom graphs, use the `graphs` property of the Application custom resource manifest file.
 A minimal graph includes only a title and a Prometheus query:
 
 ```yaml

--- a/docs/vendor/operator-defining-additional-images.md
+++ b/docs/vendor/operator-defining-additional-images.md
@@ -3,7 +3,7 @@
 To ensure that images will be available locally, the Replicated app manager finds all images defined in the application manifests and includes them in `.airgap` bundles.
 During the application install or update workflow, the app manager collects these images from the internet or from the `.airgap` bundle, if the application is installed in an air gap environment. The app manager then retags and pushes all the images to a customer-defined registry.
 
-If there are required images that are not defined in any of the Kubernetes manifests, these should be listed in the `additionalImages` attribute of the `application.yaml` manifest file.
+If there are required images that are not defined in any of the Kubernetes manifests, these should be listed in the `additionalImages` attribute of the Application custom resource manifest file.
 
 ```yaml
 apiVersion: kots.io/v1beta1

--- a/docs/vendor/operator-defining-additional-namespaces.md
+++ b/docs/vendor/operator-defining-additional-namespaces.md
@@ -8,7 +8,7 @@ In addition to RBAC policies, clusters running in air gap environments or cluste
 ## Creating additional namespaces
 
 An application can identify additional namespaces to create during installation time.
-You can define these additional namespaces in the Application custom resource by adding an `additionalNamespaces` attribute to the `application.yaml` manifest. For more information, see [Application](custom-resource-application) in the _Custom Resources_ section.
+You can define these additional namespaces in the Application custom resource by adding an `additionalNamespaces` attribute to the Application custom resource manifest file. For more information, see [Application](custom-resource-application) in the _Custom Resources_ section.
 
 When these are defined, `kots install` will create the namespaces and ensure that the Replicated admin console has full access to manage resources in these namespaces.
 This is accomplished by creating a Role and RoleBinding per namespace, and setting the Subject to the admin console service account.
@@ -32,7 +32,7 @@ An operator can reliably depend on this secret existing in all installs (online 
 ## Dynamic namespaces
 
 Some applications need access to dynamically created namespaces or even all namespaces.
-In this case, an application spec can list `"*"` as one of its `addtionalNamespaces` in the `application.yaml` file.
+In this case, an application spec can list `"*"` as one of its `addtionalNamespaces` in the Application manifest file.
 When the app manager encounters the wildcard, it will not create any namespaces, but it will ensure that the application image pull secret is copied to all namespaces.
 The admin console will run an informer internally to watch namespaces in the cluster, and when a new namespace is created, the secret will automatically be copied to it.
 

--- a/docs/vendor/packaging-private-images.md
+++ b/docs/vendor/packaging-private-images.md
@@ -65,7 +65,7 @@ Replicated will store your username and password encrypted and securely, and it 
 
 ![Add External Registry](/images/add-external-registry.png)
 
-Your application YAML will reference images that it cannot access.
+Your Application custom resource manifest file will reference images that it cannot access.
 The app manager recognizes this, and will patch the YAML using Kustomize to change the image name.
 When the app manager is attempting to install an application, it will attempt to load image manifest using the image reference from the PodSpec.
 If it’s loaded successfully, no changes will be made to the application.
@@ -110,6 +110,6 @@ However, the same secret will be added to those PodSpecs as well.
 
 ## Additional namespaces
 
-When deploying pods to namespaces other than the app manager application namespace, the namespace must be added to the `additionalNamespaces` attribute of the [Application](custom-resource-application) spec.
+When deploying pods to namespaces other than the app manager application namespace, the namespace must be added to the `additionalNamespaces` attribute of the [Application](custom-resource-application) manifest.
 This helps to ensure that the application image pull secret will get auto-provisioned by the app manager in the namespace to allow the pod to pull the image.
 For more information about the `additionalNamespaces` attribute, see [Defining additional namespaces](operator-defining-additional-namespaces).

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -1,8 +1,9 @@
 # Kubernetes RBAC
 
 When an application is installed, [Kubernetes RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) resources are created to allow the Replicated admin console to manage the application.
+
 By default, the admin console will create a ClusterRole and ClusterRoleBinding with permissions to all namespaces.
-This behavior can be controlled by editing the `application.yaml` manifest file. For more information about the `application.yaml` file, see [Application](custom-resource-application) in the _Custom Resources_ section.
+This behavior can be controlled by editing the Application custom resource manifest file. For more information about the Application manifest, see [Application](custom-resource-application) in the _Custom Resources_ section.
 
 As listed above, an application may require cluster scoped access across all namespaces on all/wildcard k8 objects or to have access limited to its given namespace.
 In either case, the user who installs an application with the kots CLI must have the wildcard privileges in the cluster.
@@ -80,7 +81,7 @@ subjects:
 
 ## Namespace-scoped access
 
-An application developer can limit the RBAC grants for the admin console to be limited to a single namespace by specifying the `requireMinimalRBACPrivileges` flag in the `application.yaml` manifest file. When this is set, the app manager will create a Role and RoleBinding, granting the admin console access to select resources in the namespace, but not outside of the cluster.
+An application developer can limit the RBAC grants for the admin console to be limited to a single namespace by specifying the `requireMinimalRBACPrivileges` flag in the Application manifest file. When this is set, the app manager will create a Role and RoleBinding, granting the admin console access to select resources in the namespace, but not outside of the cluster.
 
 Without access to cluster-scoped resources, some preflight checks and support bundle collectors will not be able to read the resources.
 These tools will continue to function, but will return less data.
@@ -96,7 +97,7 @@ Without access to the internet or the app's `.airgap` package as provided in a h
 ### Operators and multiple namespaces
 
 It is possible to use namespace-scoped access for Operators and multi-namespace applications.
-During the installation, if there are `additionalNamespaces` specified in the `application.yaml` manifest, Roles and RoleBindings will be created to give the admin console access to all namespaces specified.
+During the installation, if there are `additionalNamespaces` specified in the Application manifest, Roles and RoleBindings will be created to give the admin console access to all namespaces specified.
 
 To enable namespace-scoped access for an application:
 

--- a/docs/vendor/packaging-template-functions.md
+++ b/docs/vendor/packaging-template-functions.md
@@ -88,12 +88,14 @@ And Kubernetes will be able to handle this.
 ## Using Variables in Templates
 
 A result returned from a template function can be assigned to a variable, and the variable can be used in another template function as long as the templates are evaluated at the same time.
-All application YAML documents are templated in a single pass.
 
-The application [`Config.yaml` file](custom-resource-config) is an exception.
+All manifest files for the application are templated in a single pass.
+The Config custom resource manifest file is an exception.
 Each config item is templated separately and has no access to variables created in other config items.
 As a workaround, a hidden config item can be used to evaluate complex templates and render the results.
 The result can be accessed using the [`ConfigOption`](template-functions-config-context#configoption) function.
+
+For more information about the Config custom resource, see [Config](custom-resource-config) in the _Custom resources_ section.
 
 ### Generating TLS certs and keys example
 


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/42487/remove-all-instances-of-application-yaml

Previews: 

https://deploy-preview-111--replicated-docs.netlify.app/vendor/operator-defining-additional-images/
https://deploy-preview-111--replicated-docs.netlify.app/vendor/packaging-private-images
https://deploy-preview-111--replicated-docs.netlify.app/vendor/operator-defining-additional-namespaces
https://deploy-preview-111--replicated-docs.netlify.app/vendor/admin-console-display-app-status
https://deploy-preview-111--replicated-docs.netlify.app/vendor/admin-console-adding-buttons-links
https://deploy-preview-111--replicated-docs.netlify.app/vendor/admin-console-customize-app-icon
https://deploy-preview-111--replicated-docs.netlify.app/vendor/packaging-rbac
https://deploy-preview-111--replicated-docs.netlify.app/vendor/admin-console-prometheus-monitoring
https://deploy-preview-111--replicated-docs.netlify.app/vendor/admin-console-customize-config-screen
https://deploy-preview-111--replicated-docs.netlify.app/vendor/packaging-template-functions