### PR TITLE
40570 remove outdated info about descriptor key

### DIFF
--- a/docs/vendor/admin-console-customize-app-icon.md
+++ b/docs/vendor/admin-console-customize-app-icon.md
@@ -8,9 +8,9 @@ For information about how to choose an image file for your custom application ic
 
 To add a custom application icon:
 
-1. In the [vendor portal](https://vendor.replicated.com/apps), click **Releases**. Then, either click **Create release** to create a new release, or click **Edit YAML** to edit an existing release.
-1. Create or open the Application custom resource manifest file in the desired release. An Application custom resource manifest file has `kind: Application`.
-1. In the Application manifest, under `spec`, add an `icons` key that includes a link to the desired image.
+1. In the [vendor portal](https://vendor.replicated.com/apps), click **Releases**. Click **Create release** to create a new release, or click **Edit YAML** to edit an existing release.
+1. Create or open the Application custom resource manifest file. An Application custom resource manifest file has `kind: Application`.
+1. In the Application manifest, under `spec`, add an `icon` key that includes a link to the desired image.
 
    **Example**:
 
@@ -30,7 +30,7 @@ To add a custom application icon:
 For your custom application icon to look best in the admin console, consider the following recommendations:
 
 * Use a PNG or JPG file.
-* Use a square image rather than a rectangular one. Application icons are contained to a bounding box. So, a logo with a rectangular shape may appear small.
+* Use a square image rather than a rectangular one. Application icons are contained to a bounding box, and a logo with a rectangular shape can appear small.
 * Use an image that is at least 250 by 250 pixels.
 * Export the image file at 2x.
 * When possible, use an icon or lettermark as the application icon rather than the full wordmark.

--- a/docs/vendor/admin-console-customize-app-icon.md
+++ b/docs/vendor/admin-console-customize-app-icon.md
@@ -1,33 +1,46 @@
 # Customizing the Application Icon
 
-You can add a custom application icon that displays in the Replicated admin
-console and the download portal. Adding a custom icon helps ensure that your
-brand is reflected for your customers.
+You can add a custom application icon that displays in the Replicated admin console and the download portal. Adding a custom icon helps ensure that your brand is reflected for your customers.
 
-To add a custom application icon for the admin console and the download portal,
-create an Application custom resource manifest file and include an `icons` key under the `descriptor`.
-In the `icons` key, specify a source URL and an image type.
+## Add a Custom Icon
 
-```yaml
-apiVersion: kots.io/v1beta1
-kind: Application
-metadata:
-  name: my-application
-spec:
-  title: My Application
-  icon: https://kots.io/images/kotsadm-logo-large@2x.png
-```
+For information about how to choose an image file for your custom application icon that displays well in the admin console, see [Icon Image File Recommendations](#icon-image-file-recommendations) below.
 
-## Proper admin console logo size
-For logos to look best in the admin console, use a PNG or JPG that is square, at least 250x250 pixels, and exported at 2x. Logos are contained to a bounding box so although a logo with a rectangular shape will work, the logo may be small and hard to see. The next section will show an example.
+To add a custom application icon:
 
-Here is the full admin console wordmark logo shown on the the login screen.
-Although the entire logo is visible because it's being contained to the circle, it's a little small and will appear even smaller, about half of this size, in some parts of the admin console.
+1. In the [vendor portal](https://vendor.replicated.com/apps), click **Releases**. Then, either click **Create release** to create a new release, or click **Edit YAML** to edit an existing release.
+1. Create or open the Application custom resource manifest file in the desired release. An Application custom resource manifest file has `kind: Application`.
+1. In the Application manifest, under `spec`, add an `icons` key that includes a link to the desired image.
 
-![Kotsadm logo](/images/login-icon-large.png)
+   **Example**:
 
-Instead it is recommended to use the smaller lettermark logo as the application logo which will appear larger in the bounding boxes.
+   ```yaml
+   apiVersion: kots.io/v1beta1
+   kind: Application
+   metadata:
+     name: my-application
+   spec:
+     title: My Application
+     icon: https://kots.io/images/kotsadm-logo-large@2x.png
+   ```
+1. Save and promote the release to a development environment to test your changes.
 
-![Kotsadm lettermark logo](/images/login-icon-small.png)
+## Icon Image File Recommendations
 
-When possible it's best to use an icon or lettermark as the application icon rather than the full wordmark logo.
+For your custom application icon to look best in the admin console, consider the following recommendations:
+
+* Use a PNG or JPG file.
+* Use a square image rather than a rectangular one. Application icons are contained to a bounding box. So, a logo with a rectangular shape may appear small.
+* Use an image that is at least 250 by 250 pixels.
+* Export the image file at 2x.
+* When possible, use an icon or lettermark as the application icon rather than the full wordmark.
+
+   The following screenshot shows the full admin console wordmark logo that displays on the the login screen:
+
+   ![Kotsadm logo](/images/login-icon-large.png)
+
+    In the screenshot above, although the entire logo is visible it appears small because it is contained to the circle. Note that the admin console also displays this icon at about half of this size on other pages.
+
+    Instead, Replicated recommends that you use the smaller lettermark as the application icon. This smaller lettermark appears larger in the bounding boxes, as shown in the following screenshot:
+
+   ![Kotsadm lettermark logo](/images/login-icon-small.png)


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/40570/resolve-discrepancy-between-text-and-yaml-file-in-the-customizing-app-icon-topic

Picked this up because we'll be updating this topic for the new "preview the app icon" feature that's coming out, so I wanted to get this odd discrepancy resolved and the topic cleaned up so that it's easier to add in the updates. 

https://deploy-preview-372--replicated-docs.netlify.app/vendor/admin-console-customize-app-icon