### PR TITLE
44614 limits heading level to 2 on rns

### DIFF
--- a/docs/release-notes/rn-app-manager.md
+++ b/docs/release-notes/rn-app-manager.md
@@ -1,3 +1,7 @@
+---
+toc_max_heading_level: 2
+---
+
 # App Manager Release Notes
 
 :::note

--- a/docs/release-notes/rn-kubernetes-installer.md
+++ b/docs/release-notes/rn-kubernetes-installer.md
@@ -1,3 +1,7 @@
+---
+toc_max_heading_level: 2
+---
+
 # Kubernetes Installer Release Notes
 
 :::note


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/44614/limit-heading-level-to-2-on-release-notes-topics

https://deploy-preview-209--replicated-docs.netlify.app/release-notes/rn-app-manager

https://deploy-preview-209--replicated-docs.netlify.app/release-notes/rn-kubernetes-installer