### PR TITLE
44108 add links back to kots and kurl for earlier RNs

### DIFF
--- a/docs/release-notes/rn-app-manager.md
+++ b/docs/release-notes/rn-app-manager.md
@@ -1,5 +1,10 @@
 # App Manager Release Notes
 
+:::note
+For release notes earlier than v1.60.0, see
+[Release Notes](https://kots.io/release-notes/) in the open source KOTS documentation.
+:::
+
 ## 1.65.0
 
 Released on February 25, 2022

--- a/docs/release-notes/rn-kubernetes-installer.md
+++ b/docs/release-notes/rn-kubernetes-installer.md
@@ -1,5 +1,10 @@
 # Kubernetes Installer Release Notes
 
+:::note
+For release notes earlier than v2022.01.25-0, see
+[Release Notes](https://kurl.sh/release-notes) in the open source kURL documentation.
+:::
+
 ## Release v2022.03.01-0
 
 Released on March 1, 2022


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/44108/friday-3-4-add-a-link-to-the-app-manager-and-kubernetes-installer-rns-topics-to-point-to-older-notes

/release-notes/rn-app-manager

/release-notes/rn-kubernetes-installer