### PR TITLE
48427: Removing "Understanding Releases" because it's moot

### DIFF
--- a/docs/vendor/releases-understanding.md
+++ b/docs/vendor/releases-understanding.md
@@ -1,7 +1,0 @@
-# Semantic Versioning
-
-Semantic versioning is available with the Replicated app manager v1.58.0 and later.
-
-When you enable semantic versioning on a channel in the vendor portal, the Replicated admin console uses the semantic version format to sequence releases assigned to the channel.
-
-For more information, see [Enabling Semantic Versioning](releases-semantic-versioning).

--- a/sidebars.js
+++ b/sidebars.js
@@ -54,7 +54,6 @@ const sidebars = {
             label: 'Creating and Managing Releases',
             items: [
               'vendor/repository-workflow-and-tagging-releases',
-              'vendor/releases-understanding',
               'vendor/releases-creating-releases',
               {
                 type: 'category',


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/49427/fix-move-content-for-semantic-versioning-and-understanding-releases