### PR TITLE
46371 clarify examples in commands

### DIFF
--- a/docs/enterprise/installing-embedded-cluster.md
+++ b/docs/enterprise/installing-embedded-cluster.md
@@ -12,44 +12,58 @@ Before you install, ensure that you meet the system requirements. For more infor
 
 To install the admin console on a cluster created by the Kubernetes installer, run the installation script provided by the application vendor.
 
+For example:
+
 ```bash
-curl -sSL https://kurl.sh/supergoodtool | sudo bash
+curl -sSL https://kurl.sh/APP-SLUG | sudo bash
 ```
+Where `APP-SLUG` is the unique slug for the application. The application slug is included in the installation script provided by the vendor.
 
 :::note
-With KOTS v1.67.0 and later, you can install a specific version of the application. Use the `app-version-label` flag and the version label for a particular version of your vendor's application. Example: `curl https://kurl.sh/supergoodtool | sudo bash -s app-version-label=3.1.0`.
+With KOTS v1.67.0 and later, you can install a specific version of the application. Use the `app-version-label` flag and the version label for a particular version of your vendor's application. For example, `curl https://kurl.sh/supergoodtool | sudo bash -s app-version-label=3.1.0`.
 :::
 
 ## Install in an Air Gapped Environment
 
-To install in an air gapped environment, download the kURL air gap `.tar.gz`, untar it, and run the install.sh script.
-
-You can construct the URL for the bundle by prefixing the above online URL path with `/bundle` and adding `.tar.gz` to the end.
+To install in an air gapped environment, download the kURL air gap `.tar.gz`, untar it, and run the install.sh script:
 
 ```bash
-curl -LO https://k8s.kurl.sh/bundle/supergoodtool.tar.gz
-tar xvzf supergoodtool.tar.gz
+curl -LO https://k8s.kurl.sh/bundle/FILENAME.tar.gz
+tar xvzf FILENAME.tar.gz
 cat install.sh | sudo bash -s airgap
 ```
+Where `FILENAME` is the name of the kURL air gap `.tar.gz` file.
+
+:::note
+You can construct the URL for the air gap bundle by prefixing the URL path for online installations as described in [Install in an Online Environment](#install-in-an-online-environment) above with `/bundle` and adding `.tar.gz` to the end.
+:::
 
 :::note
 The air gap `.tar.gz` includes only the admin console components, which are required to install the application.
 :::
 
-After this command completes, the application can be installed using the application `.airgap` bundle.
+After this command completes, you can install the application with the application `.airgap` bundle:
 
-```bash
-kubectl kots install myapp \
-  --airgap-bundle ./myapp-1.0.165.airgap \
-  --license-file ./license.yaml \
-  --config-values ./config.yaml \
-  --namespace default \
-  --shared-password password
 ```
+kubectl kots install APP-NAME \
+  --airgap-bundle PATH-TO-AIRGAP-BUNDLE \
+  --license-file PATH-TO-LICENSE-FILE \
+  --config-values PATH-TO-CONFIG-VALUES \
+  --namespace default \
+  --shared-password PASSWORD
+```
+Where:
+* `APP-NAME` is a name for the application.
+* `PATH-TO-AIRGAP-BUNDLE` is the path to the `.airgap` bundle file.
+* `PATH-TO-LICENSE-FILE` is the path to the license file.
+* `PATH-TO-CONFIG-VALUES` is the path to the ConfigValues manifest file.
+* `PASSWORD` is a shared password.
+
+For more information about the `kots install` command, see [install](../reference/kots-cli-install) in the kots CLI documentation.
 
 ## Install with High Availability
 
-Both online and air gapped installations can be configured in high-availability mode.
+You can include the `ha` option to install with high availability. Both online and air gapped installations can be configured in high-availability mode.
 
 When installing on a highly available cluster, the script will prompt for a load balancer address.
 The load balancer can be preconfigured by passing in the `load-balancer-address=<host:port>` flag.
@@ -63,12 +77,18 @@ For more information on the kube-apiserver load balancer see [Create load balanc
 
 In the absence of a load balancer, all traffic will be routed to the first primary.
 
+### Online
+
+To install with high availability in an online environment, run:
+
 ```bash
-curl -sSL https://kurl.sh/supergoodtool | sudo bash -s ha
+curl -sSL https://kurl.sh/APP-SLUG | sudo bash -s ha
 ```
+Where `APP-SLUG` is the unique slug for the application. The application slug is included in the installation script provided by the vendor.
 
-or
+### Air Gap Environment
 
+To install with high availability in an air gapped environment, run the following command after you untar the `.tar.gz` file:
 ```bash
 cat install.sh | sudo bash -s airgap ha
 ```

--- a/docs/enterprise/installing-embedded-cluster.md
+++ b/docs/enterprise/installing-embedded-cluster.md
@@ -25,7 +25,7 @@ With KOTS v1.67.0 and later, you can install a specific version of the applicati
 
 ## Install in an Air Gapped Environment
 
-To install in an air gapped environment, download the kURL air gap `.tar.gz`, untar it, and run the install.sh script:
+To install in an air gapped environment, download the kURL air gap `.tar.gz`, extract it, and run the install.sh script:
 
 ```bash
 curl -LO https://k8s.kurl.sh/bundle/FILENAME.tar.gz


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/46371/airgapped-install-instructions-not-abstract-about-slug-name

Replaced the example text in a few places:
- The original request: https://deploy-preview-296--replicated-docs.netlify.app/enterprise/installing-embedded-cluster#install-in-an-air-gapped-environment
- Also: https://deploy-preview-296--replicated-docs.netlify.app/enterprise/installing-embedded-cluster#install-in-an-online-environment
- Also: https://deploy-preview-296--replicated-docs.netlify.app/enterprise/installing-embedded-cluster#install-with-high-availability