### PR TITLE
[1.67.0] 32090: Add info about appVersionLabel to enterprise install docs

### DIFF
--- a/docs/enterprise/installing-embedded-cluster.md
+++ b/docs/enterprise/installing-embedded-cluster.md
@@ -10,14 +10,14 @@ Before you install, ensure that you meet the system requirements. For more infor
 
 ## Install in an Online Environment
 
-To install the admin console on a cluster created by the Kubernetes installer, run the installation script provided by the application developer.
+To install the admin console on a cluster created by the Kubernetes installer, run the installation script provided by the application vendor.
 
 ```bash
 curl -sSL https://kurl.sh/supergoodtool | sudo bash
 ```
 
 :::note
-With KOTS v1.67.0 and higher, you can install a specific version of the application. To install a specific version, your vendor provides an installation command with the `appVersionLabel` flag. Example: `curl https://kurl.sh/supergoodtool | sudo bash -s appVersionLabel=3.1.0`.
+With KOTS v1.67.0 and higher, you can install a specific version of the application. Your application vendor provides an installation script with the `appVersionLabel` flag set to the specific version. Example: `curl https://kurl.sh/supergoodtool | sudo bash -s appVersionLabel=3.1.0`.
 :::
 
 ## Install in an Air Gapped Environment

--- a/docs/enterprise/installing-embedded-cluster.md
+++ b/docs/enterprise/installing-embedded-cluster.md
@@ -17,7 +17,7 @@ curl -sSL https://kurl.sh/supergoodtool | sudo bash
 ```
 
 :::note
-With KOTS v1.67.0 and higher, you can install a specific version of the application. To install a specific version, the command your vendor provides will have the `appVersionLabel` flag. Example: `curl https://kurl.sh/supergoodtool | sudo bash -s appVersionLabel=3.1.0`.
+With KOTS v1.67.0 and higher, you can install a specific version of the application. To install a specific version, your vendor provides an installation command with the `appVersionLabel` flag. Example: `curl https://kurl.sh/supergoodtool | sudo bash -s appVersionLabel=3.1.0`.
 :::
 
 ## Install in an Air Gapped Environment

--- a/docs/enterprise/installing-embedded-cluster.md
+++ b/docs/enterprise/installing-embedded-cluster.md
@@ -17,7 +17,7 @@ curl -sSL https://kurl.sh/supergoodtool | sudo bash
 ```
 
 :::note
-With KOTS v1.67.0 and higher, you can install a specific version of the application. Your application vendor provides an installation script with the `appVersionLabel` flag set to the specific version. Example: `curl https://kurl.sh/supergoodtool | sudo bash -s appVersionLabel=3.1.0`.
+With KOTS v1.67.0 and later, you can install a specific version of the application. Use the `appVersionLabel` flag and the version label for a particular version of your vendor's application. Example: `curl https://kurl.sh/supergoodtool | sudo bash -s appVersionLabel=3.1.0`.
 :::
 
 ## Install in an Air Gapped Environment

--- a/docs/enterprise/installing-embedded-cluster.md
+++ b/docs/enterprise/installing-embedded-cluster.md
@@ -17,7 +17,7 @@ curl -sSL https://kurl.sh/supergoodtool | sudo bash
 ```
 
 :::note
-To install a specific version, the command your vendor provides will have the `appVersionLabel` flag, for example: `curl https://kurl.sh/supergoodtool | sudo bash -s appVersionLabel=3.1.0`.
+With KOTS v1.67.0 and higher, you can install a specific version of the application. To install a specific version, the command your vendor provides will have the `appVersionLabel` flag. Example: `curl https://kurl.sh/supergoodtool | sudo bash -s appVersionLabel=3.1.0`.
 :::
 
 ## Install in an Air Gapped Environment

--- a/docs/enterprise/installing-embedded-cluster.md
+++ b/docs/enterprise/installing-embedded-cluster.md
@@ -16,6 +16,10 @@ To install the admin console on a cluster created by the Kubernetes installer, r
 curl -sSL https://kurl.sh/supergoodtool | sudo bash
 ```
 
+:::note
+To install a specific version, the command your vendor provides will have the `appVersionLabel` flag, for example: `curl https://kurl.sh/supergoodtool | sudo bash -s appVersionLabel=3.1.0`.
+:::
+
 ## Install in an Air Gapped Environment
 
 To install in an air gapped environment, download the `.airgap` bundle, untar it, and run the install.sh script.

