### PR TITLE
Add manual trigger to scrape job

### DIFF
--- a/.github/workflows/algolia-crawl.yml
+++ b/.github/workflows/algolia-crawl.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       main
+  workflow_dispatch:
 jobs:
   scrape:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a manual trigger to the search scrape job so that it can be manually run without a PR merge while we investigate a better solution.