### PR TITLE
44393 adds semver topics

### DIFF
--- a/docs/reference/replicated-cli-channel-disable-semver.md
+++ b/docs/reference/replicated-cli-channel-disable-semver.md
@@ -1,0 +1,20 @@
+# channel disable-semantic-versioning
+
+Disable semantic versioning for a channel.
+
+### Usage
+```bash
+replicated channel disable-semantic-versioning CHANNEL_ID
+```
+
+| Flag                 | Type | Description |
+|:----------------------|------|-------------|
+| `-h, --help`   |  |          Help for the command. |
+| `--app string` | |   The app slug or app id used in all calls. **Default**: Uses the `$REPLICATED_APP` environment variable. |
+| `--token string` | |  The API token used to access your app in the Vendor API. **Default**: Uses the `$REPLICATED_API_TOKEN` environment variable. |
+
+### Examples
+```bash
+replicated channel disable-semantic-versioning 1xyB2Mgbg9N7rExShfbdBYIuzeW
+Semantic versioning successfully disabled for channel 1xyB2Mgbg9N7rExShfbdBYIuzeW
+```

--- a/docs/reference/replicated-cli-channel-enable-semver.md
+++ b/docs/reference/replicated-cli-channel-enable-semver.md
@@ -1,0 +1,20 @@
+# channel enable-semantic-versioning
+
+Enable semantic versioning for a channel.
+
+### Usage
+```bash
+replicated channel enable-semantic-versioning CHANNEL_ID
+```
+
+| Flag                 | Type | Description |
+|:----------------------|------|-------------|
+| `-h, --help`   |  |          Help for the command. |
+| `--app string` | |   The app slug or app id used in all calls. **Default**: Uses the `$REPLICATED_APP` environment variable. |
+| `--token string` | |  The API token used to access your app in the Vendor API. **Default**: Uses the `$REPLICATED_API_TOKEN` environment variable. |
+
+### Examples
+```bash
+replicated channel enable-semantic-versioning 1xyB2Mgbg9N7rExShfbdBYIuzeW
+Semantic versioning successfully enabled for channel 1xyB2Mgbg9N7rExShfbdBYIuzeW
+```