--- a/docs/enterprise/installing-existing-cluster-online.md
+++ b/docs/enterprise/installing-existing-cluster-online.md
@@ -11,7 +11,7 @@ To start, run the command that was provided by the application vendor:
 kubectl kots install application-name
 ```
 :::note
-To install a specific version, the command your vendor provides will have the `appVersionlabel` flag, for example: `kubectl kots install application-name --app-version-label=3.1.0`.
+With KOTS v1.67.0 and higher, you can install a specific version of the application. To install a specific version, the command your vendor provides will have the `appVersionlabel` flag. Example: `kubectl kots install application-name --app-version-label=3.1.0`.
 :::
 
 The kubectl plugin will walk you through the necessary steps to install the application:

--- a/docs/enterprise/installing-existing-cluster-online.md
+++ b/docs/enterprise/installing-existing-cluster-online.md
@@ -10,6 +10,9 @@ To start, run the command that was provided by the application vendor:
 ```shell
 kubectl kots install application-name
 ```
+:::note
+To install a specific version, the command your vendor provides will have the `appVersionlabel` flag, for example: `kubectl kots install application-name --app-version-label=3.1.0`.
+:::
 
 The kubectl plugin will walk you through the necessary steps to install the application:
 

--- a/docs/enterprise/installing-existing-cluster-online.md
+++ b/docs/enterprise/installing-existing-cluster-online.md
@@ -11,7 +11,7 @@ To start, run the command that was provided by the application vendor:
 kubectl kots install application-name
 ```
 :::note
-With KOTS v1.67.0 and higher, you can install a specific version of the application. Your application vendor provides an installation command with the `appVersionlabel` flag set to the specific version. Example: `kubectl kots install application-name --app-version-label=3.1.0`.
+With KOTS v1.67.0 and later, you can install a specific version of the application. Use the `appVersionLabel` flag and the version label for a particular version of your vendor's application. Example: `kubectl kots install application-name --app-version-label=3.1.0`.
 :::
 
 The kubectl plugin will walk you through the necessary steps to install the application:

--- a/docs/enterprise/installing-existing-cluster-online.md
+++ b/docs/enterprise/installing-existing-cluster-online.md
@@ -11,7 +11,7 @@ To start, run the command that was provided by the application vendor:
 kubectl kots install application-name
 ```
 :::note
-With KOTS v1.67.0 and higher, you can install a specific version of the application. To install a specific version, your vendor provides your vendor provides an installation command with the `appVersionlabel` flag. Example: `kubectl kots install application-name --app-version-label=3.1.0`.
+With KOTS v1.67.0 and higher, you can install a specific version of the application. Your application vendor provides an installation command with the `appVersionlabel` flag set to the specific version. Example: `kubectl kots install application-name --app-version-label=3.1.0`.
 :::
 
 The kubectl plugin will walk you through the necessary steps to install the application:

--- a/docs/enterprise/installing-existing-cluster-online.md
+++ b/docs/enterprise/installing-existing-cluster-online.md
@@ -11,7 +11,7 @@ To start, run the command that was provided by the application vendor:
 kubectl kots install application-name
 ```
 :::note
-With KOTS v1.67.0 and higher, you can install a specific version of the application. To install a specific version, the command your vendor provides will have the `appVersionlabel` flag. Example: `kubectl kots install application-name --app-version-label=3.1.0`.
+With KOTS v1.67.0 and higher, you can install a specific version of the application. To install a specific version, your vendor provides your vendor provides an installation command with the `appVersionlabel` flag. Example: `kubectl kots install application-name --app-version-label=3.1.0`.
 :::
 
 The kubectl plugin will walk you through the necessary steps to install the application:

--- a/docs/enterprise/updating-embedded-cluster.md
+++ b/docs/enterprise/updating-embedded-cluster.md
@@ -12,10 +12,6 @@ All flags passed to the script for the initial installation must be passed again
 curl -sSL https://kurl.sh/supergoodtool | sudo bash
 ```
 
-:::note
-To install a specific version, the command your vendor provides will have the `appVersionLabel` flag, for example: `curl https://kurl.sh/supergoodtool | sudo bash -s appVersionLabel=3.1.0`.
-:::
-
 ### Air Gapped Installations
 
 To update admin console in an air gapped environment, download the new Kubernetes installer air gap bundle, extract it, and run the install.sh script.

--- a/docs/enterprise/updating-embedded-cluster.md
+++ b/docs/enterprise/updating-embedded-cluster.md
@@ -12,6 +12,10 @@ All flags passed to the script for the initial installation must be passed again
 curl -sSL https://kurl.sh/supergoodtool | sudo bash
 ```
 
+:::note
+To install a specific version, the command your vendor provides will have the `appVersionLabel` flag, for example: `curl https://kurl.sh/supergoodtool | sudo bash -s appVersionLabel=3.1.0`.
+:::
+
 ### Air Gapped Installations
 
 To update admin console in an air gapped environment, download the new Kubernetes installer air gap bundle, extract it, and run the install.sh script.


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/32090/ability-to-install-a-specific-prior-app-version-for-embedded-and-existing-cluster-online-installs

Previews:

- https://deploy-preview-236--replicated-docs.netlify.app/enterprise/installing-existing-cluster-online#install-with-the-app-manager

- https://deploy-preview-236--replicated-docs.netlify.app/enterprise/installing-embedded-cluster
