### PR TITLE
Blocked on Release - 45921: Add CA Cert field to Snapshots Docs

### DIFF
--- a/docs/enterprise/snapshots-storage-destinations.md
+++ b/docs/enterprise/snapshots-storage-destinations.md
@@ -28,8 +28,8 @@ When configuring the admin console to store snapshots on AWS, the following fiel
 | Path (optional)              | The path in the bucket to store all snapshots in                                                                |
 | Access Key ID (optional)     | The AWS IAM Access Key ID that can read from and write to the bucket                                            |
 | Secret Access Key (optional) | The AWS IAM Secret Access Key that is associated with the Access Key ID                                         |
-| Add a CA Certificate         | (Optional) Upload a 3rd-party proxy CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded, however, it is possible to concatenate multiple certificates into one file. **Supported formats:** PEM, CER, CRT, CA, and KEY.          |
 | Use Instance Role            | When enabled, instead of providing an Access Key ID and Secret Access Key, Velero will use an instance IAM role |
+| Add a CA Certificate         | (Optional) Upload a 3rd-party proxy CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded, however, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
 
 ## GCP
 
@@ -40,6 +40,7 @@ When configuring the admin console to store snapshots on GCP, the following fiel
 | Bucket          | The name of the GCP storage bucket to use                                                                 |
 | Path (optional) | The path in the bucket to store all snapshots in                                                          |
 | Service Account | The GCP IAM Service Account JSON file that has permissions to read from and write to the storage location |
+| Add a CA Certificate         | (Optional) Upload a 3rd-party proxy CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded, however, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
 
 ## Azure
 
@@ -56,6 +57,7 @@ When configuring the admin console to store snapshots on a Azure, the following 
 | Client ID                  | The Client ID of a Service Principle with access to the target Container (required only for access via Service Principle)                  |
 | Client Secret              | The Client Secret of a Service Principle with access to the target Container (required only for access via Service Principle)              |
 | Cloud Name                 | The Azure cloud for the target storage (options: AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud)              |
+| Add a CA Certificate         | (Optional) Upload a 3rd-party proxy CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded, however, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
 
 Only connections with Service Principles are supported at this time.
 
@@ -74,6 +76,7 @@ When configuring the admin console to store snapshots on an S3-Compatible storag
 | Access Key ID (optional)     | The AWS IAM Access Key ID that can read from and write to the bucket                                            |
 | Secret Access Key (optional) | The AWS IAM Secret Access Key that is associated with the Access Key ID                                         |
 | Use Instance Role            | When enabled, instead of providing an Access Key ID and Secret Access Key, Velero will use an instance IAM role |
+| Add a CA Certificate         | (Optional) Upload a 3rd-party proxy CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded, however, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
 
 ## Network File System (NFS)
 

--- a/docs/enterprise/snapshots-storage-destinations.md
+++ b/docs/enterprise/snapshots-storage-destinations.md
@@ -25,11 +25,11 @@ When configuring the admin console to store snapshots on AWS, the following fiel
 |------------------------------|-----------------------------------------------------------------------------------------------------------------|
 | Region                       | The AWS region that the S3 bucket is available in                                                               |
 | Bucket                       | The name of the S3 bucket to use                                                                                |
-| Path (optional)              | The path in the bucket to store all snapshots in                                                                |
-| Access Key ID (optional)     | The AWS IAM Access Key ID that can read from and write to the bucket                                            |
-| Secret Access Key (optional) | The AWS IAM Secret Access Key that is associated with the Access Key ID                                         |
+| Path (Optional)              | The path in the bucket to store all snapshots in                                                                |
+| Access Key ID (Optional)     | The AWS IAM Access Key ID that can read from and write to the bucket                                            |
+| Secret Access Key (Optional) | The AWS IAM Secret Access Key that is associated with the Access Key ID                                         |
 | Use Instance Role            | When enabled, instead of providing an Access Key ID and Secret Access Key, Velero will use an instance IAM role |
-| Add a CA Certificate         | (Optional) Upload a 3rd-party proxy CA issued certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded, however, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
+| Add a CA Certificate         | (Optional) Upload a third-party issued proxy CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded. However, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
 
 ## GCP
 
@@ -38,9 +38,9 @@ When configuring the admin console to store snapshots on GCP, the following fiel
 | Name            | Description                                                                                               |
 |-----------------|-----------------------------------------------------------------------------------------------------------|
 | Bucket          | The name of the GCP storage bucket to use                                                                 |
-| Path (optional) | The path in the bucket to store all snapshots in                                                          |
+| Path (Optional) | The path in the bucket to store all snapshots in                                                          |
 | Service Account | The GCP IAM Service Account JSON file that has permissions to read from and write to the storage location |
-| Add a CA Certificate         | (Optional) Upload a 3rd-party proxy CA issued certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded, however, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
+| Add a CA Certificate         | (Optional) Upload a third-party issued proxy CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded. However, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
 
 ## Azure
 
