### PR TITLE
42928 adds ../reference/ to links from /vendor/ to /reference/replicated CLI

### DIFF
--- a/docs/intro-replicated.md
+++ b/docs/intro-replicated.md
@@ -45,7 +45,7 @@ users to complete tasks programmatically.
 
 For information about the Vendor API v3, see [Using the Vendor API v3](vendor/reference-vendor-api).
 
-For information about the replicated CLI, see [Installing the replicated CLI](vendor/vendor-cli-installing).
+For information about the replicated CLI, see [Installing the replicated CLI](reference/replicated-cli-installing).
 
 For information about the kots CLI, see [Getting Started with KOTS](https://kots.io/kots-cli/getting-started/)
 in the kots CLI documentation.

--- a/docs/vendor/getting-started-how-to-use-replicated.md
+++ b/docs/vendor/getting-started-how-to-use-replicated.md
@@ -5,7 +5,7 @@ This is a high-level workflow for releasing an application using Replicated. For
 1. [Create your vendor account](getting-started-creating-vendor-account).
 1. [Review the checklist and package the application](packaging-planning-checklist).
 1. [Release and share the packaged application](releases-workflow).
-1. Optional: [Install the replicated CLI](replicated-cli-installing). This option lets you use the replicated command-line interface (CLI) to deploy and manage your application deployments.
+1. Optional: [Install the replicated CLI](../reference/replicated-cli-installing). This option lets you use the replicated command-line interface (CLI) to deploy and manage your application deployments.
 
 
 ## Additional Resources

--- a/docs/vendor/releases-creating-releases.md
+++ b/docs/vendor/releases-creating-releases.md
@@ -16,7 +16,7 @@ We recommend that you bookmark the Replicated [vendor portal](https://vendor.rep
 
   A YAML editor displays.
 
-1. In the YAML editor, you can define how your application will work and define the integration with the Replicated app manager functionality. You can manually edit YAML on this page or use the replicated CLI and API to automate this. For more information about using the CLI, see [Installing the replicated CLI](replicated-cli-installing).
+1. In the YAML editor, you can define how your application will work and define the integration with the Replicated app manager functionality. You can manually edit YAML on this page or use the replicated CLI and API to automate this. For more information about using the CLI, see [Installing the replicated CLI](../reference/replicated-cli-installing).
 
   The default YAML documents (`replicated-app.yaml`, `preflight.yaml`, `config.yaml`, `support-bundle.yaml`) contain information for the app manager, preflight checks, customer configuration screen options, and support bundle analyzers for troubleshooting installs.
 

--- a/docs/vendor/tutorial-installing-with-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-with-existing-cluster.md
@@ -39,7 +39,7 @@ You should now see a YAML editor where you can define how your application will 
 
 **Note**: Since this guide is intended as a "Hello, World" example, we'll skip editing the YAML right now and just proceed with the defaults. We'll make some changes later on in this guide.
 
-When you are familiar with these concepts, you can use the replicated CLI and the Replicated Vendor API to automate this task rather than manually editing the YAML on this page. For more information, see [Installing the replicated CLI](replicated-cli-installing) and [Using the Vendor API v3](reference-vendor-api).
+When you are familiar with these concepts, you can use the replicated CLI and the Replicated Vendor API to automate this task rather than manually editing the YAML on this page. For more information, see [Installing the replicated CLI](../reference/replicated-cli-installing) and [Using the Vendor API v3](reference-vendor-api).
 
 ![Default YAML](/images/guides/kots/default-yaml.png)
 

--- a/docs/vendor/tutorial-installing-without-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-without-existing-cluster.md
@@ -42,7 +42,7 @@ You should now see a YAML editor where you can define how your application will 
 
 **Note**: Since this guide is intended as a "Hello, World" example, we'll skip editing the YAML right now and just proceed with the defaults. We'll make some changes later on in this guide.
 
-When you are familiar with these concepts, you can use the replicated CLI and API to automate this task rather than manually editing the YAML on this page. For more information, see [Installing the replicated CLI](replicated-cli-installing) and [Using the Replicated Vendor API v3](reference-vendor-api).
+When you are familiar with these concepts, you can use the replicated CLI and API to automate this task rather than manually editing the YAML on this page. For more information, see [Installing the replicated CLI](../reference/replicated-cli-installing) and [Using the Replicated Vendor API v3](reference-vendor-api).
 
 ![Default YAML](/images/guides/kots/default-yaml.png)
 


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/42928/update-any-broken-links-to-topics-in-the-reference-replicated-cli-section

https://deploy-preview-130--replicated-docs.netlify.app/intro-replicated
https://deploy-preview-130--replicated-docs.netlify.app/vendor/getting-started-how-to-use-replicated
https://deploy-preview-130--replicated-docs.netlify.app/vendor/releases-creating-releases
https://deploy-preview-130--replicated-docs.netlify.app/vendor/tutorial-installing-with-existing-cluster
https://deploy-preview-130--replicated-docs.netlify.app/vendor/tutorial-installing-without-existing-cluster