### PR TITLE
Update tutorial-installing-without-existing-cluster.md

### DIFF
--- a/docs/vendor/tutorial-installing-without-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-without-existing-cluster.md
@@ -129,7 +129,7 @@ To create the test server and install the app manager:
 1. Run the installation script:
 
   ```shell
-  curl -sSL https://kurl.sh/<your-app-name-and-channel> | sudo bash
+  curl -sSL https://k8s.kurl.sh/<your-app-name-and-channel> | sudo bash
   ```
 
   This script installs Docker, Kubernetes, and the Replicated admin console containers (kotsadm).


### PR DESCRIPTION
When I create a release, the hostname for the installer is `k8s.kurl.sh` not `kurl.sh`
<img width="433" alt="Screen Shot 2022-06-08 at 13 24 53" src="https://user-images.githubusercontent.com/4998130/172689657-a9a9abdd-430d-40d4-a545-bc5847ad94c6.png">
