### PR TITLE
Tutorial update disk space requirement

### DIFF
--- a/docs/vendor/tutorial-installing-without-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-without-existing-cluster.md
@@ -119,7 +119,7 @@ To create the test server and install the app manager:
     * Ubuntu 18.04
     * At least 8 GB of RAM
     * 4 CPU cores
-    * At least 40GB of disk space
+    * At least 50GB of disk space
 
   :::note
   You can also use any cloud provider or local virtual machine.


### PR DESCRIPTION
Based on the host preflight check this disk space requirement should be 50GB instead of 40GB. I am not sure whether this is also an issue for installing it into an existing cluster

`[PASS] Longhorn Disk Usage: The disk containing directory /var/lib/longhorn has at least 50Gi of total space and is less than 60% full`