### PR TITLE
45284 adds max heading level

### DIFF
--- a/docs/release-notes/rn-app-manager.md
+++ b/docs/release-notes/rn-app-manager.md
@@ -1,3 +1,7 @@
+---
+toc_max_heading_level: 2
+---
+
 # App Manager Release Notes
 
 ## 1.67.0


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/45284/max-heading-level-missing-from-app-manager-rns