### PR TITLE
[1.68.0] 45428: Add `supportsMinimalRBACPrivilege` feature

### DIFF
--- a/docs/enterprise/installing-existing-cluster-requirements.md
+++ b/docs/enterprise/installing-existing-cluster-requirements.md
@@ -14,6 +14,6 @@ To install an application on an existing cluster with Replicated, the cluster mu
    * An existing namespace and an RBAC binding that permits the user of the kubectl command-line tool to create workloads, ClusterRoles, and ClusterRoleBindings.
    * cluster-admin permissions to create namespaces and assign RBAC roles across the cluster.
 
-   **Note**: If the `requireMinimalRBACPrivileges` or the `supportsMinimalRBACPrivileges` property is set to `true` in the Application custom resource manifest file, the app manager does not require the ability to create ClusterRoles and ClusterRoleBindings because the app manager uses a namespace-scoped Role and RoleBinding instead. For more information about the Application custom resource, see [Application](../reference/custom-resource-application) in _Custom resources_.
+   **Note**: If the `requireMinimalRBACPrivileges` or the `supportsMinimalRBACPrivileges` property is set to `true` in the Application custom resource manifest file, the app manager does not require the ability to create ClusterRoles and ClusterRoleBindings and uses a namespace-scoped Role and RoleBinding instead. For more information about the Application custom resource, see [Application](../reference/custom-resource-application) in _Custom resources_.
 
 **Note**: Root access on nodes or workstations is *not* required to install an application on an existing cluster.

--- a/docs/enterprise/installing-existing-cluster-requirements.md
+++ b/docs/enterprise/installing-existing-cluster-requirements.md
@@ -14,6 +14,8 @@ To install an application on an existing cluster with Replicated, the cluster mu
    * An existing namespace and an RBAC binding that permits the user of the kubectl command-line tool to create workloads, ClusterRoles, and ClusterRoleBindings.
    * cluster-admin permissions to create namespaces and assign RBAC roles across the cluster.
 
-   **Note**: If the `requireMinimalRBACPrivileges` property is set to `true` in the Application custom resource manifest, or if the `supportsMinimalRBACPrivileges` property is set to `true` in the Application custom resource manifest and the `--use-minimal-rbac` flag is passed to the `kots install` command, the app manager does not require the ability to create ClusterRoles and ClusterRoleBindings and uses a namespace-scoped Role and RoleBinding instead. For more information about the Application custom resource, see [Application](../reference/custom-resource-application) in _Custom resources_.
+:::note
+If the `requireMinimalRBACPrivileges` property is set to `true` in the Application custom resource manifest, or if the `supportsMinimalRBACPrivileges` property is set to `true` in the Application custom resource manifest and the `--use-minimal-rbac` flag is passed to the `kots install` command, the app manager does not require the ability to create ClusterRoles and ClusterRoleBindings and uses a namespace-scoped Role and RoleBinding instead. For more information about the Application custom resource, see [Application](../reference/custom-resource-application) in _Custom resources_.
+:::
 
 **Note**: Root access on nodes or workstations is *not* required to install an application on an existing cluster.