@@ -49,7 +49,7 @@ When configuring the admin console to store snapshots on a Azure, the following 
 | Name                       | Description                                                                                                                                |
 |----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
 | Bucket                     | The name of the Azure Blob Storage Container to use                                                                                        |
-| Path (optional)            | The path in the Blob Storage Container to store all snapshots in                                                                           |
+| Path (Optional)            | The path in the Blob Storage Container to store all snapshots in                                                                           |
 | Resource Group             | The Resource Group name of the target Blob Storage Container                                                                               |
 | Storage Account            | The Storage Account Name of the target Blob Storage Container                                                                              |
 | Subscription ID            | The Subscription ID associated with the target Blob Storage Container (required only for access via Service Principle or AAD Pod Identity) |
@@ -57,7 +57,7 @@ When configuring the admin console to store snapshots on a Azure, the following 
 | Client ID                  | The Client ID of a Service Principle with access to the target Container (required only for access via Service Principle)                  |
 | Client Secret              | The Client Secret of a Service Principle with access to the target Container (required only for access via Service Principle)              |
 | Cloud Name                 | The Azure cloud for the target storage (options: AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud)              |
-| Add a CA Certificate         | (Optional) Upload a 3rd-party proxy CA issued certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded, however, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
+| Add a CA Certificate         | (Optional) Upload a third-party issued proxy CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded. However, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
 
 Only connections with Service Principles are supported at this time.
 
@@ -72,11 +72,11 @@ When configuring the admin console to store snapshots on an S3-Compatible storag
 | Region                       | The AWS region that the S3 bucket is available in                                                               |
 | Endpoint                     | The endpoint to use to connect to the bucket                                                                    |
 | Bucket                       | The name of the S3 bucket to use                                                                                |
-| Path (optional)              | The path in the bucket to store all snapshots in                                                                |
-| Access Key ID (optional)     | The AWS IAM Access Key ID that can read from and write to the bucket                                            |
-| Secret Access Key (optional) | The AWS IAM Secret Access Key that is associated with the Access Key ID                                         |
+| Path (Optional)              | The path in the bucket to store all snapshots in                                                                |
+| Access Key ID (Optional)     | The AWS IAM Access Key ID that can read from and write to the bucket                                            |
+| Secret Access Key (Optional) | The AWS IAM Secret Access Key that is associated with the Access Key ID                                         |
 | Use Instance Role            | When enabled, instead of providing an Access Key ID and Secret Access Key, Velero will use an instance IAM role |
-| Add a CA Certificate         | (Optional) Upload a 3rd-party proxy CA issued certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded, however, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
+| Add a CA Certificate         | (Optional) Upload a third-party issued proxy CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded. However, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
 
 ## Network File System (NFS)
 

--- a/docs/enterprise/snapshots-storage-destinations.md
+++ b/docs/enterprise/snapshots-storage-destinations.md
@@ -29,7 +29,7 @@ When configuring the admin console to store snapshots on AWS, the following fiel
 | Access Key ID (Optional)     | The AWS IAM Access Key ID that can read from and write to the bucket                                            |
 | Secret Access Key (Optional) | The AWS IAM Secret Access Key that is associated with the Access Key ID                                         |
 | Use Instance Role            | When enabled, instead of providing an Access Key ID and Secret Access Key, Velero will use an instance IAM role |
-| Add a CA Certificate         | (Optional) Upload a third-party issued proxy CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded. However, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
+| Add a CA Certificate         | (Optional) Upload a third-party issued (proxy) CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded. However, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
 
 ## GCP
 
@@ -40,7 +40,7 @@ When configuring the admin console to store snapshots on GCP, the following fiel
 | Bucket          | The name of the GCP storage bucket to use                                                                 |
 | Path (Optional) | The path in the bucket to store all snapshots in                                                          |
 | Service Account | The GCP IAM Service Account JSON file that has permissions to read from and write to the storage location |
-| Add a CA Certificate         | (Optional) Upload a third-party issued proxy CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded. However, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
+| Add a CA Certificate         | (Optional) Upload a third-party issued (proxy) CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded. However, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
 
 ## Azure
 
@@ -57,7 +57,7 @@ When configuring the admin console to store snapshots on a Azure, the following 
 | Client ID                  | The Client ID of a Service Principle with access to the target Container (required only for access via Service Principle)                  |
 | Client Secret              | The Client Secret of a Service Principle with access to the target Container (required only for access via Service Principle)              |
 | Cloud Name                 | The Azure cloud for the target storage (options: AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud)              |
-| Add a CA Certificate         | (Optional) Upload a third-party issued proxy CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded. However, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
+| Add a CA Certificate         | (Optional) Upload a third-party issued (proxy) CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded. However, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
 
 Only connections with Service Principles are supported at this time.
 
