### PR TITLE
42927 fixes broken links to temp func topics

### DIFF
--- a/docs/reference/template-functions-about.md
+++ b/docs/reference/template-functions-about.md
@@ -3,7 +3,7 @@
 Template functions are grouped into different contexts, depending on the phase of the application lifecycle when the function is available and the context data that is provided.
 Static, Config, and License contexts are available everywhere, while kURL context functions are not available on the config page.
 
-For more information about using template functions, see [Template functions](packaging-template-functions).
+For more information about using template functions, see [Template functions](../vendor/packaging-template-functions).
 
 ## Static context
 Template functions in the static context can be used in any YAML, at any time.

--- a/docs/vendor/helm-optional-charts.md
+++ b/docs/vendor/helm-optional-charts.md
@@ -4,7 +4,7 @@
 
 Charts can be optionally included in an application. By default, an instance of a Helm chart is created for every `apiVersion: kots.io/v1beta` and `kind: HelmChart` that's found in the upstream application manifests.
 
-To make a chart optional, add a [template-parsable](template-functions-about) `exclude` attribute to the `kind: HelmChart` document.
+To make a chart optional, add a [template-parsable](../reference/template-functions-about) `exclude` attribute to the `kind: HelmChart` document.
 When downloading, the Replicated app manager will render this field and exclude the entire chart if the output of this field can be parsed as a boolean evaluating to `true`.
 
 If this value is not provided, the chart will be included.

--- a/docs/vendor/identity-service-configuring.md
+++ b/docs/vendor/identity-service-configuring.md
@@ -19,7 +19,7 @@ Once you are editing the release, create a new [Identity CRD](custom-resource-id
 
 ![Identity Service CRD](/images/identity-service-crd.png)
 
-The identity service has to be accessible from the browser. For that reason, the app manager provides the service name and port to the app through the [identity template functions](template-functions-identity-context) so that the app can then configure ingress for the identity service, for example:
+The identity service has to be accessible from the browser. For that reason, the app manager provides the service name and port to the app through the [identity template functions](../reference/template-functions-identity-context) so that the app can then configure ingress for the identity service, for example:
 
 ![Identity Service Ingress](/images/identity-service-ingress.png)
 

--- a/docs/vendor/licenses-referencing-fields.md
+++ b/docs/vendor/licenses-referencing-fields.md
@@ -35,7 +35,7 @@ you can reference built-in and custom license fields in a Kubernetes manifest.
 
 The Replicated app manager uses the `LicenseFieldValue` template function to read
 license fields when a customer installs or updates your application. For more
-information, see [LicenseFieldValue](template-functions-license-context#licensefieldvalue).
+information, see [LicenseFieldValue](../reference/template-functions-license-context#licensefieldvalue).
 
 ### Example: Reference a custom license field in a preflight check
 

--- a/docs/vendor/operator-defining-additional-namespaces.md
+++ b/docs/vendor/operator-defining-additional-namespaces.md
@@ -26,7 +26,7 @@ spec:
 ```
 
 In addition to creating these namespaces, the admin console will ensure that the application pull secret exists in them, and that this secret has access to pull the application images (both images that are used and [additionalImages](operator-additional-images)).
-Pull secret name can be obtained using the [ImagePullSecretName](template-functions-config-context/#imagepullsecretname) template function.
+Pull secret name can be obtained using the [ImagePullSecretName](../reference/template-functions-config-context/#imagepullsecretname) template function.
 An operator can reliably depend on this secret existing in all installs (online and air gapped), and can use this secret name in any created `podspec` to pull private images.
 
 ## Dynamic namespaces

--- a/docs/vendor/operator-referencing-images.md
+++ b/docs/vendor/operator-referencing-images.md
@@ -61,7 +61,7 @@ env:
 
 Private, local images will need to reference an image pull secret to be pulled.
 The value of the secret's `.dockerconfigjson` is provided in a template function, and the application can write this pull secret as a new secret to the namespace.
-If the application is deploying the pod to the same namespace as the Operator, the pull secret will already exist in the namespace, and the secret name can be obtained using the [ImagePullSecretName](template-functions-config-context/#imagepullsecretname) template function.
+If the application is deploying the pod to the same namespace as the Operator, the pull secret will already exist in the namespace, and the secret name can be obtained using the [ImagePullSecretName](../reference/template-functions-config-context/#imagepullsecretname) template function.
 The app manager will create this secret automatically, but only in the namespace that the Operator is running in.
 It's the responsibility of the application developer (the Operator code) to ensure that this secret is present in any namespace that new pods will be deployed to.
 

--- a/docs/vendor/packaging-include-resources.md
+++ b/docs/vendor/packaging-include-resources.md
@@ -4,7 +4,7 @@ Often, vendors need a way to optionally install resources depending on customers
 
 In this scenario, when a customer chooses to bring their own database, it is not desirable to deploy the optional database resources (StatefulSet, Service, etc.). This means that the customer-supplied configuration input values may result in optional Kubernetes manifests that should not be installed.
 
-To provide optional resource installation, the app manager uses [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) and [template functions](template-functions-about) to conditionally include or exclude resources.
+To provide optional resource installation, the app manager uses [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) and [template functions](../reference/template-functions-about) to conditionally include or exclude resources.
 
 ## App Manager Annotations
 

--- a/docs/vendor/packaging-template-functions.md
+++ b/docs/vendor/packaging-template-functions.md
@@ -4,7 +4,7 @@ Replicated app manager applications have access to a rich set of template functi
 
 The app manager uses Go's [text/template](https://golang.org/pkg/text/template/) libraries as the basis for the templating. All functionality of Go's templating language can be used in conjunction with the app manager custom functions.
 
-All template functions are documented in the [template function reference](template-functions-about) section.
+All template functions are documented in the [template function reference](../reference/template-functions-about) section.
 
 ## Using Template Functions
 
@@ -93,7 +93,7 @@ All manifest files for the application are templated in a single pass.
 The Config custom resource manifest file is an exception.
 Each config item is templated separately and has no access to variables created in other config items.
 As a workaround, a hidden config item can be used to evaluate complex templates and render the results.
-The result can be accessed using the [`ConfigOption`](template-functions-config-context#configoption) function.
+The result can be accessed using the [`ConfigOption`](../reference/template-functions-config-context#configoption) function.
 
 For more information about the Config custom resource, see [Config](custom-resource-config) in the _Custom resources_ section.
 


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/42927/update-any-broken-links-to-topics-in-the-reference-template-functions-section

https://deploy-preview-128--replicated-docs.netlify.app/reference/template-functions-about
https://deploy-preview-128--replicated-docs.netlify.app/vendor/helm-optional-charts
https://deploy-preview-128--replicated-docs.netlify.app/vendor/identity-service-configuring
https://deploy-preview-128--replicated-docs.netlify.app/vendor/licenses-referencing-fields
https://deploy-preview-128--replicated-docs.netlify.app/vendor/operator-defining-additional-namespaces
https://deploy-preview-128--replicated-docs.netlify.app/vendor/operator-referencing-images
https://deploy-preview-128--replicated-docs.netlify.app/vendor/packaging-include-resources
https://deploy-preview-128--replicated-docs.netlify.app/vendor/packaging-template-functions