--- a/docs/enterprise/installing-existing-cluster-requirements.md
+++ b/docs/enterprise/installing-existing-cluster-requirements.md
@@ -10,11 +10,10 @@ To install an application on an existing cluster with Replicated, the cluster mu
 
    For more information about the versions of Kubernetes that are compatible with each version of KOTS, see [Kubernetes Version Compatibility](installing-general-requirements/#kubernetes-version-compatibility) in _General System Requirements_.
 * **Storage class**: The cluster must have an existing storage class available. For more information, see [Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/) in the Kubernetes documentation.
-* **Roll-based access control (RBAC)**: Replicated requires the following RBAC permissions on the cluster:
+* **Role-based access control (RBAC)**: Replicated requires the following RBAC permissions on the cluster:
    * An existing namespace and an RBAC binding that permits the user of the kubectl command-line tool to create workloads, ClusterRoles, and ClusterRoleBindings.
    * cluster-admin permissions to create namespaces and assign RBAC roles across the cluster.
 
-   **Note**: If the `requireMinimalRBACPrivileges` property is set to `true` in the Application custom resource manifest file for the application, the app manager does not require the ability to create ClusterRoles and ClusterRoleBindings.
-   When `requireMinimalRBACPrivileges` is set to `true`, the app manager uses a namespace-scoped Role and RoleBinding. For more information about the attributes in the Application custom resource, see [Application](../reference/custom-resource-application) in _Custom resources_.
+   **Note**: If the `requireMinimalRBACPrivileges` or the `supportsMinimalRBACPrivileges` property is set to `true` in the Application custom resource manifest file, the app manager does not require the ability to create ClusterRoles and ClusterRoleBindings because the app manager uses a namespace-scoped Role and RoleBinding instead. For more information about the Application custom resource, see [Application](../reference/custom-resource-application) in _Custom resources_.
 
 **Note**: Root access on nodes or workstations is *not* required to install an application on an existing cluster.

--- a/docs/enterprise/installing-existing-cluster-requirements.md
+++ b/docs/enterprise/installing-existing-cluster-requirements.md
@@ -14,6 +14,6 @@ To install an application on an existing cluster with Replicated, the cluster mu
    * An existing namespace and an RBAC binding that permits the user of the kubectl command-line tool to create workloads, ClusterRoles, and ClusterRoleBindings.
    * cluster-admin permissions to create namespaces and assign RBAC roles across the cluster.
 
-   **Note**: If the `requireMinimalRBACPrivileges` or the `supportsMinimalRBACPrivileges` property is set to `true` in the Application custom resource manifest file, the app manager does not require the ability to create ClusterRoles and ClusterRoleBindings and uses a namespace-scoped Role and RoleBinding instead. For more information about the Application custom resource, see [Application](../reference/custom-resource-application) in _Custom resources_.
+   **Note**: If the `requireMinimalRBACPrivileges` property is set to `true` in the Application custom resource manifest, or if the `supportsMinimalRBACPrivileges` property is set to `true` in the Application custom resource manifest and the `--use-minimal-rbac` flag is passed to the `kots install` command, the app manager does not require the ability to create ClusterRoles and ClusterRoleBindings and uses a namespace-scoped Role and RoleBinding instead. For more information about the Application custom resource, see [Application](../reference/custom-resource-application) in _Custom resources_.
 
 **Note**: Root access on nodes or workstations is *not* required to install an application on an existing cluster.

--- a/docs/reference/custom-resource-application.md
+++ b/docs/reference/custom-resource-application.md
@@ -112,7 +112,7 @@ When installing with minimal role-based access control (RBAC), the app manager r
 
 This option is applicable to existing clusters only.
 
-Allows minimal role-based access control (RBAC) for be set on a per-customer basis. When set to `true`, the app manager enables a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. However, as a per-customer feature, it is not triggered by default in the installation. You must also tell the end user to opt in using the `kots install` command with the `-- use-minimal-rbac` flag set to `true`.
+Allows minimal role-based access control (RBAC) for be used for a subset of customer installations. When set to `true`, the app manager supports creating a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. Minimal RBAC will not be used by default. It will only be used when the `--use-minimal-rbac` flag is passed to the `kots install` command.
 
 When installing with minimal RBAC, the app manager recognizes if the preflight checks fail due to insufficient privileges. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
 

--- a/docs/reference/custom-resource-application.md
+++ b/docs/reference/custom-resource-application.md
@@ -114,7 +114,7 @@ This option is applicable to existing clusters only.
 
 Allows minimal role-based access control (RBAC) for be used for a subset of customer installations. When set to `true`, the app manager supports creating a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. Minimal RBAC will not be used by default. It will only be used when the `--use-minimal-rbac` flag is passed to the `kots install` command.
 
-When installing with minimal RBAC, the app manager recognizes if the preflight checks fail due to insufficient privileges. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
+For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
 
 ## ports
 These are extra ports (additional to the :8800 admin console port) that should be port-forwarded when running the `kots admin-console` command.

--- a/docs/reference/custom-resource-application.md
+++ b/docs/reference/custom-resource-application.md
@@ -104,7 +104,7 @@ When an exact version is specified, the app manager will choose the matching maj
 
 This option is applicable to existing clusters only.
 
-Allows minimal role-based access control (RBAC) to be used for all customer installations. When set to `true`, the app manager creates a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
+Requires minimal role-based access control (RBAC) be used for all customer installations. When set to `true`, the app manager creates a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
 
 When installing with minimal role-based access control (RBAC), the app manager recognizes if the preflight checks failed due to insufficient privileges. When this occurs, a `kubectl preflight` command is displayed that can be run manually in the cluster to run the preflight checks. When the command runs and completes, the results are automatically uploaded to the app manager.
 

--- a/docs/reference/custom-resource-application.md
+++ b/docs/reference/custom-resource-application.md
@@ -104,7 +104,7 @@ When an exact version is specified, the app manager will choose the matching maj
 
 This option is applicable to existing clusters only.
 
-When set to `true`, the app manager creates a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. Setting this flag applies to all customers.
+Allows minimal role-based access control (RBAC) to be used for all customer installations. When set to `true`, the app manager creates a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding.
 
 When installing with minimal role-based access control (RBAC), the app manager recognizes if the preflight checks fail due to insufficient privileges. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
 

--- a/docs/reference/custom-resource-application.md
+++ b/docs/reference/custom-resource-application.md
@@ -106,7 +106,7 @@ This option is applicable to existing clusters only.
 
 Allows minimal role-based access control (RBAC) to be used for all customer installations. When set to `true`, the app manager creates a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding.
 
-When installing with minimal role-based access control (RBAC), the app manager recognizes if the preflight checks fail due to insufficient privileges. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
+For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
 
 ## supportsMinimalRBACPrivileges
 

--- a/docs/reference/custom-resource-application.md
+++ b/docs/reference/custom-resource-application.md
@@ -106,19 +106,11 @@ This option is applicable to existing clusters only.
 
 Requires minimal role-based access control (RBAC) be used for all customer installations. When set to `true`, the app manager creates a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
 
-:::note
-When installing with minimal role-based access control (RBAC), preflight checks can fail due to insufficient privileges. For more information, see [Using Preflight Checks with Minimal RBAC](../vendor/preflight-support-bundle-creating#using-preflight-checks-with-minimal-rbac).
-:::
-
 ## supportsMinimalRBACPrivileges
 
 This option is applicable to existing clusters only.
 
 Allows minimal role-based access control (RBAC) to be used for a subset of customer installations. When set to `true`, the app manager supports creating a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. Minimal RBAC will not be used by default. It will only be used when the `--use-minimal-rbac` flag is passed to the `kots install` command. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
-
-:::note
-When installing with minimal role-based access control (RBAC), preflight checks can fail due to insufficient privileges. For more information, see [Using Preflight Checks with Minimal RBAC](../vendor/preflight-support-bundle-creating#using-preflight-checks-with-minimal-rbac).
-:::
 
 ## ports
 These are extra ports (additional to the :8800 admin console port) that should be port-forwarded when running the `kots admin-console` command.

--- a/docs/reference/custom-resource-application.md
+++ b/docs/reference/custom-resource-application.md
@@ -101,17 +101,17 @@ For backwards compatibility, exact versions are also supported.
 When an exact version is specified, the app manager will choose the matching major and minor version.
 
 ## requireMinimalRBACPrivileges
-When set to `true`, the app manager creates a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding.
+When set to `true`, the app manager creates a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. Setting this applies to all customers. To apply this on a per-customer basis, see [`supportsMinimalRBACPrivileges`](#supportsinimalrbacprivileges).
 
-When installing with [minimal role-based access control (RBAC)](../reference/custom-resource-application#requireminimalrbacprivileges), the app manager recognizes if the preflight checks failed due to insufficient privileges. When this occurs, a `kubectl preflight` command is displayed that can be run manually in the cluster to run the preflight checks. When the command runs and completes, the results are automatically uploaded to the app manager.
+When installing with minimal role-based access control (RBAC), the app manager recognizes if the preflight checks fail due to insufficient privileges. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
 
-**Example:**
+## supportsMinimalRBACPrivileges
 
-```bash
-curl https://krew.sh/preflight | bash
-kubectl preflight secret/<namespace>/kotsadm-<appslug>-preflight
-```
-For more information, see the [RBAC](../vendor/packaging-rbac) documentation.
+This option is applicable to existing clusters only.
+
+Allows minimal role-based access control (RBAC) for be set on a per-customer basis. When set to `true`, the app manager enables a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. However, as a per-customer feature, it is not triggered by default in the installation. You must also tell the end user to opt in using the `kots install` command with the `-- use-minimal-rbac` flag set to `true`.
+
+When installing with minimal RBAC, the app manager recognizes if the preflight checks fail due to insufficient privileges. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
 
 ## ports
 These are extra ports (additional to the :8800 admin console port) that should be port-forwarded when running the `kots admin-console` command.

--- a/docs/reference/custom-resource-application.md
+++ b/docs/reference/custom-resource-application.md
@@ -119,7 +119,7 @@ kubectl preflight secret/<namespace>/kotsadm-<appslug>-preflight
 
 This option is applicable to existing clusters only.
 
-Allows minimal role-based access control (RBAC) for be used for a subset of customer installations. When set to `true`, the app manager supports creating a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. Minimal RBAC will not be used by default. It will only be used when the `--use-minimal-rbac` flag is passed to the `kots install` command. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
+Allows minimal role-based access control (RBAC) to be used for a subset of customer installations. When set to `true`, the app manager supports creating a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. Minimal RBAC will not be used by default. It will only be used when the `--use-minimal-rbac` flag is passed to the `kots install` command. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
 
 When installing with minimal role-based access control (RBAC), the app manager recognizes if the preflight checks failed due to insufficient privileges. When this occurs, a `kubectl preflight` command is displayed that can be run manually in the cluster to run the preflight checks. When the command runs and completes, the results are automatically uploaded to the app manager.
 

--- a/docs/reference/custom-resource-application.md
+++ b/docs/reference/custom-resource-application.md
@@ -101,6 +101,9 @@ For backwards compatibility, exact versions are also supported.
 When an exact version is specified, the app manager will choose the matching major and minor version.
 
 ## requireMinimalRBACPrivileges
+
+This option is applicable to existing clusters only.
+
 When set to `true`, the app manager creates a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. Setting this flag applies to all customers.
 
 When installing with minimal role-based access control (RBAC), the app manager recognizes if the preflight checks fail due to insufficient privileges. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.

--- a/docs/reference/custom-resource-application.md
+++ b/docs/reference/custom-resource-application.md
@@ -104,17 +104,31 @@ When an exact version is specified, the app manager will choose the matching maj
 
 This option is applicable to existing clusters only.
 
-Allows minimal role-based access control (RBAC) to be used for all customer installations. When set to `true`, the app manager creates a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding.
+Allows minimal role-based access control (RBAC) to be used for all customer installations. When set to `true`, the app manager creates a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
 
-For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
+When installing with minimal role-based access control (RBAC), the app manager recognizes if the preflight checks failed due to insufficient privileges. When this occurs, a `kubectl preflight` command is displayed that can be run manually in the cluster to run the preflight checks. When the command runs and completes, the results are automatically uploaded to the app manager.
+
+**Example: `kubectl preflight` command**
+
+```bash
+curl https://krew.sh/preflight | bash
+kubectl preflight secret/<namespace>/kotsadm-<appslug>-preflight
+```
 
 ## supportsMinimalRBACPrivileges
 
 This option is applicable to existing clusters only.
 
-Allows minimal role-based access control (RBAC) for be used for a subset of customer installations. When set to `true`, the app manager supports creating a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. Minimal RBAC will not be used by default. It will only be used when the `--use-minimal-rbac` flag is passed to the `kots install` command.
+Allows minimal role-based access control (RBAC) for be used for a subset of customer installations. When set to `true`, the app manager supports creating a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. Minimal RBAC will not be used by default. It will only be used when the `--use-minimal-rbac` flag is passed to the `kots install` command. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
 
-For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
+When installing with minimal role-based access control (RBAC), the app manager recognizes if the preflight checks failed due to insufficient privileges. When this occurs, a `kubectl preflight` command is displayed that can be run manually in the cluster to run the preflight checks. When the command runs and completes, the results are automatically uploaded to the app manager.
+
+**Example: `kubectl preflight` command**
+
+```bash
+curl https://krew.sh/preflight | bash
+kubectl preflight secret/<namespace>/kotsadm-<appslug>-preflight
+```
 
 ## ports
 These are extra ports (additional to the :8800 admin console port) that should be port-forwarded when running the `kots admin-console` command.

--- a/docs/reference/custom-resource-application.md
+++ b/docs/reference/custom-resource-application.md
@@ -110,7 +110,7 @@ Requires minimal role-based access control (RBAC) be used for all customer insta
 
 This option is applicable to existing clusters only.
 
-Allows minimal role-based access control (RBAC) to be used for a subset of customer installations. When set to `true`, the app manager supports creating a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. Minimal RBAC will not be used by default. It will only be used when the `--use-minimal-rbac` flag is passed to the `kots install` command. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
+Allows minimal role-based access control (RBAC) to be used for a subset of customer installations. When set to `true`, the app manager supports creating a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. Minimal RBAC is not used by default. It is only used when the `--use-minimal-rbac` flag is passed to the `kots install` command. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
 
 ## ports
 These are extra ports (additional to the :8800 admin console port) that should be port-forwarded when running the `kots admin-console` command.

--- a/docs/reference/custom-resource-application.md
+++ b/docs/reference/custom-resource-application.md
@@ -106,14 +106,9 @@ This option is applicable to existing clusters only.
 
 Requires minimal role-based access control (RBAC) be used for all customer installations. When set to `true`, the app manager creates a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
 
-When installing with minimal role-based access control (RBAC), the app manager recognizes if the preflight checks failed due to insufficient privileges. When this occurs, a `kubectl preflight` command is displayed that can be run manually in the cluster to run the preflight checks. When the command runs and completes, the results are automatically uploaded to the app manager.
-
-**Example: `kubectl preflight` command**
-
-```bash
-curl https://krew.sh/preflight | bash
-kubectl preflight secret/<namespace>/kotsadm-<appslug>-preflight
-```
+:::note
+When installing with minimal role-based access control (RBAC), preflight checks can fail due to insufficient privileges. For more information, see [Using Preflight Checks with Minimal RBAC](../vendor/preflight-support-bundle-creating#using-preflight-checks-with-minimal-rbac).
+:::
 
 ## supportsMinimalRBACPrivileges
 
@@ -121,14 +116,9 @@ This option is applicable to existing clusters only.
 
 Allows minimal role-based access control (RBAC) to be used for a subset of customer installations. When set to `true`, the app manager supports creating a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. Minimal RBAC will not be used by default. It will only be used when the `--use-minimal-rbac` flag is passed to the `kots install` command. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
 
-When installing with minimal role-based access control (RBAC), the app manager recognizes if the preflight checks failed due to insufficient privileges. When this occurs, a `kubectl preflight` command is displayed that can be run manually in the cluster to run the preflight checks. When the command runs and completes, the results are automatically uploaded to the app manager.
-
-**Example: `kubectl preflight` command**
-
-```bash
-curl https://krew.sh/preflight | bash
-kubectl preflight secret/<namespace>/kotsadm-<appslug>-preflight
-```
+:::note
+When installing with minimal role-based access control (RBAC), preflight checks can fail due to insufficient privileges. For more information, see [Using Preflight Checks with Minimal RBAC](../vendor/preflight-support-bundle-creating#using-preflight-checks-with-minimal-rbac).
+:::
 
 ## ports
 These are extra ports (additional to the :8800 admin console port) that should be port-forwarded when running the `kots admin-console` command.

--- a/docs/reference/custom-resource-application.md
+++ b/docs/reference/custom-resource-application.md
@@ -101,7 +101,7 @@ For backwards compatibility, exact versions are also supported.
 When an exact version is specified, the app manager will choose the matching major and minor version.
 
 ## requireMinimalRBACPrivileges
-When set to `true`, the app manager creates a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. Setting this applies to all customers. To apply this on a per-customer basis, see [`supportsMinimalRBACPrivileges`](#supportsinimalrbacprivileges).
+When set to `true`, the app manager creates a namespace-scoped Role and RoleBinding, instead of the default cluster-scoped ClusterRole and ClusterRoleBinding. Setting this flag applies to all customers.
 
 When installing with minimal role-based access control (RBAC), the app manager recognizes if the preflight checks fail due to insufficient privileges. For more information about RBAC, see [Namespace-scoped Access](../vendor/packaging-rbac/#namespace-scoped-access) in _Configuring Role-based Access Control_.
 

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -144,7 +144,7 @@ rules:
 ```
 
 :::note
-The kotsadm-operator component receives an authorization for all verb, all resources and all apiGroups in the namespace.
+The kotsadm-operator component receives an authorization for all verbs, resources, and apiGroups in the namespace.
 :::
 
 ## Converting

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -5,9 +5,9 @@ When an application is installed, [Kubernetes RBAC](https://kubernetes.io/docs/r
 By default, the admin console will create a ClusterRole and ClusterRoleBinding with permissions to all namespaces.
 This behavior can be controlled by editing the Application custom resource manifest file. For more information about the Application manifest, see [Application](../reference/custom-resource-application) in the _Custom Resources_ section.
 
-As listed above, an application may require cluster scoped access across all namespaces on all/wildcard k8 objects or to have access limited to its given namespace.
+As listed above, an application can require cluster scoped access across all namespaces on all/wildcard k8 objects or to have access limited to its given namespace.
 In either case, the user who installs an application with the kots CLI must have the wildcard privileges in the cluster.
-If the user has insufficient privileges the following error will be shown when attempting install or upgrade.
+If the user has insufficient privileges the following error is shown when attempting install or upgrade.
 
 ```bash
 $  kubectl kots install appslug
@@ -81,15 +81,15 @@ subjects:
 
 ## Namespace-scoped access
 
-An application developer can limit the minimal role-based access control (RBAC) grants for the admin console to be limited to a single namespace by specifying one of the following options in the Application manifest file.
+An application developer can limit the role-based access control (RBAC) grants for the admin console to a single namespace by specifying one of the following options in the Application manifest file.
 
-* `requireMinimalRBACPrivileges` - When this flag is set, the app manager will create a Role and RoleBinding, granting the admin console access to select resources in the namespace, but not outside of the cluster. Setting this applies to all customers.
+* `requireMinimalRBACPrivileges` - When this flag is set, the app manager creates a Role and RoleBinding, granting the admin console access to select resources in the namespace, but not outside of the cluster. Setting this flag applies to all customers.
 
-* `suppportMinimalRBACPrivileges` - Applicable to existing clusters only. When set to `true`, the app manager enables a namespace-scoped Role and RoleBinding on a per-customer basis. Therefore, it is not triggered by default in the installation. You must also tell the end user to opt in using the `kots install` command with the `-- use-minimal-rbac` flag set to `true`.
+* `supportMinimalRBACPrivileges` - Applicable to existing clusters only. When set to `true`, the app manager enables a namespace-scoped Role and RoleBinding on a per-customer basis. Therefore, this setting is not triggered by default in the installation. You must also tell the end user to opt in using the `kots install` command with the `-- use-minimal-rbac` flag set to `true`.
 
 ### Preflight Checks and Support Bundles
 
-Without access to cluster-scoped resources, some preflight checks and support bundle collectors will not be able to read the resources. These tools will continue to function, but will return less data. In this situation, the admin console presents an option for the user to either proceed with limited data or use the displayed `kubectl preflight` command to run the preflight checks or support bundle remotely with the user's RBAC authorizations. After the command runs, the results are automatically uploaded to the app manager.
+Without access to cluster-scoped resources, some preflight checks and support bundle collectors are not be able to read the resources. These tools continue to function, but return less data. In this situation, the admin console presents an option for the user to either proceed with limited data or use the displayed `kubectl preflight` command to run the preflight checks or support bundle remotely with the user's RBAC authorizations. After the command runs, the results are automatically uploaded to the app manager.
 
 **Example: `kubectl preflight` command**
 
@@ -108,7 +108,7 @@ The `kubectl kots velero ensure-permissions` command can be used to create addit
 ### Air Gap Installations
 
 Air gap installations honor the `requireMinimalRBACPrivileges` flag in [headless mode only](../enterprise/installing-existing-cluster-automation#airgap-install).
-Without access to the internet or the app's `.airgap` package as provided in a headless install, the app manager does not have the information required to determine whether minimal RBAC is appropriate and so it defaults to the more permissive RBAC policy.
+Without access to the internet or the application's `.airgap` package as provided in a headless install, the app manager does not have the information required to determine whether minimal RBAC is appropriate and so it defaults to the more permissive RBAC policy.
 
 ### Operators and multiple namespaces
 
@@ -143,11 +143,11 @@ rules:
     verb: "*"
 ```
 
-(Note that the kotsadm-operator component receives an authorization for all verb, all resources and all apiGroups in the namespace).
+:::note
+The kotsadm-operator component receives an authorization for all verb, all resources and all apiGroups in the namespace.
+:::
 
 ## Converting
 
-The RBAC permissions are set during the initial installation.
-The admin console is running using the assumed identity and cannot change its own authorization.
-Changing the RBAC scope from cluster to namespace or from namespace to cluster affects only new installations of the application; existing installations continue to run with their current authorization.
+The RBAC permissions are set during the initial installation. The admin console is running using the assumed identity and cannot change its own authorization. Changing the RBAC scope from cluster to namespace or from namespace to cluster affects only new installations of the application; existing installations continue to run with their current authorization.
 For applications that need to elevate their permission from namespace to cluster, we recommend including a preflight check to ensure the permission is available.

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -142,5 +142,5 @@ The kotsadm-operator component receives an authorization for all verbs, resource
 
 ## Converting
 
-The RBAC permissions are set during the initial installation. The admin console is running using the assumed identity and cannot change its own authorization. Changing the RBAC scope from cluster to namespace or from namespace to cluster affects only new installations of the application; existing installations continue to run with their current authorization.
+The RBAC permissions are set during the initial installation. The admin console runs using the assumed identity and cannot change its own authorization. Changing the RBAC scope from cluster to namespace or conversely affects only new installations . Existing installations continue to run with their current authorization.
 For applications that need to elevate their permission from namespace to cluster, we recommend including a preflight check to ensure the permission is available.

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -85,7 +85,7 @@ An application vendor can limit the role-based access control (RBAC) grants for 
 
 * `requireMinimalRBACPrivileges` - Applicable to existing clusters only. When set to `true`, the app manager creates a Role and RoleBinding, granting the admin console access to all resources in the namespace, but not to any resources outside of the namespace. Use this option if you want all customer installations to use minimal RBAC.
 
-* `supportMinimalRBACPrivileges` - Applicable to existing clusters only. When set to `true`, the app manager supports creating a namespace-scoped Role and RoleBinding, granting the admin console access to all resources in the namespace, but not to any resources outside of the namespace. Minimal RBAC is not be used by default. It is used only when the `--use-minimal-rbac` flag is passed to the `kots install` command. Use this option if you want a subset of customer installations to use minimal RBAC.
+* `supportMinimalRBACPrivileges` - Applicable to existing clusters only. When set to `true`, the app manager supports creating a Role and RoleBinding, granting the admin console access to all resources in the namespace, but not to any resources outside of the namespace. Minimal RBAC is not used by default. It is used only when the `--use-minimal-rbac` flag is passed to the `kots install` command. Use this option if you want a subset of customer installations to use minimal RBAC.
 
 ### Strict Preflight Checks
 

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -81,7 +81,7 @@ subjects:
 
 ## Namespace-scoped access
 
-An application developer can limit the role-based access control (RBAC) grants for the admin console to a single namespace by specifying one of the following options in the Application manifest file.
+An application vendor can limit the role-based access control (RBAC) grants for the admin console to a single namespace by specifying one of the following options in the Application manifest file.
 
 * `requireMinimalRBACPrivileges` - When this flag is set, the app manager creates a Role and RoleBinding, granting the admin console access to select resources in the namespace, but not outside of the cluster. Setting this flag applies to all customers.
 

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -5,7 +5,7 @@ When an application is installed, [Kubernetes RBAC](https://kubernetes.io/docs/r
 By default, the admin console will create a ClusterRole and ClusterRoleBinding with permissions to all namespaces.
 This behavior can be controlled by editing the Application custom resource manifest file. For more information about the Application manifest, see [Application](../reference/custom-resource-application) in the _Custom Resources_ section.
 
-As listed above, an application can require cluster scoped access across all namespaces on all/wildcard k8 objects or to have access limited to its given namespace.
+As listed above, an application can require cluster-scoped access across all namespaces on all/wildcard Kubernetes objects, or it can have access limited to its given namespace.
 In either case, the user who installs an application with the kots CLI must have the wildcard privileges in the cluster.
 If the user has insufficient privileges, the following error is shown when attempting to install or upgrade.
 

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -83,7 +83,7 @@ subjects:
 
 An application vendor can limit the role-based access control (RBAC) grants for the admin console to a single namespace by specifying one of the following options in the Application manifest file.
 
-* `requireMinimalRBACPrivileges` - When this flag is set, the app manager creates a Role and RoleBinding, granting the admin console access to select resources in the namespace, but not outside of the cluster. Setting this flag applies to all customers.
+* `requireMinimalRBACPrivileges` - Applicable to existing clusters only. When set to `true`, the app manager creates a Role and RoleBinding, granting the admin console access to all resources in the namespace, but not to any resources outside of the namespace. If you want all customer installations to use minimal RBAC, use this option.
 
 * `supportMinimalRBACPrivileges` - Applicable to existing clusters only. When set to `true`, the app manager enables a namespace-scoped Role and RoleBinding on a per-customer basis. Therefore, this setting is not triggered by default in the installation. You must also tell the end user to opt in using the `kots install` command with the `-- use-minimal-rbac` flag set to `true`.
 

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -107,7 +107,7 @@ The `kubectl kots velero ensure-permissions` command can be used to create addit
 
 ### Air Gap Installations
 
-Air gap installations honor the `requireMinimalRBACPrivileges` flag in [headless mode only](../enterprise/installing-existing-cluster-automation#airgap-install).
+Air gap installations honor the `requireMinimalRBACPrivileges` and `supportsMinimalRBACPrivileges` flags in [headless mode only](../enterprise/installing-existing-cluster-automation#airgap-install).
 Without access to the internet or the application's `.airgap` package as provided in a headless install, the app manager does not have the information required to determine whether minimal RBAC is appropriate and so it defaults to the more permissive RBAC policy.
 
 ### Operators and multiple namespaces

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -142,5 +142,5 @@ The kotsadm-operator component receives an authorization for all verbs, resource
 
 ## Converting
 
-The RBAC permissions are set during the initial installation. The admin console runs using the assumed identity and cannot change its own authorization. Changing the RBAC scope from cluster to namespace or conversely affects only new installations . Existing installations continue to run with their current authorization.
+The RBAC permissions are set during the initial installation. The admin console runs using the assumed identity and cannot change its own authorization. Changing the RBAC scope from cluster to namespace or from namespace to cluster affects only new installations. Existing installations continue to run with their current authorization.
 For applications that need to elevate their permission from namespace to cluster, we recommend including a preflight check to ensure the permission is available.

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -83,9 +83,9 @@ subjects:
 
 An application vendor can limit the role-based access control (RBAC) grants for the admin console to a single namespace by specifying one of the following options in the Application manifest file.
 
-* `requireMinimalRBACPrivileges` - Applicable to existing clusters only. When set to `true`, the app manager creates a Role and RoleBinding, granting the admin console access to all resources in the namespace, but not to any resources outside of the namespace. If you want all customer installations to use minimal RBAC, use this option.
+* `requireMinimalRBACPrivileges` - Applicable to existing clusters only. When set to `true`, the app manager creates a Role and RoleBinding, granting the admin console access to all resources in the namespace, but not to any resources outside of the namespace. Use this option if you want all customer installations to use minimal RBAC.
 
-* `supportMinimalRBACPrivileges` - Applicable to existing clusters only. When set to `true`, the app manager enables a namespace-scoped Role and RoleBinding on a per-customer basis. Therefore, this setting is not triggered by default in the installation. You must also tell the end user to opt in using the `kots install` command with the `-- use-minimal-rbac` flag set to `true`.
+* `supportMinimalRBACPrivileges` - Applicable to existing clusters only. When set to `true`, the app manager supports creating a namespace-scoped Role and RoleBinding, granting the admin console access to all resources in the namespace, but not to any resources outside of the namespace. Minimal RBAC is not be used by default. It is used only when the `--use-minimal-rbac` flag is passed to the `kots install` command. Use this option if you want a subset of customer installations to use minimal RBAC.
 
 ### Preflight Checks and Support Bundles
 

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -7,7 +7,7 @@ This behavior can be controlled by editing the Application custom resource manif
 
 As listed above, an application can require cluster scoped access across all namespaces on all/wildcard k8 objects or to have access limited to its given namespace.
 In either case, the user who installs an application with the kots CLI must have the wildcard privileges in the cluster.
-If the user has insufficient privileges the following error is shown when attempting install or upgrade.
+If the user has insufficient privileges, the following error is shown when attempting to install or upgrade.
 
 ```bash
 $  kubectl kots install appslug

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -89,7 +89,7 @@ An application vendor can limit the role-based access control (RBAC) grants for 
 
 ### Strict Preflight Checks
 
-Without access to cluster-scoped resources, some preflight checks are not be able to read the resources. These tools continue to function, but return less data. For more information, see [Creating Preflight Checks and Support Bundles](https://docs.replicated.com/vendor/preflight-support-bundle-creating).
+Without access to cluster-scoped resources, some preflight checks are not be able to read the resources. These tools continue to function, but return less data. For more information, see [Creating Preflight Checks and Support Bundles](../vendor/preflight-support-bundle-creating).
 
 ### Velero Namespace Access
 

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -87,16 +87,9 @@ An application vendor can limit the role-based access control (RBAC) grants for 
 
 * `supportMinimalRBACPrivileges` - Applicable to existing clusters only. When set to `true`, the app manager supports creating a namespace-scoped Role and RoleBinding, granting the admin console access to all resources in the namespace, but not to any resources outside of the namespace. Minimal RBAC is not be used by default. It is used only when the `--use-minimal-rbac` flag is passed to the `kots install` command. Use this option if you want a subset of customer installations to use minimal RBAC.
 
-### Preflight Checks and Support Bundles
+### Strict Preflight Checks
 
-Without access to cluster-scoped resources, some preflight checks and support bundle collectors are not be able to read the resources. These tools continue to function, but return less data. In this situation, the admin console presents an option for the user to either proceed with limited data or use the displayed `kubectl preflight` command to run the preflight checks or support bundle remotely with the user's RBAC authorizations. After the command runs, the results are automatically uploaded to the app manager.
-
-**Example: `kubectl preflight` command**
-
-```bash
-curl https://krew.sh/preflight | bash
-kubectl preflight secret/<namespace>/kotsadm-<appslug>-preflight
-```
+Without access to cluster-scoped resources, some preflight checks are not be able to read the resources. These tools continue to function, but return less data. For more information, see [Creating Preflight Checks and Support Bundles](https://docs.replicated.com/vendor/preflight-support-bundle-creating).
 
 ### Velero Namespace Access
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -16,8 +16,8 @@ deployments.
 on which a customer installs your application. Preflight checks provide clear
 feedback to your customer about any missing requirements or incompatibilities in
 the cluster before they install and deploy your application. This can reduce the number of support escaltions during installation.
-  
-* **Strict preflight checks**: When an analyzer is marked as [`strict`](https://troubleshoot.sh/docs/analyze/#strict), any `fail` outcomes for that analyzer block the deployment of the release. This can be used to prevent users from deploying a release until vendor-specified requirements are met. When configuring `strict` preflight checks, vendors should consider the app manager [cluster privileges](../reference/custom-resource-application#requireminimalrbacprivileges). 
+
+* **Strict preflight checks**: When an analyzer is marked as [`strict`](https://troubleshoot.sh/docs/analyze/#strict), any `fail` outcomes for that analyzer block the deployment of the release. This can be used to prevent users from deploying a release until vendor-specified requirements are met. When configuring `strict` preflight checks, vendors should consider the app manager [cluster privileges](../reference/custom-resource-application#requireminimalrbacprivileges).
 
 ## Creating preflight checks
 
@@ -35,6 +35,16 @@ see [Getting Started](https://troubleshoot.sh/docs/) in the Troubleshoot documen
 For more information about creating preflight checks, see
 [Preflight Checks](https://troubleshoot.sh/docs/preflight/introduction/) in the
 Troubleshoot documentation. There are also a number of basic examples for checking CPU, memory, and disk capacity under [Node Resources Analyzer](https://troubleshoot.sh/reference/analyzers/node-resources/).
+
+### Using Preflight Checks with Minimal RBAC
+When installing with minimal role-based access control (RBAC), the app manager recognizes if the preflight checks failed due to insufficient privileges. When this occurs, a `kubectl preflight` command is displayed that can be run manually in the cluster to run the preflight checks. When the command runs and completes, the results are automatically uploaded to the app manager.
+
+**Example: `kubectl preflight` command**
+
+```bash
+curl https://krew.sh/preflight | bash
+kubectl preflight secret/<namespace>/kotsadm-<appslug>-preflight
+```
 
 ## Creating support bundles
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -36,16 +36,6 @@ For more information about creating preflight checks, see
 [Preflight Checks](https://troubleshoot.sh/docs/preflight/introduction/) in the
 Troubleshoot documentation. There are also a number of basic examples for checking CPU, memory, and disk capacity under [Node Resources Analyzer](https://troubleshoot.sh/reference/analyzers/node-resources/).
 
-### Using Preflight Checks with Minimal RBAC
-When installing with minimal role-based access control (RBAC), the app manager recognizes if the preflight checks failed due to insufficient privileges. When this occurs, a `kubectl preflight` command is displayed that can be run manually in the cluster to run the preflight checks. When the command runs and completes, the results are automatically uploaded to the app manager.
-
-**Example: `kubectl preflight` command**
-
-```bash
-curl https://krew.sh/preflight | bash
-kubectl preflight secret/<namespace>/kotsadm-<appslug>-preflight
-```
-
 ## Creating support bundles
 
 You can create support bundles with the `support-bundle` plugin for the `kubectl` Kubernetes command-line tool.

--- a/docs/vendor/tutorial-installing-with-cli.md
+++ b/docs/vendor/tutorial-installing-with-cli.md
@@ -423,7 +423,7 @@ To install the application:
 
     ![Run Preflight Checks Manually](/images/manual-run-preflights.png)
 
-    When this occurs, a `kubectl preflight` command is displayed that lets the end user manually run the preflight checks and upload the results automatically to the app manager. For more information about configuring RBAC privileges, see [`requireMinimalRBACPrivileges`](../reference/custom-resource-application#requireminimalrbacprivileges) in Application custom resources.
+    When this occurs, a `kubectl preflight` command is displayed that lets the end user manually run the preflight checks and upload the results automatically to the app manager. For more information about configuring RBAC privileges, see [`requireMinimalRBACPrivileges`](../reference/custom-resource-application#requireminimalrbacprivileges) and [`supportsMinimalRBACPrivileges`](../reference/custom-resource-application#supportsminimalrbacprivileges) in Application custom resources.
 
     After the preflight checks pass, the Version History page opens and displays the initial version that was deployed. Later, you will come back to this page to deploy an update to the application.
 

--- a/docs/vendor/tutorial-installing-with-cli.md
+++ b/docs/vendor/tutorial-installing-with-cli.md
@@ -423,7 +423,7 @@ To install the application:
 
     ![Run Preflight Checks Manually](/images/manual-run-preflights.png)
 
-    When this occurs, a `kubectl preflight` command is displayed that lets the end user manually run the preflight checks and upload the results automatically to the app manager. For more information about configuring RBAC privileges, see [`requireMinimalRBACPrivileges`](../reference/custom-resource-application#requireminimalrbacprivileges) and [`supportsMinimalRBACPrivileges`](../reference/custom-resource-application#supportsminimalrbacprivileges) in Application custom resources.
+    When this occurs, a `kubectl preflight` command is displayed that lets the end user manually run the preflight checks and upload the results automatically to the app manager. For more information about configuring RBAC privileges, see [`requireMinimalRBACPrivileges`](../reference/custom-resource-application#requireminimalrbacprivileges) and [`supportsMinimalRBACPrivileges`](../reference/custom-resource-application#supportsminimalrbacprivileges) in the Application custom resource.
 
     After the preflight checks pass, the Version History page opens and displays the initial version that was deployed. Later, you will come back to this page to deploy an update to the application.
 

--- a/docs/vendor/tutorial-installing-with-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-with-existing-cluster.md
@@ -184,7 +184,7 @@ To install the application:
 
     ![Run Preflight Checks Manually](/images/manual-run-preflights.png)
 
-    When this occurs, a `kubectl preflight` command is displayed that lets the end user manually run the preflight checks and upload the results automatically to the app manager. For more information about configuring RBAC privileges, see [`requireMinimalRBACPrivileges`](../reference/custom-resource-application#requireminimalrbacprivileges) and [`supportsMinimalRBACPrivileges`](../reference/custom-resource-application#supportsminimalrbacprivileges) in Application custom resources.
+    When this occurs, a `kubectl preflight` command is displayed that lets the end user manually run the preflight checks and upload the results automatically to the app manager. For more information about configuring RBAC privileges, see [`requireMinimalRBACPrivileges`](../reference/custom-resource-application#requireminimalrbacprivileges) and [`supportsMinimalRBACPrivileges`](../reference/custom-resource-application#supportsminimalrbacprivileges) in the Application custom resource.
 
 1. Click **Application** on the top to see the application running. If you are still connected to this server using SSH, `kubectl get pods` shows the example NGINX service that you just deployed.
 

--- a/docs/vendor/tutorial-installing-with-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-with-existing-cluster.md
@@ -184,7 +184,7 @@ To install the application:
 
     ![Run Preflight Checks Manually](/images/manual-run-preflights.png)
 
-    When this occurs, a `kubectl preflight` command is displayed that lets the end user manually run the preflight checks and upload the results automatically to the app manager. For more information about configuring RBAC privileges, see [`requireMinimalRBACPrivileges`](../reference/custom-resource-application#requireminimalrbacprivileges) in Application custom resources.
+    When this occurs, a `kubectl preflight` command is displayed that lets the end user manually run the preflight checks and upload the results automatically to the app manager. For more information about configuring RBAC privileges, see [`requireMinimalRBACPrivileges`](../reference/custom-resource-application#requireminimalrbacprivileges) and [`supportsMinimalRBACPrivileges`](../reference/custom-resource-application#supportsminimalrbacprivileges) in Application custom resources.
 
 1. Click **Application** on the top to see the application running. If you are still connected to this server using SSH, `kubectl get pods` shows the example NGINX service that you just deployed.
 


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/45428/add-the-supportsminimalrbacprivileges-feature

Previews: 

- https://deploy-preview-262--replicated-docs.netlify.app/enterprise/installing-existing-cluster-requirements

- https://deploy-preview-262--replicated-docs.netlify.app/vendor/packaging-rbac#namespace-scoped-access

- https://deploy-preview-262--replicated-docs.netlify.app/vendor/tutorial-installing-with-existing-cluster#install-the-application

- https://deploy-preview-262--replicated-docs.netlify.app/vendor/tutorial-installing-with-cli#install-the-application

- https://deploy-preview-262--replicated-docs.netlify.app/reference/custom-resource-application#requireminimalrbacprivileges

- https://deploy-preview-262--replicated-docs.netlify.app/reference/custom-resource-application#supportsminimalrbacprivileges

- https://deploy-preview-262--replicated-docs.netlify.app/vendor/preflight-support-bundle-creating#using-preflight-checks-with-minimal-rbac