### PR TITLE
update broken link docusaurus config to error

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,7 +10,7 @@ const config = {
   tagline: 'Technical documentation for Replicated vendors and their enterprise end-customers.',
   url: 'https://docs.replicated.com',
   baseUrl: '/',
-  onBrokenLinks: 'warn',
+  onBrokenLinks: 'error',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'images/favicon.png',
   organizationName: 'replicatedhq', // Usually your GitHub org/user name.


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/43881/update-docusaurus-to-error-on-broken-links-rather-than-warn