### PR TITLE
42910 content diff for get config topic

### DIFF
--- a/docs/reference/kots-cli-get-config.md
+++ b/docs/reference/kots-cli-get-config.md
@@ -1,6 +1,6 @@
 # get config
 
-The `kots get config` command returns the **configValues** file for an application.
+The `kots get config` command returns the `configValues` file for an application.
 
 ### Usage
 
@@ -12,7 +12,7 @@ kubectl kots get config [flags]
 
 | Flag              | Type   | Description                                                         |
 | :---------------- | ------ | ------------------------------------------------------------------- |
-| `--appslug`       | string | The application slug of the application for which the `configValues` file is retrieved. Required when more than one app is deployed.|
+| `--appslug`       | string | The application slug of the application for which the `configValues` file is retrieved. Required when more than one application is deployed.|
 | `--sequence`      | int    | The application sequence for which the `configValues` file is retrieved. **Default**: latest.|
 | `--decrypt`       | bool   | Decrypts password items within the configuration.|
 | `-h, --help`      |        | Help for `get config`.|


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/42910/content-diff-new-default-behavior-for-kots-get-config

Preview: https://deploy-preview-136--replicated-docs.netlify.app/reference/kots-cli-get-config/

Jonquil: Do you have any other suggestions for better ways to word these descriptions? We edited them some, but I think they still sound a little confusing. Or if it sounds good to you, then maybe I've just been staring at it too long :) 