@@ -76,7 +76,7 @@ When configuring the admin console to store snapshots on an S3-Compatible storag
 | Access Key ID (Optional)     | The AWS IAM Access Key ID that can read from and write to the bucket                                            |
 | Secret Access Key (Optional) | The AWS IAM Secret Access Key that is associated with the Access Key ID                                         |
 | Use Instance Role            | When enabled, instead of providing an Access Key ID and Secret Access Key, Velero will use an instance IAM role |
-| Add a CA Certificate         | (Optional) Upload a third-party issued proxy CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded. However, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
+| Add a CA Certificate         | (Optional) Upload a third-party issued (proxy) CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded. However, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
 
 ## Network File System (NFS)
 

--- a/docs/enterprise/snapshots-storage-destinations.md
+++ b/docs/enterprise/snapshots-storage-destinations.md
@@ -29,7 +29,7 @@ When configuring the admin console to store snapshots on AWS, the following fiel
 | Access Key ID (optional)     | The AWS IAM Access Key ID that can read from and write to the bucket                                            |
 | Secret Access Key (optional) | The AWS IAM Secret Access Key that is associated with the Access Key ID                                         |
 | Use Instance Role            | When enabled, instead of providing an Access Key ID and Secret Access Key, Velero will use an instance IAM role |
-| Add a CA Certificate         | (Optional) Upload a 3rd-party proxy CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded, however, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
+| Add a CA Certificate         | (Optional) Upload a 3rd-party proxy CA issued certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded, however, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
 
 ## GCP
 
@@ -40,7 +40,7 @@ When configuring the admin console to store snapshots on GCP, the following fiel
 | Bucket          | The name of the GCP storage bucket to use                                                                 |
 | Path (optional) | The path in the bucket to store all snapshots in                                                          |
 | Service Account | The GCP IAM Service Account JSON file that has permissions to read from and write to the storage location |
-| Add a CA Certificate         | (Optional) Upload a 3rd-party proxy CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded, however, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
+| Add a CA Certificate         | (Optional) Upload a 3rd-party proxy CA issued certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded, however, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
 
 ## Azure
 
@@ -57,7 +57,7 @@ When configuring the admin console to store snapshots on a Azure, the following 
 | Client ID                  | The Client ID of a Service Principle with access to the target Container (required only for access via Service Principle)                  |
 | Client Secret              | The Client Secret of a Service Principle with access to the target Container (required only for access via Service Principle)              |
 | Cloud Name                 | The Azure cloud for the target storage (options: AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud)              |
-| Add a CA Certificate         | (Optional) Upload a 3rd-party proxy CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded, however, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
+| Add a CA Certificate         | (Optional) Upload a 3rd-party proxy CA issued certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded, however, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
 
 Only connections with Service Principles are supported at this time.
 
@@ -76,7 +76,7 @@ When configuring the admin console to store snapshots on an S3-Compatible storag
 | Access Key ID (optional)     | The AWS IAM Access Key ID that can read from and write to the bucket                                            |
 | Secret Access Key (optional) | The AWS IAM Secret Access Key that is associated with the Access Key ID                                         |
 | Use Instance Role            | When enabled, instead of providing an Access Key ID and Secret Access Key, Velero will use an instance IAM role |
-| Add a CA Certificate         | (Optional) Upload a 3rd-party proxy CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded, however, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
+| Add a CA Certificate         | (Optional) Upload a 3rd-party proxy CA issued certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded, however, it is possible to concatenate multiple certificates into one file. **Formats:** PEM, CER, CRT, CA, and KEY          |
 
 ## Network File System (NFS)
 

--- a/docs/enterprise/snapshots-storage-destinations.md
+++ b/docs/enterprise/snapshots-storage-destinations.md
@@ -28,6 +28,7 @@ When configuring the admin console to store snapshots on AWS, the following fiel
 | Path (optional)              | The path in the bucket to store all snapshots in                                                                |
 | Access Key ID (optional)     | The AWS IAM Access Key ID that can read from and write to the bucket                                            |
 | Secret Access Key (optional) | The AWS IAM Secret Access Key that is associated with the Access Key ID                                         |
+| Add a CA Certificate         | (Optional) Upload a 3rd-party proxy CA certificate used for trusting the authenticity of the snapshot storage endpoint. Only one file can be uploaded, however, it is possible to concatenate multiple certificates into one file. **Supported formats:** PEM, CER, CRT, CA, and KEY.          |
 | Use Instance Role            | When enabled, instead of providing an Access Key ID and Secret Access Key, Velero will use an instance IAM role |
 
 ## GCP


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/45921/blue-team-add-ca-certificate-upload-info-to-snapshots-docs

Preview: https://deploy-preview-270--replicated-docs.netlify.app/enterprise/snapshots-storage-destinations