### PR TITLE
Use "Kubernetes installer-created" terminology

### DIFF
--- a/docs/enterprise/image-registry-embedded-cluster.md
+++ b/docs/enterprise/image-registry-embedded-cluster.md
@@ -1,4 +1,4 @@
-# Image Registry for Kubernetes Installer Clusters
+# Image Registry for Kubernetes Installer-Created Clusters
 
 You can use the open source kURL registry add-on to host application images on Kubernetes installer-created clusters.
 

--- a/docs/enterprise/updating-embedded-cluster.md
+++ b/docs/enterprise/updating-embedded-cluster.md
@@ -1,4 +1,4 @@
-# Updating the Admin Console on a Kubernetes Installer Cluster
+# Updating the Admin Console on a Kubernetes Installer-Created Cluster
 
 This document refers to upgrading the Replicated admin console on a Kubernetes installer-created cluster (embedded cluster).
 For information about how to upgrade the admin console on an existing cluster, see [Updating the admin console on an existing cluster](updating-existing-cluster).

--- a/docs/enterprise/updating-existing-cluster.md
+++ b/docs/enterprise/updating-existing-cluster.md
@@ -1,7 +1,7 @@
 # Updating the Admin Console on an Existing Cluster
 
 This document refers to upgrading the Replicated admin console on an existing cluster.
-For information about how to upgrade the admin console on a Kubernetes installer-created cluster (embedded cluster), see [Updating the admin console on a Kubernetes installer cluster](updating-embedded-cluster).
+For information about how to upgrade the admin console on a Kubernetes installer-created cluster (embedded cluster), see [Updating the admin console on a Kubernetes installer-created cluster](updating-embedded-cluster).
 
 **Prerequisites**
 

--- a/docs/reference/kots-cli-getting-started.md
+++ b/docs/reference/kots-cli-getting-started.md
@@ -8,7 +8,7 @@ The Replicated app manager uses the kots CLI, which is a `kubectl`-based plugin,
 Before you install the kots CLI, install [kubectl](https://kubernetes.io/docs/tasks/tools/) on your machine.
 
 :::note
-If you are using an [embedded Kubernetes installer cluster](../enterprise/installing-embedded-cluster), both tools are already pre-installed.
+If you are using an [embedded Kubernetes installer-created cluster](../enterprise/installing-embedded-cluster), both tools are already pre-installed.
 :::
 
 ## Install the kots CLI

--- a/docs/vendor/packaging-ingress.md
+++ b/docs/vendor/packaging-ingress.md
@@ -1,12 +1,12 @@
 # Configuring Cluster Ingress
 
 When delivering a configurable application, ingress can be challenging as it is very cluster specific.
-Below is an example of a flexible `ingress.yaml` file designed to work in most Kubernetes clusters including existing and Kubernetes installer clusters.
+Below is an example of a flexible `ingress.yaml` file designed to work in most Kubernetes clusters including existing and Kubernetes installer-created clusters.
 
 ## Example
 
 The following example includes an Ingress resource with a single host based routing rule.
-The resource will work in both existing clusters and Kubernetes installer clusters.
+The resource will work in both existing clusters and Kubernetes installer-created clusters.
 
 ### Config
 
@@ -59,7 +59,7 @@ spec:
 ### Ingress
 
 For ingress, you must create two separate resources.
-The first of which will be deployed to existing cluster installations, while the second will only be deployed to a Kubernetes installer cluster.
+The first of which will be deployed to existing cluster installations, while the second will only be deployed to a Kubernetes installer-created cluster.
 Both of these resources are selectively excluded with the [`exclude` annotation](packaging-include-resources).
 
 ```yaml

--- a/docs/vendor/tutorial-installing-with-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-with-existing-cluster.md
@@ -110,7 +110,7 @@ To create a customer license:
 
 The app manager can be installed either into an existing Kubernetes cluster, or as a Kubernetes installer-created cluster (embedded cluster). You can see the installation options at the bottom of each channel on the Channels page.
 
-Installing the app manager on existing clusters is similar to using a [Kubernetes installer cluster](tutorial-installing-without-existing-cluster#installing-and-testing), except instead of bringing a plain virtual machine (VM), you will use a pre-built Kubernetes cluster and deploy your application into a namespace.
+Installing the app manager on existing clusters is similar to using a [Kubernetes installer-created cluster](tutorial-installing-without-existing-cluster#installing-and-testing), except instead of bringing a plain virtual machine (VM), you will use a pre-built Kubernetes cluster and deploy your application into a namespace.
 
 ![Installation Methods](/images/guides/kots/installation-methods-existing.png)
 


### PR DESCRIPTION
Rather then "embedded cluster" or "Kubernetes installer cluster"