--- a/docs/vendor/releases-semantic-versioning.md
+++ b/docs/vendor/releases-semantic-versioning.md
@@ -12,7 +12,7 @@ For existing applications created before February 23, 2022, semantic versioning 
 
 When you enable semantic versioning on a channel, the version label for a release promoted to that channel is verified to ensure that it is a valid semantic version. For more information about valid semantic versions, see [Semantic Versioning 2.0.0](https://semver.org).
 
-For channels with semantic versioning, the Replicated admin console sequences releases by their semantic versions instead of their creation dates. The admin console does not sort any releases already promoted to the channel that do not use a valid semantic version.
+For channels with semantic versioning enabled, the Replicated admin console sequences releases by their semantic versions instead of their creation dates. The admin console does not sort any releases already promoted to the channel that do not use a valid semantic version.
 
 If releases that do not use a valid semantic version are already promoted to a channel, the admin console sorts the releases that do have semantic versions starting with the earliest version and proceeding to the latest. For example, assume that you promote these releases in the following order to a channel: 1.0.0, abc, 0.1.0, xyz, and 2.0.0. Then, you enable semantic versioning on that channel. The admin console would sequence the version history as follows for the channel: 0.1.0, 1.0.0, abc, xyz, 2.0.0.
 

--- a/docs/vendor/releases-semantic-versioning.md
+++ b/docs/vendor/releases-semantic-versioning.md
@@ -14,7 +14,7 @@ When you enable semantic versioning on a channel, the version label for a releas
 
 For channels with semantic versioning, the Replicated admin console sequences releases by their semantic versions instead of their creation dates. The admin console does not sort any releases already promoted to the channel that do not use a valid semantic version.
 
-The admin console sorts releases with semantic versions starting with the earliest version and proceeding to the latest. For example, assume that you promote these releases in the following order to a channel: 1.0.0, abc, 0.1.0, xyz, and 2.0.0. Then, you enable semantic versioning on that channel. The admin console would sequence the version history as follows for the channel: 0.1.0, 1.0.0, abc, xyz, 2.0.0.
+If releases that do not use a valid semantic version are already promoted to a channel, the admin console sorts the releases that do have semantic versions starting with the earliest version and proceeding to the latest. For example, assume that you promote these releases in the following order to a channel: 1.0.0, abc, 0.1.0, xyz, and 2.0.0. Then, you enable semantic versioning on that channel. The admin console would sequence the version history as follows for the channel: 0.1.0, 1.0.0, abc, xyz, 2.0.0.
 
 For more information about how enterprise application users check for application updates in the admin console, see [Checking for Updates](../enterprise/updating-apps#checking-for-updates).
 

--- a/docs/vendor/releases-semantic-versioning.md
+++ b/docs/vendor/releases-semantic-versioning.md
@@ -1,0 +1,31 @@
+# Enabling Semantic Versioning
+
+Semantic versioning is available with the Replicated app manager v1.58.0 and later.
+
+For applications created in the vendor portal on or after February 23, 2022, semantic versioning is enabled by default on the Stable and Beta channels. Semantic versioning is disabled on the Unstable channel by default.
+
+For applications created before February 23, 2022, semantic versioning is disabled by default on new and existing channels.
+
+## About Semantic Versioning
+
+When you enable semantic versioning on a channel, the version label for a release promoted to that channel is verified to ensure that it is a valid semantic version. For more information about valid semantic versions, see [Semantic Versioning 2.0.0](https://semver.org).
+
+For channels with semantic versioning, the Replicated admin console sequences releases by their semantic versions instead of their creation dates. The admin console does not sort any releases already promoted to the channel that do not use a valid semantic version.
+
+The admin console sorts releases with semantic versions starting with the earliest version and proceeding to the latest.
+
+For example, assume that you promote these releases in the following order to a channel: 1.0.0, abc, 0.1.0, xyz, and 2.0.0. Then, you enable semantic versioning on that channel. The admin console would sequence the version history as follows for the channel: 0.1.0, 1.0.0, abc, xyz, 2.0.0.
+
+For more information about how enterprise application users check for application updates in the admin console, see [Checking for Updates](../enterprise/updating-apps#checking-for-updates).
+
+## Enable Semantic Versioning
+
+You enable semantic versioning on a per-channel basis. If you enable semantic versioning for a channel and then promote releases to it, Replicated recommends that you do not later disable semantic versioning for that channel.
+
+To enable semantic versioning on a channel, do one of the following:
+
+* **In the vendor portal**: Select **Enable semantic versioning** when creating a channel or editing an existing channel on the Channels page.
+
+* **With the replicated CLI**: Run `replicated channel enable-semantic-versioning CHANNEL_ID` to enable semantic versioning. Replace `CHANNEL_ID` with the ID of the target channel.
+
+   For more information, see [channel enable-semantic-versioning](../reference/replicated-cli-channel-enable-semver) and [channel disable-semantic-versioning](../reference/replicated-cli-channel-disable-semver).

--- a/docs/vendor/releases-semantic-versioning.md
+++ b/docs/vendor/releases-semantic-versioning.md
@@ -2,9 +2,11 @@
 
 Semantic versioning is available with the Replicated app manager v1.58.0 and later.
 
+When you create a new channel for an application in the vendor portal, semantic versioning is disabled by default.
+
 For applications created in the vendor portal on or after February 23, 2022, semantic versioning is enabled by default on the Stable and Beta channels. Semantic versioning is disabled on the Unstable channel by default.
 
-For applications created before February 23, 2022, semantic versioning is disabled by default on new and existing channels.
+For existing applications created before February 23, 2022, semantic versioning is disabled by default on all channels.
 
 ## About Semantic Versioning
 
@@ -12,9 +14,7 @@ When you enable semantic versioning on a channel, the version label for a releas
 
 For channels with semantic versioning, the Replicated admin console sequences releases by their semantic versions instead of their creation dates. The admin console does not sort any releases already promoted to the channel that do not use a valid semantic version.
 
-The admin console sorts releases with semantic versions starting with the earliest version and proceeding to the latest.
-
-For example, assume that you promote these releases in the following order to a channel: 1.0.0, abc, 0.1.0, xyz, and 2.0.0. Then, you enable semantic versioning on that channel. The admin console would sequence the version history as follows for the channel: 0.1.0, 1.0.0, abc, xyz, 2.0.0.
+The admin console sorts releases with semantic versions starting with the earliest version and proceeding to the latest. For example, assume that you promote these releases in the following order to a channel: 1.0.0, abc, 0.1.0, xyz, and 2.0.0. Then, you enable semantic versioning on that channel. The admin console would sequence the version history as follows for the channel: 0.1.0, 1.0.0, abc, xyz, 2.0.0.
 
 For more information about how enterprise application users check for application updates in the admin console, see [Checking for Updates](../enterprise/updating-apps#checking-for-updates).
 

--- a/docs/vendor/releases-understanding.md
+++ b/docs/vendor/releases-understanding.md
@@ -3,15 +3,15 @@
 The Replicated [vendor portal](https://vendor.replicated.com) provides you with a location to create and release versions of your application to various release channels. The vendor portal hosts a built-in YAML editor and linter to help you write and validate manifest files.
 
 ## Semantic Versioning
-Semantic versioning is available in the app manager v1.58.0 and later. You can use the semantic version format for the version label that you assign to a release in the Replicated admin console. For more information about semantic versioning, see [Semantic Versioning 2.0.0](https://semver.org).
 
-**Note:** If you use semantic versioning on a channel, we recommend that you always use semantic versioning on that channel.
+Semantic versioning is available with the Replicated app manager v1.58.0 and later.
 
-If the version label that you assign to a channel is in the semantic version format, the admin console uses the version label for sequencing of releases during updates.
+When you enable semantic versioning on a channel in the vendor portal, the Replicated admin console uses the semantic version format to sequence releases assigned to the channel.
 
-For releases that do not use semantic versioning, the admin console sequences them in the order of their creation.
+For more information, see [Enabling Semantic Versioning](releases-semantic-versioning).
 
 ## About Promoting Releases
+
 After a release is ready to be installed, the release can be promoted to one or more release channels.
 
 Every Replicated license points to a release channel.

--- a/sidebars.js
+++ b/sidebars.js
@@ -47,6 +47,7 @@ const sidebars = {
             items: [
               'vendor/releases-creating-channels',
               'vendor/releases-about-channels',
+              'vendor/releases-semantic-versioning',
             ],
           },
           {
@@ -398,6 +399,8 @@ const sidebars = {
             'reference/replicated-cli-app-ls',
             'reference/replicated-cli-channel-create',
             'reference/replicated-cli-channel-delete',
+            'reference/replicated-cli-channel-disable-semver',
+            'reference/replicated-cli-channel-enable-semver',
             'reference/replicated-cli-channel-inspect',
             'reference/replicated-cli-channel-ls',
             'reference/replicated-cli-customer-create',


### PR DESCRIPTION
SC cards:
- Enabling semver content: https://app.shortcut.com/replicated/story/44393/content-diff-update-semver-docs
- Adds semver replicated CLI commands: https://app.shortcut.com/replicated/story/44507/migrate-replicated-cli-semver-commands

https://deploy-preview-200--replicated-docs.netlify.app/vendor/releases-understanding

https://deploy-preview-200--replicated-docs.netlify.app/vendor/releases-semantic-versioning

https://deploy-preview-200--replicated-docs.netlify.app/reference/replicated-cli-channel-enable-semver and https://deploy-preview-200--replicated-docs.netlify.app/reference/replicated-cli-channel-disable-semver