### PR TITLE
46907 change velero links

### DIFF
--- a/docs/enterprise/snapshots-restoring-full.md
+++ b/docs/enterprise/snapshots-restoring-full.md
@@ -7,7 +7,7 @@ This is especially true for installations on cluster created with the Replicated
 
 1. Begin with installing a version of Velero compatible with the one that was used to make the snapshot.
     * If restoring from an NFS or a host path storage destination, see [Configuring NFS](snapshots-configuring-nfs) or [Configuring a host path](snapshots-configuring-hostpath) for the configuration steps and how to set up Velero.
-    * Otherwise, see [Basic Install](https://velero.netlify.app/docs/v1.5/basic-install/) and [Plugins](https://velero.netlify.app/plugins/) in the Velero documentation.
+    * Otherwise, see [Basic Install](https://velero.io/docs/v1.5/basic-install/) and [Plugins](https://velero.io/plugins/) in the Velero documentation.
 
     **Note**: Restic is required and `--use-restic` flag must be used with `velero install` command.
 

--- a/docs/enterprise/snapshots-restoring-partial.md
+++ b/docs/enterprise/snapshots-restoring-partial.md
@@ -5,4 +5,4 @@ During this process, all existing application manifests will be removed from the
 
 The restore process will then re-deploy all application manifests to the namespace, and all pods will have an extra `initContainer` and an extra directory named `.velero`. This is used for restore hooks.
 
-For more information about the restore process, see [Restore Reference](https://velero.netlify.app/docs/v1.5/restore-reference/) in the Velero documentation.
+For more information about the restore process, see [Restore Reference](https://velero.io/docs/v1.5/restore-reference/) in the Velero documentation.

--- a/docs/enterprise/snapshots-storage-destinations.md
+++ b/docs/enterprise/snapshots-storage-destinations.md
@@ -1,6 +1,6 @@
 # Storage Destinations
 
-The Replicated snapshot feature supports any compatible Velero storage provider. For more information, see [Providers](https://velero.netlify.app/docs/main/supported-providers/) in the Velero documentation.
+The Replicated snapshot feature supports any compatible Velero storage provider. For more information, see [Providers](https://velero.io/docs/main/supported-providers/) in the Velero documentation.
 
 The Replicated admin console has built-in support for configuring AWS, GCP, Azure, S3-Compatible object store, NFS Server, or local host path as destinations.
 
@@ -14,7 +14,7 @@ For more information about RBAC priviledges for the admin console, see [Kubernet
 
 ## Prerequisites for Cloud Configurations
 
-* Existing clusters: Customers must install Velero before configuring snapshots. See [Basic Install](https://velero.netlify.app/docs/v1.6/basic-install/) in the Velero documentation.
+* Existing clusters: Customers must install Velero before configuring snapshots. See [Basic Install](https://velero.io/docs/v1.6/basic-install/) in the Velero documentation.
 * Kubernetes installer-created clusters: The vendor can provide the Velero add-on in the embedded cluster installation. If it is not provided, the snapshots configuration dialog in the admin console notifies you to install Velero before you can proceed with the configuration.
 
 ## AWS

--- a/docs/enterprise/snapshots-troubleshooting-backup-restore.md
+++ b/docs/enterprise/snapshots-troubleshooting-backup-restore.md
@@ -68,4 +68,4 @@ example-nginx-77b878b4f-zwv2h         3/3     Running     0          4m15s
 
 We've seen this issue with Velero version 1.5.4 and opened up this issue with the project to inspect the root cause: https://github.com/vmware-tanzu/velero/issues/3686. However we have not experienced this using Velero 1.6.0 or greater.
 
-Summary: Upgrade Velero to 1.6.0. You can upgrade using the Replicated Kubernetes installer. Or, to follow the Velero upgrade instructions, see [Upgrading to Velero 1.6](https://velero.netlify.app/docs/v1.6/upgrade-to-1.6/) in the Velero documentation.
+Summary: Upgrade Velero to 1.6.0. You can upgrade using the Replicated Kubernetes installer. Or, to follow the Velero upgrade instructions, see [Upgrading to Velero 1.6](https://velero.io/docs/v1.6/upgrade-to-1.6/) in the Velero documentation.

--- a/docs/reference/custom-resource-about.md
+++ b/docs/reference/custom-resource-about.md
@@ -14,6 +14,6 @@ The custom resources defined here are included to control the application experi
 | troubleshoot.replicated.com/v1beta2 | [Redactor](https://troubleshoot.sh/reference/redactors/overview/) | Defines custom redactors that apply to support bundle contents. Only configurable using the admin console. |
 | app.k8s.io/v1beta1 | [SIG Application](custom-resource-sig-application) | Defines metadata about the application. |
 | kots.io/v1beta1 | [HelmChart](custom-resource-helmchart) | Identifies an instantiation of a Helm Chart. |
-| velero.io/v1 | [Backup](https://velero.netlify.app/docs/v1.3.2/api-types/backup/) | A Velero backup request, triggered when the user initiates a [snapshot](../vendor/snapshots-overview). |
+| velero.io/v1 | [Backup](https://velero.io/docs/v1.3.2/api-types/backup/) | A Velero backup request, triggered when the user initiates a [snapshot](../vendor/snapshots-overview). |
 | kots.io/v1beta1 | [Identity](custom-resource-identity) | Contains vendor-supplied configuration for the Replicated identity service. |
 | troubleshoot.sh/v1beta2 | [Support Bundle](custom-resource-support-bundle) | Defines the custom diagnostic data to collect and analyze in a support bundle. |

--- a/docs/reference/custom-resource-backup.md
+++ b/docs/reference/custom-resource-backup.md
@@ -2,7 +2,7 @@
 
 When you include a Backup custom resource in an application, the Replicated admin console enables [snapshots](../vendor/snapshots-overview) for the application.
 
-For more information about the Backup custom resource, including all options for this custom resource, see [Backups](https://velero.netlify.app/docs/v1.5/api-types/backup/) in the Velero documentation.
+For more information about the Backup custom resource, including all options for this custom resource, see [Backups](https://velero.io/docs/v1.5/api-types/backup/) in the Velero documentation.
 
 This custom resource supports optional resource installations. For more information, see [Include optional resources](../vendor/packaging-include-resources).
 
@@ -24,7 +24,7 @@ The following top-level fields for Backup custom resources are not supported in 
 - `volumeSnapshotLocations`
 - `labelSelector`, `includedResources` and `excludedResources`
 
-All resources are included by default. To exclude resources from the backup, the [`velero.io/exclude-from-backup=true`](https://velero.netlify.app/docs/v1.5/resource-filtering/#veleroioexclude-from-backuptrue) label must be used and added to the resource instead.
+All resources are included by default. To exclude resources from the backup, the [`velero.io/exclude-from-backup=true`](https://velero.io/docs/v1.5/resource-filtering/#veleroioexclude-from-backuptrue) label must be used and added to the resource instead.
 
 - `includeClusterResources`: this will always be set to `true`.
 - `ttl`: this is set to `720h` (1 month) by default and is only configurable by the customer.

--- a/docs/vendor/helm-native-helm-install-order.md
+++ b/docs/vendor/helm-native-helm-install-order.md
@@ -1,8 +1,14 @@
-# Native Helm Charts Installation Order
+# Setting Installation Order for Native Helm Charts
 
-When deploying applications with native Helm charts, your charts are deployed to the cluster in parallel with any other Kubernetes YAML within your application.
-This includes Custom Resource Definitions (CRDs).
-Any custom resources referenced within a native Helm chart must themselves be created by a native Helm chart, and used only within that native Helm chart.
+When you deploy an application with native Helm charts, the Replicated app manager deploys your Helm charts to the cluster along with any other Kubernetes manifest files in your application.
+This includes custom resources.
 
-Helm charts do not have a defined order in which they will be applied.
-If one Helm chart depends on another, Helm [dependencies](https://helm.sh/docs/topics/charts/#chart-dependencies) or subcharts should be used to ensure that the ordering constraints are fulfilled during deployment.
+Any custom resources that you reference in a native Helm chart must themselves be created by a native Helm chart, and used only within that native Helm chart.
+
+You can assign a `weight` to your HelmChart manifest files in Replicated to specify the order in which the app manager deploys each HelmChart.
+
+The `weight` defines the order Helm charts are deployed in ascending order.
+
+If you do not assign a weight to HelmChart manifest files, then the app manager does not deploy Helm charts in a defined order. By default, all HelmChart manifests have `weight` set to `0`. When `weight` is set to `0`, no deployment order is defined.
+
+The app manager also deploys any subcharts and dependencies when deploying a Helm chart. For more information about Helm dependencies, see [dependencies](https://helm.sh/docs/topics/charts/#chart-dependencies) in the Helm documentation.

--- a/docs/vendor/snapshots-backup-hooks.md
+++ b/docs/vendor/snapshots-backup-hooks.md
@@ -1,7 +1,7 @@
 # Configuring Backup Hooks
 
 For many application workloads, additional processing or scripts need to be run before and/or after a backup is taken to prepare the system for a backup.
-Velero has support for this, using [Backup Hooks](https://velero.netlify.app/docs/main/backup-hooks/).
+Velero has support for this, using [Backup Hooks](https://velero.io/docs/main/backup-hooks/).
 
 Some common examples of how a Hook can be used to create successful backups are:
 - Run `pg_dump` to export a postgres database prior to backup

--- a/docs/vendor/snapshots-overview.md
+++ b/docs/vendor/snapshots-overview.md
@@ -2,7 +2,7 @@
 
 Snapshots is the backup and restore feature for applications. This is an optional feature, and it requires that licenses have the Allow Snapshots feature enabled.
 
-To enable snapshots, the Replicated app manager uses the [Velero open source project](https://velero.netlify.app) on the backend to back up Kubernetes manifests and persistent volumes. Velero is a mature, fully-featured application.
+To enable snapshots, the Replicated app manager uses the Velero open source project on the backend to back up Kubernetes manifests and persistent volumes. Velero is a mature, fully-featured application. For more information, see the [Velero documentation](https://velero.io).
 
 In addition to the default functionality that Velero provides, the app manager provides a detailed interface in the [admin console](../enterprise/snapshots-scheduling) where end users can manage the storage destination and schedule, and perform and monitor the backup process. These details can also be managed using the kots CLI, the CLI for the app manager.
 


### PR DESCRIPTION
Changes the velero docs links back to "velero.io" instead of netlify.app.

(Wasn't able to revert the old PR since too much has since changed in those topics, so updated manually and confirmed with an `ag` for `.netlify.app`)

https://app.shortcut.com/replicated/story/46907/update-velero-docs-links-that-point-to-the-netlify-preview-site

For comparison, here is the old PR: https://app.shortcut.com/replicated/story/42549/what-happened-to-the-velero-docs