### PR TITLE
43494 moves quick starts to top, updates CLI title

### DIFF
--- a/docs/vendor/distributing-workflow.md
+++ b/docs/vendor/distributing-workflow.md
@@ -1,4 +1,4 @@
-# How to Distribute an Application
+# How to Distribute a Production Application
 
 Complete the following procedures to distribute your application to your customers with
 Replicated:

--- a/docs/vendor/tutorial-installing-air-gap.md
+++ b/docs/vendor/tutorial-installing-air-gap.md
@@ -1,4 +1,4 @@
-# Installing in an air gapped environment
+# Installing in an Air Gapped Environment
 
 This advanced guide shows how to install the Replicated app manager in an air gapped environment.
 This guide assumes that you have already completed one of the [Getting Started Guides](/vendor/guides/#getting-started) to set up a non-airgapped cluster.

--- a/docs/vendor/tutorial-installing-with-cli.md
+++ b/docs/vendor/tutorial-installing-with-cli.md
@@ -1,4 +1,4 @@
-# Installing a Sample Application with the CLI
+# Managing Releases with the CLI
 
 This tutorial helps you use Replicated app manager to quickly deploy, install, and iterate with a sample Kubernetes application using a CLI-based workflow.
 

--- a/docs/vendor/tutorial-installing-with-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-with-existing-cluster.md
@@ -1,4 +1,4 @@
-# Installing applications with an existing cluster
+# Installing with an Existing Cluster
 
 This topic demonstrates packaging and installing a simple NGINX application in Kubernetes on an existing cluster in GKE (or another cluster you have handy).
 

--- a/docs/vendor/tutorial-installing-without-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-without-existing-cluster.md
@@ -1,4 +1,4 @@
-# Installing applications without an existing cluster
+# Installing without an Existing Cluster
 
 This topic demonstrates packaging and installing a simple NGINX application in Kubernetes using a single virtual machine (VM).
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -29,6 +29,17 @@ const sidebars = {
       items: [
         'vendor/distributing-workflow',
         'vendor/vendor-portal-creating-account',
+        {
+          type: 'category',
+          label: 'Quick Start Tutorials with Sample Applications',
+          items: [
+            'vendor/tutorial-installing-without-existing-cluster',
+            'vendor/tutorial-installing-with-existing-cluster',
+            'vendor/tutorial-installing-with-cli',
+            'vendor/tutorial-installing-air-gap',
+            'vendor/tutorial-installing-air-gap-existing-cluster-gcp',
+          ]
+        },
         'vendor/planning-questionnaire',
           {
             type: 'category',
@@ -141,11 +152,6 @@ const sidebars = {
           type: 'category',
           label: 'Tutorials',
           items: [
-            'vendor/tutorial-installing-without-existing-cluster',
-            'vendor/tutorial-installing-with-existing-cluster',
-            'vendor/tutorial-installing-with-cli',
-            'vendor/tutorial-installing-air-gap',
-            'vendor/tutorial-installing-air-gap-existing-cluster-gcp',
             'vendor/tutorial-ecr-private-images',
             'vendor/tutorial-ha-cluster-deploying',
             'vendor/tutorial-ci-cd-integration',


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/43494/move-the-quickstart-tutorials-to-the-top-of-the-toc

Preview: https://deploy-preview-153--replicated-docs.netlify.app/vendor/tutorial-installing-with-cli

Note: Will update the xrefs to these topics as part of another story this week https://app.shortcut.com/replicated/story/43617/update-xrefs-to-the-tutorial-topics-in-how-to-distribute