### PR TITLE
44644 updates titles and headings to title case

### DIFF
--- a/docs/vendor/licenses-about-types.md
+++ b/docs/vendor/licenses-about-types.md
@@ -1,9 +1,9 @@
-# About customer license types
+# About Customer License Types
 
 This topic describes the types of customer licenses. It also describes the
 differences between community licenses and the other types of licenses.
 
-## Types of customer licenses
+## Types of Customer License
 
 Each customer license includes a `license_type` field.
 
@@ -23,7 +23,7 @@ additional information can be provided.
 application. For more details about this type, see [About community licenses](#about-community-licenses)
 below.
 
-## About community licenses
+## About Community Licenses
 
 This section describes what a community license is and what happens when your
 customer uses a community license in the Replicated admin console.

--- a/docs/vendor/licenses-using-builtin-fields.md
+++ b/docs/vendor/licenses-using-builtin-fields.md
@@ -1,9 +1,9 @@
-# About built-in license fields
+# About Built-in License Fields
 
 This topic describes the built-in license fields. For information about creating
 custom license fields for a customer, see [Managing Custom License Fields](licenses-adding-custom-fields).
 
-## Built-in license fields
+## Built-in License Fields
 
 All applications that are packaged and delivered through the Replicated vendor
 portal include built-in license fields. Built-in fields are reserved field names

--- a/docs/vendor/policies-data-transmission.md
+++ b/docs/vendor/policies-data-transmission.md
@@ -1,4 +1,4 @@
-# Data transmission policy
+# Data Transmission Policy
 
 A Replicated installation connects to a Replicated-hosted endpoint periodically to perform various tasks including checking for updates and syncing the installed license properties. During this time, some data is transmitted from an installed instance to the Replicated API. This data is limited to:
 

--- a/docs/vendor/policies-vulnerability-patch.md
+++ b/docs/vendor/policies-vulnerability-patch.md
@@ -1,4 +1,4 @@
-# Vulnerability patch policy
+# Vulnerability Patch Policy
 
 While it’s our goal to distribute vulnerability-free versions of all components, this isn’t always possible.
 Kubernetes and KOTS are made from many components, each authored by different vendors.

--- a/docs/vendor/releases-about-channels.md
+++ b/docs/vendor/releases-about-channels.md
@@ -1,5 +1,5 @@
 
-# About release channels
+# About Release Channels
 
 By default, there are 3 release channels: Stable, Beta and Unstable. When you first log in to Replicated and select the Channels tab, you’ll see these default release channels created.
 You can delete, edit, or create new channels at any time.

--- a/docs/vendor/releases-creating-channels.md
+++ b/docs/vendor/releases-creating-channels.md
@@ -1,4 +1,4 @@
-# Creating and editing channels
+# Creating and Editing Channels
 
 There are three default channels that can be configured, and you can add custom channels.
 
@@ -9,7 +9,7 @@ The default channels are:
 
 For more information, see [About channels](releases-about-channels).
 
-## Create a channel
+## Create a Channel
 
 To create a channel:
 
@@ -25,7 +25,7 @@ To create a channel:
 1. Optional: To enable the semantic versioning, turn on the toggle for preventing promoting releases with an invalid version to this channel.
 1. Click **Create Channel**.
 
-## Edit a channel
+## Edit a Channel
 
 To edit an existing channel:
 
@@ -44,10 +44,10 @@ To edit an existing channel:
 
 1. Click **Save**.
 
-## Next steps
+## Next Steps
 
 [Creating a release](releases-creating-releases)
 
-## Additional resources
+## Additional Resources
 
 [How to Distribute an Application](distributing-workflow)

--- a/docs/vendor/releases-creating-releases.md
+++ b/docs/vendor/releases-creating-releases.md
@@ -30,10 +30,10 @@ We recommend that you bookmark the Replicated [vendor portal](https://vendor.rep
 
 1. Click **Save release**.
 
-## Next steps
+## Next Steps
 
 [Promoting releases](releases-promoting)
 
-## Additional resources
+## Additional Resources
 
 [How to Distribute an Application](distributing-workflow)

--- a/docs/vendor/releases-promoting.md
+++ b/docs/vendor/releases-promoting.md
@@ -1,4 +1,4 @@
-# Promoting releases
+# Promoting Releases
 
 After you create a release, it must be promoted to a channel to be active.
 
@@ -23,11 +23,11 @@ To promote a release:
 1. Click **Promote**.
 
 
-## Next steps
+## Next Steps
 
 [Creating customers and downloading licenses](releases-creating-customer)
 
-## Additional resources
+## Additional Resources
 
 * [Understanding channels and releases](releases-understanding)
 * [How to Distribute an Application](distributing-workflow)

--- a/docs/vendor/releases-sharing-license-install-script.md
+++ b/docs/vendor/releases-sharing-license-install-script.md
@@ -7,7 +7,7 @@ For more information about how customers use the license file and installation
 script to install your application,
 see [Overview of installing an application with Replicated app manager](../enterprise/installing-overview).
 
-## Share the license file
+## Share the License File
 
 After you create a customer, assign the customer to a channel, and define the customer's
 license file in the Replicated vendor portal, you can share the license file with your customer.
@@ -21,7 +21,7 @@ To share the license file with a customer, you can do one of the following:
 * Send your customer a link to the Replicated download portal where they can download
 the license file. See [Share the license file through the download portal](#share-the-license-file-through-the-download-portal).
 
-### Download and share the license file
+### Download and Share the License File
 
 To download and share the license file:
 
@@ -32,7 +32,7 @@ To download and share the license file:
 1. Send the license file to your customer along with their installation script.
 See [Share the installation script](#share-the-installation-script).
 
-### Share the license file through the download portal
+### Share the License File through the Download Portal
 
 To share the license file through the download portal:
 
@@ -47,7 +47,7 @@ and preview your customer's experience.
 1. Send the URL and password for the download portal to your customer along with
 their installation script. See [Share the installation script](#share-the-installation-script).
 
-## Share the installation script
+## Share the Installation Script
 
 In the vendor portal, Replicated provides installation scripts that your customer
 can use to install your application.
@@ -69,6 +69,6 @@ customer is assigned.
 1. Copy the command displayed and send it to your customer along with their
 license file.
 
-## Additional resources
+## Additional Resources
 
 [How to Distribute an Application](distributing-workflow)

--- a/docs/vendor/releases-updating.md
+++ b/docs/vendor/releases-updating.md
@@ -1,4 +1,4 @@
-# Updating releases
+# Updating Releases
 
 You can deliver an update to an application after it has been released.
 

--- a/docs/vendor/snapshots-overview.md
+++ b/docs/vendor/snapshots-overview.md
@@ -10,7 +10,7 @@ In addition to the default functionality that Velero provides, the app manager p
 
 The app manager also exposes hooks that can be used to inject scripts to execute with Snapshots both [before and after a backup](snapshots-configuring-backups) and [before and after a restore](../enterprise/snapshots-understanding).
 
-## Velero version compatibility
+## Velero Version Compatibility
 
 The following table lists which versions of Velero are compatible with each version of the app manager.
 

--- a/docs/vendor/tutorial-adding-db-config.md
+++ b/docs/vendor/tutorial-adding-db-config.md
@@ -1,4 +1,4 @@
-# Adding database configuration options for your application
+# Adding Database Configuration Options for your Application
 
 In this tutorial, we'll explore ways to give your end user the option to either embed a database instance with the application, or connect your application to an external database instance that they will manage.
 We'll use a PostgreSQL database as an example, configuring an example app to connect.
@@ -430,7 +430,7 @@ Now that we've configured our application to read from an embedded postgres inst
 
 * * *
 
-## Connecting to an external Database
+## Connecting to an External Database
 
 In this section, we'll expand our configuration section to allow end users to bring their own Postgres instance.
 
@@ -669,7 +669,7 @@ psql: could not translate host name "fake" to address: Name or service not known
 
 We'll optionally wire this to a real external Postgres database later, but for now we'll proceed to add the rest of the fields.
 
-### Extending this to all fields
+### Extending this to All Fields
 
 Now that we've wired the DB_HOST field all the way through, we'll do the same for the other fields.
 In the end, your Secret and Deployment should look like the following YAML files:
@@ -877,7 +877,7 @@ DB_HOST=10.128.0.12
 DB_USER=postgres
 ```
 
-### Triggering restarts on changes
+### Triggering Restarts on Changes
 
 In order to automate this restart on changes, we're going to use a hash of all database parameters to trigger a rolling update whenever database parameters are changed.
 We'll use a `hidden`, `readonly` field to store this in our config screen:
@@ -944,7 +944,7 @@ spec:
 ```
 
 
-### Integrating a real Database
+### Integrating a Real Database
 
 If you'd like at this point, you can integrate a real database in your environment, just fill out your configuration fields. You'll know you did it right if your pg-consumer pod can connect.
 

--- a/docs/vendor/tutorial-ci-cd-integration.md
+++ b/docs/vendor/tutorial-ci-cd-integration.md
@@ -1,4 +1,4 @@
-# Integrating with an existing CI/CD platform
+# Integrating with an Existing CI/CD Platform
 
 This tutorial demonstrates how you can package and release an application with Replicated within your existing continuous integration and continuous deployment (CI/CD) platform.
 

--- a/docs/vendor/tutorial-ecr-private-images.md
+++ b/docs/vendor/tutorial-ecr-private-images.md
@@ -1,4 +1,4 @@
-# Using ECR for private images
+# Using ECR for Private Images
 
 The Replicated app manager supports working with private images stored in Amazon's Elastic Container Registry (ECR).
 

--- a/docs/vendor/tutorial-ha-cluster-deploying.md
+++ b/docs/vendor/tutorial-ha-cluster-deploying.md
@@ -1,4 +1,4 @@
-# Deploying a high availability cluster
+# Deploying a High Availability Cluster
 
 In this guide, we will walk through the steps needed to enable Kubernetes high availability capabilities with a cluster installed by the Replicated Kubernetes installer and managed by the Replicated app manager. This only applies to Kubernetes installer-created cluster (embedded cluster) installations. (The Kubernetes installer is our commercial distribution of the kURL open source project).
 


### PR DESCRIPTION
Just the topics in the Vendor section.

SC: https://app.shortcut.com/replicated/story/44644/all-topics-in-vendor-section-should-have-title-case-capitalization-for-titles-and-headings