### PR TITLE
41574: Adding Host Preflight Checks

### DIFF
--- a/docs/release-notes/rn-kubernetes-installer.md
+++ b/docs/release-notes/rn-kubernetes-installer.md
@@ -4,6 +4,15 @@ toc_max_heading_level: 2
 
 # Kubernetes Installer Release Notes
 
+## Release v2022.06.24-0
+
+Released on June 24, 2022
+
+### New Features {#new-features-v2022-06-24-0}
+
+- Adds [KOTS add-on](https://kurl.sh/docs/add-ons/kotsadm) version 1.73.0.
+- Adds [Prometheus add-on](https://kurl.sh/docs/add-ons/prometheus) version 0.57.0-36.2.0 to address the following critical and high severity CVEs: CVE-2022-28391, CVE-2022-0778, CVE-2022-28391, CVE-2022-1271, CVE-2018-25032.
+
 ## Release v2022.06.17-0
 
 Released on June 17, 2022
@@ -11,7 +20,7 @@ Released on June 17, 2022
 ### Improvements {#improvements-v2022-06-17-0}
 
 - Adds [KOTS add-on](https://kurl.sh/docs/add-ons/kotsadm) version 1.72.1.
-- Adds [MinIO add-on](https://kurl.sh/docs/add-ons/minio) version 2022-06-11T19-55-32Z to address the following critical and high severity CVEs: CVE-2020-14040, CVE-2021-42836, CVE-2020-36067, CVE-2020-36066, CVE-2020-35380, CVE-2020-26521, CVE-2020-26892, CVE-2021-3121, CVE-2020-26160, CVE-2021-28831, CVE-2020-11080, CVE-2021-3450, CVE-2021-23840, CVE-2020-1967, CVE-2020-8286, CVE-2020-8285, CVE-2020-8231, CVE-2020-8177, CVE-2020-8169, CVE-2021-30139, CVE-2021-36159
+- Adds [MinIO add-on](https://kurl.sh/docs/add-ons/minio) version 2022-06-11T19-55-32Z to address the following critical and high severity CVEs: CVE-2020-14040, CVE-2021-42836, CVE-2020-36067, CVE-2020-36066, CVE-2020-35380, CVE-2020-26521, CVE-2020-26892, CVE-2021-3121, CVE-2020-26160, CVE-2021-28831, CVE-2020-11080, CVE-2021-3450, CVE-2021-23840, CVE-2020-1967, CVE-2020-8286, CVE-2020-8285, CVE-2020-8231, CVE-2020-8177, CVE-2020-8169, CVE-2021-30139, CVE-2021-36159.
 - Adds details to the documentation for the [AWS add-on](https://kurl.sh/docs/add-ons/aws) to include details on applying the appropriate [AWS IAM](https://aws.amazon.com/iam/) roles required for the add-on to function properly and additional specific requirements necessary for integrating with [AWS ELB](https://aws.amazon.com/elasticloadbalancing/) service.
 
 ### Bug Fixes {#bug-fixes-v2022-06-17-0}

--- a/docs/release-notes/rn-kubernetes-installer.md
+++ b/docs/release-notes/rn-kubernetes-installer.md
@@ -13,6 +13,21 @@ Released on June 24, 2022
 - Adds [KOTS add-on](https://kurl.sh/docs/add-ons/kotsadm) version 1.73.0.
 - Adds [Prometheus add-on](https://kurl.sh/docs/add-ons/prometheus) version 0.57.0-36.2.0 to address the following critical and high severity CVEs: CVE-2022-28391, CVE-2022-0778, CVE-2022-28391, CVE-2022-1271, CVE-2018-25032.
 
+## Release v2022.06.22-0
+
+Released on June 22, 2022
+
+### Improvements {#improvements-v2022-06-22-0}
+
+- Adds [Contour add-on](https://kurl.sh/docs/add-ons/contour) version 1.21.1.
+- Adds [Prometheus add-on](https://kurl.sh/docs/add-ons/prometheus) version 0.57.0-36.0.3.
+- Adds [Sonobuoy add-on](https://kurl.sh/docs/add-ons/sonobuoy) version 0.56.7.
+
+### Bug Fixes {#bug-fixes-v2022-06-22-0}
+
+- Fixes CVEs for [Weave add-on](https://kurl.sh/docs/add-ons/weave) version 2.8.1. CVEs addressed: CVE-2021-36159, CVE-2021-25216, CVE-2021-30139, CVE-2020-8620, CVE-2020-8621, CVE-2020-8623, CVE-2020-8625, CVE-2021-25215, CVE-2021-28831, CVE-2020-8169, CVE-2020-8177, CVE-2020-8231, CVE-2020-8285, CVE-2020-8286, CVE-2020-28196, CVE-2021-23840, CVE-2021-3450, CVE-2021-3517, CVE-2021-3518.
+- Updates the local-volume-provider image to v0.3.5 for the [Velero add-on](https://kurl.sh/docs/add-ons/velero) to address CVE-2022-1664 with critical severity.
+
 ## Release v2022.06.17-0
 
 Released on June 17, 2022
@@ -25,7 +40,6 @@ Released on June 17, 2022
 
 ### Bug Fixes {#bug-fixes-v2022-06-17-0}
 
-- Fixes CVEs for [Weave add-on](https://kurl.sh/docs/add-ons/weave) version 2.8.1. CVEs addressed: CVE-2021-36159, CVE-2021-25216, CVE-2021-30139, CVE-2020-8620, CVE-2020-8621, CVE-2020-8623, CVE-2020-8625, CVE-2021-25215, CVE-2021-28831, CVE-2020-8169, CVE-2020-8177, CVE-2020-8231, CVE-2020-8285, CVE-2020-8286, CVE-2020-28196, CVE-2021-23840, CVE-2021-3450, CVE-2021-3517, CVE-2021-3518
 - Fixes a bug where the [AWS add-on](https://kurl.sh/docs/add-ons/aws) would fail if `latest` or `0.1.x` was used.
 - Fixes a bug when `excludeStorageClass` is set to `true` would cause the [AWS add-on](https://kurl.sh/docs/add-ons/aws) to fail. 
 
@@ -78,7 +92,7 @@ Released on May 16, 2022
 
 ### Improvements
 
-- Adds [Contour add-on](https://kurl.sh/docs/add-ons/contour) version 1.70.0.
+- Adds [Contour add-on](https://kurl.sh/docs/add-ons/contour) version 1.21.0.
 - Adds [Prometheus add-on](https://kurl.sh/docs/add-ons/prometheus) version 0.56.2-35.2.0.
 - Adds [Velero add-on](https://kurl.sh/docs/add-ons/velero) version 1.8.1.
 

--- a/docs/vendor/distributing-workflow.md
+++ b/docs/vendor/distributing-workflow.md
@@ -105,7 +105,7 @@ To iterate on the release of your production application:
         <td>Limit access to a single namespace in a cluster.</td>
       </tr>
       <tr>
-        <td><a href="preflight-support-bundle-creating">Creating Preflight Checks and Support Bundles</a></td>
+        <td><a href="preflight-support-bundle-creating">Defining Preflight Checks and Support Bundles</a></td>
         <td>Define preflight checks to test for system compliance during the installation process and reduce the number of support escalations. <br></br><br></br>Enable support bundles to collect and analyze troubleshooting data from your customers' clusters to help you diagnose problems with application deployments.</td>
       </tr>
       <tr>

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -89,7 +89,7 @@ An application vendor can limit the role-based access control (RBAC) grants for 
 
 ### Strict Preflight Checks
 
-Without access to cluster-scoped resources, some preflight checks are not be able to read the resources. These tools continue to function, but return less data. For more information, see [Creating Preflight Checks and Support Bundles](../vendor/preflight-support-bundle-creating).
+Without access to cluster-scoped resources, some preflight checks are not be able to read the resources. These tools continue to function, but return less data. For more information, see [Defining Preflight Checks and Support Bundles](../vendor/preflight-support-bundle-creating).
 
 ### Velero Namespace Access
 

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -89,7 +89,7 @@ An application vendor can limit the role-based access control (RBAC) grants for 
 
 ### Strict Preflight Checks
 
-Without access to cluster-scoped resources, some preflight checks are not be able to read the resources. These tools continue to function, but return less data. For more information, see [Defining Preflight Checks and Support Bundles](../vendor/preflight-support-bundle-creating).
+Without access to cluster-scoped resources, some preflight checks are not be able to read the resources. These tools continue to function, but return less data. For more information, see [Define Preflight Checks and Support Bundles](../vendor/preflight-support-bundle-creating#define-preflight-checks).
 
 ### Velero Namespace Access
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -70,9 +70,9 @@ To include host preflight checks:
 
 1. Add the default `host-preflights.yaml` specification for each kURL add-on to the installer YAML. You must add the appropriate version for each add-on. For the links to the YAML files for each add-on, see [Finding the Add=on Host Preflight Checks](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL documentation.
 
-1. Add the `kurl` key to the installer.
+1. Add the `kurl` specification to the installer. See [Kurl Add-On](https://kurl.sh/docs/add-ons/kurl) in the kURL documentation.
 
-  The following example shows a Kubernetes installer manifest with a `kurl` configuration for default host preflight keys set to the default values for the kURL add-on>
+  The following example shows a Kubernetes installer manifest with a `kurl` configuration for default host preflight flags set to the default values for the kURL add-on. For simplicity, the host preflights for the other add-ons are not displayed.
 
   ```
   apiVersion: "cluster.kurl.sh/v1beta1"
@@ -105,6 +105,25 @@ To include host preflight checks:
       excludeBuiltinHostPreflights: false
       hostPreflightIgnore: false
       hostPreflightEnforceWarnings: false
+      hostPreflights:
+      apiVersion: troubleshoot.sh/v1beta2
+      kind: HostPreflight
+      spec:
+        collectors:
+          - cpu: {}
+        analyzers:
+          - cpu:
+              checkName: Number of CPU check
+              outcomes:
+                - warn:
+                    when: "count < 6"
+                    message: This server has less than 6 CPU cores
+                - fail:
+                    when: "count < 4"
+                    message: This server has less than 4 CPU cores
+                - pass:
+                    when: "count >= 6"
+                    message: This server has at least 6 CPU cores
   ```
 
 1. (Optional) Set any of the following keys to customize host preflights:
@@ -164,13 +183,6 @@ To include host preflight checks:
     longhorn:
       version: "1.2.x"
     kurl:
-      airgap: true
-      proxyAddress: http://10.128.0.70:3128
-      additionalNoProxyAddresses:
-      - .corporate.internal
-      noProxy: false
-      licenseURL: https://somecompany.com/license-agreement.txt
-      nameserver: 8.8.8.8
       skipSystemPackageInstall: false
       excludeBuiltinHostPreflights: true
       hostPreflightIgnore: false

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -65,7 +65,7 @@ For more information about kURL host preflight advanced options, see [Install Wi
 
 To customize host preflight checks:
 
-1. Get the Kubernetes installer YAML (kind: "Installer") from the landing page at [kurl.sh](https://kurl.sh/). To use Replicated app manager, you must include the KOTS add-on. The easiest way to include add-ons is to select them from the list on the landing page, which adds them automatically to the installer YAML.
+1. Get the Kubernetes installer YAML (kind: "Installer") and add-ons from the landing page at [kurl.sh](https://kurl.sh/). To use Replicated app manager, you must include the KOTS add-on.
 
 1. Add the `kurl` key to the installer.
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -1,4 +1,4 @@
-# Creating Preflight Checks and Support Bundles
+# Defining Preflight Checks and Support Bundles
 
 This topic provides information about how to create preflight checks and support
 bundles and include them with your application.
@@ -21,7 +21,7 @@ the cluster before they install and deploy your application. This can reduce the
 
 * **Host preflight checks**: Host preflight checks can be defined for Kubernetes installers to codify your infrastructure requirements and endure that everything needed to run Kubernetes successfully exists before Kubernetes is installed. You can also verify some of your application system requirements in advance of the Kubernetes installation. See [About Host Preflight Checks](#about-host-preflight-checks-for-kubernetes-installers).
 
-### Defining Preflight Checks
+### Define Preflight Checks
 
 You define preflight checks by creating a `preflight.yaml`
 manifest file. This file specifies the cluster data that is collected and redacted as part of the preflight check.
@@ -37,7 +37,7 @@ For more information about creating preflight checks, see
 Troubleshoot documentation. There are also a number of basic examples for checking CPU, memory, and disk capacity under [Node Resources Analyzer](https://troubleshoot.sh/reference/analyzers/node-resources/).
 
 ## About Host Preflight Checks for Kubernetes Installers
-Kubernetes installers can include host preflight checks to verify your infrastructure requirements are met before installing Kubernetes and help ensure the ongoing health of the cluster. Host preflight checks can also verify that minimum requirements are met for kURL add-ons that are included in the installer.
+Kubernetes installers can include host preflight checks to verify that your infrastructure requirements are met before installing Kubernetes and to help ensure the ongoing health of the cluster. Host preflight checks can also verify that minimum requirements are met for kURL add-ons that are included in the installer.
 
 You can codify some of your application requirements as part of the host preflight checks so that users get feedback before installing the application. For example, you can check that there are enough CPUs to run your application before Kubernetes is installed, which saves time and effort for your customer.
 
@@ -59,7 +59,7 @@ To customize host preflight checks:
 
 1. Get the Kubernetes installer YAML (kind: Installer) from [kurl.sh](https://kurl.sh/).
 
-1. Add `kurl` to the installer. The following example shows the `kurl` configuration for an air gap installation, and the default host preflight checks.
+1. Add `kurl` to the installer. The following example shows the `kurl` configuration for an air gap installation and the default host preflight checks.
 
   ```
   apiVersion: "cluster.kurl.sh/v1beta1"
@@ -107,59 +107,84 @@ To customize host preflight checks:
 
 1. (Optional) Set `hostPreflightEnforceWarnings: true` to block an installation by enforcing a warning.
 
-1. (Optional) Add a `hostPreflights` specification to the YAML file to define custom collectors and analyzers. The following example shows host preflight checks for CPUs for an application that requires more CPUs than the default, and a host preflight check to access a website that may be critical to a business.
+1. (Optional) Add a `hostPreflights` specification to the installer YAML file to define custom collectors and analyzers. The following example shows host preflight checks for CPUs for an application that requires more CPUs than the default, and a host preflight check to access a website that may be critical to a business.
 
   ```
-  kurl:
-    airgap: true
-    proxyAddress: http://10.128.0.70:3128
-    additionalNoProxyAddresses:
-    - .corporate.internal
-    noProxy: false
-    licenseURL: https://somecompany.com/license-agreement.txt
-    nameserver: 8.8.8.8
-    skipSystemPackageInstall: false
-    excludeBuiltinHostPreflights: true
-    hostPreflightIgnore: true
-    hostPreflightEnforceWarnings: true
-    hostPreflights:
-      apiVersion: troubleshoot.sh/v1beta2
-      kind: HostPreflight
-      spec:
-        collectors:
-          - cpu: {}
-          - http:
-       collectorName: Can Access A Website
-               get:
-           Url: https://myFavoriteWebsite.com
-        analyzers:
-          - cpu:
-              checkName: Number of CPU check
-              outcomes:
-                - warn:
-                    when: "count < 6"
-                    message: This server has less than 6 CPU cores
-                - fail:
-                    when: "count < 4"
-                    message: This server has less than 4 CPU cores
-                - pass:
-                    when: "count >= 6"
-                    message: This server has at least 6 CPU cores
-          - http:
-              checkName: Can Access A Website
-              collectorName: Can Access A Website
-              outcomes:
-                - warn:
-                    when: "error"
-                    message: Error connecting to https://myFavoriteWebsite.com
-                    - pass:
-                    when: "statuscode == 200"
-                    message: Connected to https://myFavoriteWebsite.com
+  apiVersion: "cluster.kurl.sh/v1beta1"
+  kind: "Installer"
+  metadata:
+    name: "latest"
+  spec:
+    kubernetes:
+      version: "1.23.x"
+    weave:
+      version: "2.6.x"
+    contour:
+      version: "1.21.x"
+    prometheus:
+      version: "0.57.x"
+    registry:
+      version: "2.7.x"
+    containerd:
+      version: "1.5.x"
+    kotsadm:
+        version: "latest"
+    ekco:
+      version: "latest"
+    minio:
+      version: "2022-06-11T19-55-32Z"
+    longhorn:
+      version: "1.2.x"
+    kurl:
+      airgap: true
+      proxyAddress: http://10.128.0.70:3128
+      additionalNoProxyAddresses:
+      - .corporate.internal
+      noProxy: false
+      licenseURL: https://somecompany.com/license-agreement.txt
+      nameserver: 8.8.8.8
+      skipSystemPackageInstall: false
+      excludeBuiltinHostPreflights: true
+      hostPreflightIgnore: true
+      hostPreflightEnforceWarnings: true
+      hostPreflights:
+        apiVersion: troubleshoot.sh/v1beta2
+        kind: HostPreflight
+        spec:
+          collectors:
+            - cpu: {}
+            - http:
+         collectorName: Can Access A Website
+                 get:
+             Url: https://myFavoriteWebsite.com
+          analyzers:
+            - cpu:
+                checkName: Number of CPU check
+                outcomes:
+                  - warn:
+                      when: "count < 6"
+                      message: This server has less than 6 CPU cores
+                  - fail:
+                      when: "count < 4"
+                      message: This server has less than 4 CPU cores
+                  - pass:
+                      when: "count >= 6"
+                      message: This server has at least 6 CPU cores
+            - http:
+                checkName: Can Access A Website
+                collectorName: Can Access A Website
+                outcomes:
+                  - warn:
+                      when: "error"
+                      message: Error connecting to https://myFavoriteWebsite.com
+                      - pass:
+                      when: "statuscode == 200"
+                      message: Connected to https://myFavoriteWebsite.com
       ```
 
-1. Promote and test your release in a development environment before sharing it with customers.
+1. Promote and test your installer in a development environment before sharing it with customers.
 
-## Defining Support Bundles
+## Define Support Bundles
 
 You define support bundles by creating a `support-bundle.yaml` manifest file. This file specifies the cluster data
 that is collected and redacted as part of the support bundle. The manifest file also defines how the collected data is analyzed.

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -50,30 +50,29 @@ Default host preflight checks verify conditions such as operating system and dis
 
 Host preflight checks run automatically. Default checks can vary, depending on whether the installation is new, an upgrade, joining a node, or an air gap installation. Additionally, some checks only run when certain add-ons are enabled or configured a certain way in the installer. For a complete list of default host preflight checks, see [Default Host Preflights](https://kurl.sh/docs/install-with-kurl/host-preflights#default-host-preflights) in the kURL documentation.
 
-Host preflight checks can be customized. For more information, see [Customize Host Preflight Checks](#customize-host-preflight-checks).
+Host preflight checks can be partially or completely customized. For more information about customizing kURL host preflights, see [Customizing Host Preflights](https://kurl.sh/docs/create-installer/host-preflights/) in the kURL documentation.
 
 
-### Customize Host Preflight Checks
+## Include Host Preflight Checks
 
-You can customize host preflight checks to:
+Include the default host preflights in your Kubernetes installer YAML file to retain Replicated best practices. Then, you can customize parts of the specification if needed. Customizations include the ability to:
 
 - Bypass failures
 - Block an installation for warnings
 - Exclude certain preflights under specific conditions, such as when a particular license entitlement is enabled
 - Skip the default host preflight checks and run only custom checks
 
-For more information about customizing kURL host preflights, see [Customizing Host Preflights](https://kurl.sh/docs/create-installer/host-preflights/) in the kURL documentation.
-
-To customize host preflight checks:
+To include host preflight checks:
 
 1. Get the Kubernetes installer YAML (kind: "Installer") and add-ons from the landing page at [kurl.sh](https://kurl.sh/). To use Replicated app manager, you must include the KOTS add-on.
 
+1. Add the default kURL host preflights YAML to the installer YAML. See [host-preflights.yaml](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL repository.
+
+1. Add the default `host-preflights.yaml` specification for each kURL add-on to the installer YAML. You must add the appropriate version for each add-on. For the links to the YAML files for each add-on, see [Finding the Add=on Host Preflight Checks](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL documentation.
+
 1. Add the `kurl` key to the installer.
 
-  The following example shows a Kubernetes installer manifest with a `kurl` configuration for:
-
-    - An air gap installation
-    - Default host preflight keys set to the default values
+  The following example shows a Kubernetes installer manifest with a `kurl` configuration for default host preflight keys set to the default values for the kURL add-on>
 
   ```
   apiVersion: "cluster.kurl.sh/v1beta1"
@@ -102,13 +101,6 @@ To customize host preflight checks:
     longhorn:
       version: "1.2.x"
     kurl:
-      airgap: true
-      proxyAddress: http://192.0.2.21:3128
-      additionalNoProxyAddresses:
-      - .corporate.internal
-      noProxy: false
-      licenseURL: https://somecompany.com/license-agreement.txt
-      nameserver: 8.8.8.8
       skipSystemPackageInstall: false
       excludeBuiltinHostPreflights: false
       hostPreflightIgnore: false

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -80,7 +80,7 @@ To customize host preflight checks:
         <th width="70%">Description</th>
       </tr>
       <tr>
-        <td><code>`excludeBuiltinHostPreflights: true`</code></td>
+        <td><code>excludeBuiltinHostPreflights: true</code></td>
         <td>Disables the default host preflights for Kubernetes and any included add-ons</td>
       </tr>
       <tr>

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -66,7 +66,7 @@ To customize host preflight checks:
 
 1. Get the Kubernetes installer YAML (kind: "Installer") and add-ons from the landing page at [kurl.sh](https://kurl.sh/). To use Replicated app manager, you must include the KOTS add-on.
 
-1. Copy the default kURL `host-preflights.yaml` specification or the add-on specification that you want to customize to the installer YAML. Copying the default specifications lets you leverage the best practices supplied by Replicated and just customize the parts that you need to.
+1. Copy the default kURL `host-preflights.yaml` specification or the add-on specification that you want to customize to the installer YAML. Copying the default specifications lets you leverage the best practices provided by Replicated and just customize the parts that you need to.
 
   For the default kURL host preflights YAML, see [host-preflights.yaml](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL repository.
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -50,7 +50,7 @@ Default host preflight checks verify conditions such as operating system and dis
 
 Host preflight checks run automatically. Default checks can vary, depending on whether the installation is new, an upgrade, joining a node, or an air gap installation. Additionally, some checks only run when certain add-ons are enabled or configured a certain way in the installer. For a complete list of default host preflight checks, see [Default Host Preflights](https://kurl.sh/docs/install-with-kurl/host-preflights#default-host-preflights) in the kURL documentation.
 
-Host preflight checks can be customized. For more information, see [Customize Host Preflight Checks](#customize-host-prefligt-checks).
+Host preflight checks can be customized. For more information, see [Customize Host Preflight Checks](#customize-host-preflight-checks).
 
 
 ### Customize Host Preflight Checks

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -24,7 +24,7 @@ You define preflight checks by creating a `preflight.yaml`
 manifest file. This file specifies the cluster data that is collected and redacted as part of the preflight check.
 The manifest file also defines how the collected data is analyzed.
 
-When an analyzer is marked as [`strict`](https://troubleshoot.sh/docs/analyze/#strict), any `fail` outcomes for that analyzer block the deployment of the release. This can be used to prevent users from deploying a release until vendor-specified requirements are met. When configuring `strict` preflight checks, vendors should consider the app manager [cluster privileges](../reference/custom-resource-application#requireminimalrbacprivileges).
+When an analyzer is marked as [`strict`](https://troubleshoot.sh/docs/analyze/#strict), any `fail` outcomes for that analyzer block the deployment of the release. This can be used to prevent users from deploying a release until vendor-specified requirements are met. When configuring strict preflight checks, vendors should consider the app manager [cluster privileges](../reference/custom-resource-application#requireminimalrbacprivileges).
 
 You then add the `preflight.yaml` manifest file to the application that you are packaging and distributing with Replicated.    
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -59,7 +59,7 @@ You can customize host preflight checks to:
 
 - Bypass failures
 - Block an installation for warnings
-- Exclude preflights under certain conditions, such as special license entitlements
+- Exclude certain preflights under specific conditions, such as when a particular license entitlement is enabled
 - Skip the default host preflight checks and run only custom checks
 - Include unique messaging and links
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -190,9 +190,9 @@ To customize host preflight checks:
           collectors:
             - cpu: {}
             - http:
-         collectorName: Can Access A Website
-                 get:
-             Url: https://myFavoriteWebsite.com
+                collectorName: Can Access A Website
+                get:
+                 Url: https://myFavoriteWebsite.com
           analyzers:
             - cpu:
                 checkName: Number of CPU check

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -5,7 +5,7 @@ bundles to include with your application, and host preflight checks that you can
 
 ## About Preflight Checks and Support Bundles
 
-Preflight checks and support bundles help to improve and troubleshoot customer deployments.
+Preflight checks and support bundles collect and analyze data in the environment to ensure requirements are met and to troubleshoot issues.
 
 * **Preflight checks**: Preflight checks allow you to define requirements and dependencies for the cluster
 on which a customer installs your application. Preflight checks provide clear

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -66,13 +66,11 @@ To include host preflight checks:
 
 1. Get the Kubernetes installer YAML (kind: "Installer") and add-ons from the landing page at [kurl.sh](https://kurl.sh/). To use Replicated app manager, you must include the KOTS add-on.
 
+1. Add the default `host-preflights.yaml` specification for each add-on to the installer YAML. You must add the appropriate version for each add-on. For the links to the YAML files for each add-on, see [Finding the Add-on Host Preflight Checks](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL documentation.
+
 1. Add the default kURL host preflights YAML to the installer YAML. See [host-preflights.yaml](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL repository.
 
-1. Add the default `host-preflights.yaml` specification for each kURL add-on to the installer YAML. You must add the appropriate version for each add-on. For the links to the YAML files for each add-on, see [Finding the Add=on Host Preflight Checks](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL documentation.
-
-1. Add the `kurl` specification to the installer. See [Kurl Add-On](https://kurl.sh/docs/add-ons/kurl) in the kURL documentation.
-
-  The following example shows a Kubernetes installer manifest with a `kurl` configuration for default host preflight flags set to the default values for the kURL add-on. For simplicity, the host preflights for the other add-ons are not displayed.
+  The following example shows a Kubernetes installer manifest with a `kurl` configuration for default host preflight flags set to the default values for the kURL add-on. For simplicity, the default host preflights for kURL and the other add-ons are not displayed.
 
   ```
   apiVersion: "cluster.kurl.sh/v1beta1"
@@ -125,11 +123,11 @@ To include host preflight checks:
                     message: This server has at least 6 CPU cores
   ```
 
-1. (Optional) Set any of the following keys to customize host preflights:
+1. (Optional) Set any of the following flags to customize host preflights:
 
     <table>
       <tr>
-        <th width="30%">Key: Value</th>
+        <th width="30%">Flag: Value</th>
         <th width="70%">Description</th>
       </tr>
       <tr>

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -61,7 +61,6 @@ You can customize host preflight checks to:
 - Block an installation for warnings
 - Exclude certain preflights under specific conditions, such as when a particular license entitlement is enabled
 - Skip the default host preflight checks and run only custom checks
-- Include unique messaging and links
 
 For more information about kURL host preflight advanced options, see [Install With Kurl - Advanced Options](https://kurl.sh/docs/install-with-kurl/advanced-options) in the kURL documentation.
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -107,7 +107,7 @@ To customize host preflight checks:
       excludeBuiltinHostPreflights: true
   ```
 
-1. (Optional) To keep the default host preflight checks and add customized host preflights, add a `hostPreflights` field to the `kurl` or add-on specification in the Installer manifest. Under the `hostPreflights` field, add a host preflight specification (`kind: HostPreflight`) with your customizations. You only need to specify your customizations because the default host preflights will run automatically.
+1. (Optional) To keep the default host preflight checks and add customized host preflights, add a `hostPreflights` field to the `kurl` or add-on specification in the Installer manifest. Under the `hostPreflights` field, add a host preflight specification (`kind: HostPreflight`) with your customizations. You only need to specify your customizations because the default host preflights run automatically.
 
   The following example shows customized `kurl` host preflight checks for:
 
@@ -188,7 +188,7 @@ To customize host preflight checks:
       </tr>
       <tr>
         <td><code>hostPreflightIgnore: true</code></td>
-        <td>Ignores host preflight failures and warnings. The installation will proceed.</td>
+        <td>Ignores host preflight failures and warnings. The installation proceeds.</td>
       </tr>
       <tr>
         <td><code>hostPreflightEnforceWarnings: true</code></td>
@@ -199,8 +199,8 @@ To customize host preflight checks:
     The following example shows:
 
     - Default host preflights checks are disabled
-    - Customized host preflight checks will run
-    - The installation will be blocked if there is a warning
+    - Customized host preflight checks run
+    - The installation is blocked if there is a warning
 
     ```yaml
     apiVersion: "cluster.kurl.sh/v1beta1"
@@ -285,13 +285,13 @@ Troubleshoot documentation.
 
 A robust support bundle is essential to minimizing back-and-forth when things go wrong.
 At a very minimum, every app's support bundle should contain logs for an application's core pods.
-Usually this will be done with label selectors. To get the labels for an application, either inspect the YAML, or run the following YAML against a running instance to see what labels are used:
+Usually this is done with label selectors. To get the labels for an application, either inspect the YAML, or run the following YAML against a running instance to see what labels are used:
 
 ```shell
 kubectl get pods --show-labels
 ```
 
-Once the labels are discovered, a [logs collector](https://troubleshoot.sh/reference/collectors/pod-logs/) can be used to include logs from these pods in a bundle.
+After the labels are discovered, a [logs collector](https://troubleshoot.sh/reference/collectors/pod-logs/) can be used to include logs from these pods in a bundle.
 Depending on the complexity of an app's labeling schema, you may need a few different declarations of the `logs` collector.
 
-As common issues are encountered in the field, it will make sense to add not only collectors but also analyzers to an app's troubleshooting stack. For example, when an error in a log file is discovered that should be surfaced to an end user in the future, a simple [Text Analyzer](https://troubleshoot.sh/reference/analyzers/regex/) can detect specific log lines and inform an end user of remediation steps.
+As common issues are encountered in the field, it makes sense to add not only collectors but also analyzers to an app's troubleshooting stack. For example, when an error in a log file is discovered that should be surfaced to an end user in the future, a simple [Text Analyzer](https://troubleshoot.sh/reference/analyzers/regex/) can detect specific log lines and inform an end user of remediation steps.

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -36,7 +36,7 @@ For more information about defining preflight checks, see
 Troubleshoot documentation. There are also a number of basic examples for checking CPU, memory, and disk capacity under [Node Resources Analyzer](https://troubleshoot.sh/reference/analyzers/node-resources/).
 
 ## About Host Preflight Checks for Kubernetes Installers
-You can include host preflight checks with Kubernetes installers to verify that infrastructure requirements are met before installing Kubernetes for:
+You can include host preflight checks with Kubernetes installers to verify that infrastructure requirements are met for:
 
 - Kubernetes
 - kURL add-ons
@@ -46,7 +46,7 @@ This helps to ensure successful installation and the ongoing health of the clust
 
 Default host preflight checks verify conditions such as operating system and disk usage. Default host preflight failures block the installation from continuing and exit with a non-zero return code. Users can then update their environment and re-run the host preflight checks.
 
-Default host preflight checks run automatically and can vary, depending on whether the installation is new, an upgrade, a joining node, or an air gap installation. Additionally, some checks only run when certain add-ons are enabled or configured a certain way in the installer. For a complete list of default host preflight checks, see [Default Host Preflights](https://kurl.sh/docs/install-with-kurl/host-preflights#default-host-preflights) in the kURL documentation.
+Host preflight checks run automatically. Default checks can vary, depending on whether the installation is new, an upgrade, a joining node, or an air gap installation. Additionally, some checks only run when certain add-ons are enabled or configured a certain way in the installer. For a complete list of default host preflight checks, see [Default Host Preflights](https://kurl.sh/docs/install-with-kurl/host-preflights#default-host-preflights) in the kURL documentation.
 
 Host preflight checks can be customized. For more information, see [Customize Host Preflight Checks](#customize-host-prefligt-checks).
 
@@ -65,9 +65,14 @@ For more information about kURL host preflight advanced options, see [Install Wi
 
 To customize host preflight checks:
 
-1. Get the Kubernetes installer YAML (kind: "Installer") from the landing page at [kurl.sh](https://kurl.sh/). To use Replicated app manager, you must include the KOTS add-on. The easiest way to do that is to select the KOTS add-on, and any other add-ons that you want to include, on the landing page to automatically add it to the installer YAML.
+1. Get the Kubernetes installer YAML (kind: "Installer") from the landing page at [kurl.sh](https://kurl.sh/). To use Replicated app manager, you must include the KOTS add-on. The easiest way to include add-ons is to select them from the list on the landing page, which adds them automatically to the installer YAML.
 
-1. Add the `kurl` key to the installer. The following example shows a Kubernetes installer manifest with a `kurl` configuration for an air gap installation and the default host preflight keys set to the default values.
+1. Add the `kurl` key to the installer.
+
+  The following example shows a Kubernetes installer manifest with a `kurl` configuration for:
+
+    - An air gap installation
+    - Default host preflight keys set to the default values
 
   ```
   apiVersion: "cluster.kurl.sh/v1beta1"
@@ -130,7 +135,9 @@ To customize host preflight checks:
       </tr>
     </table>
 
-1. (Optional) Add a `hostPreflights` specification to the Installer YAML file to define custom collectors and analyzers. The following example shows host preflight checks and outcomes for:
+1. (Optional) Add a `hostPreflights` specification to the Installer YAML file to define custom collectors and analyzers.
+
+  The following example shows custom host preflight checks and outcomes for:
     - CPUs for an application that requires more CPUs than the default
     - Accessing a website that is critical to the business
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -197,14 +197,13 @@ To customize host preflight checks:
             - cpu:
                 checkName: Number of CPU check
                 outcomes:
-                  - warn:
-                      when: "count < 6"
-                      message: This server has less than 6 CPU cores
                   - fail:
                       when: "count < 4"
                       message: This server has less than 4 CPU cores
+                  - warn:
+                      when: "count < 6"
+                      message: This server has less than 6 CPU cores
                   - pass:
-                      when: "count >= 6"
                       message: This server has at least 6 CPU cores
             - http:
                 checkName: Can Access A Website

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -53,75 +53,24 @@ Host preflight checks run automatically. Default checks can vary, depending on w
 Host preflight checks can be partially or completely customized. For more information about customizing kURL host preflights, see [Customizing Host Preflights](https://kurl.sh/docs/create-installer/host-preflights/) in the kURL documentation.
 
 
-## Include Host Preflight Checks
+## Customize Host Preflight Checks
 
-Include the default host preflights in your Kubernetes installer YAML file to retain Replicated best practices. Then, you can customize parts of the specification if needed. Customizations include the ability to:
+The default host preflights run automatically as part of your Kubernetes installer. There are general kURL host preflight checks that run with all installers. There are also host preflight checks included with certain add-ons. You can customize any of these host preflights if needed. Customizations include the ability to:
 
 - Bypass failures
 - Block an installation for warnings
 - Exclude certain preflights under specific conditions, such as when a particular license entitlement is enabled
 - Skip the default host preflight checks and run only custom checks
 
-To include host preflight checks:
+To customize host preflight checks:
 
 1. Get the Kubernetes installer YAML (kind: "Installer") and add-ons from the landing page at [kurl.sh](https://kurl.sh/). To use Replicated app manager, you must include the KOTS add-on.
 
-1. Add the default `host-preflights.yaml` specification for each add-on to the installer YAML. You must add the appropriate version for each add-on. For the links to the add=on YAML files, see [Finding the Add-on Host Preflight Checks](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL documentation.
+1. Copy the default `host-preflights.yaml` specification to the installer YAML for kURL or any add-on that you want to customize. This lets you leverage the Replicated best practices supplied in the add-on code and just customize the parts that you need to.
 
-1. Add the default kURL host preflights YAML to the installer YAML. See [host-preflights.yaml](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL repository.
+  For the default kURL host preflights YAML, see [host-preflights.yaml](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL repository.
 
-  The following example shows a Kubernetes installer manifest with a `kurl` configuration for default host preflight flags set to the default values for the kURL add-on. For simplicity, the default host preflights for kURL and the other add-ons are not displayed.
-
-  ```
-  apiVersion: "cluster.kurl.sh/v1beta1"
-  kind: "Installer"
-  metadata:
-    name: "latest"
-  spec:
-    kubernetes:
-      version: "1.23.x"
-    weave:
-      version: "2.6.x"
-    contour:
-      version: "1.21.x"
-    prometheus:
-      version: "0.57.x"
-    registry:
-      version: "2.7.x"
-    containerd:
-      version: "1.5.x"
-    kotsadm:
-        version: "latest"
-    ekco:
-      version: "latest"
-    minio:
-      version: "2022-06-11T19-55-32Z"
-    longhorn:
-      version: "1.2.x"
-    kurl:
-      excludeBuiltinHostPreflights: false
-      hostPreflightIgnore: false
-      hostPreflightEnforceWarnings: false
-      hostPreflights:
-      apiVersion: troubleshoot.sh/v1beta2
-      kind: HostPreflight
-      spec:
-        collectors:
-          - cpu: {}
-        analyzers:
-          - cpu:
-              checkName: Number of CPU check
-              outcomes:
-                - warn:
-                    when: "count < 6"
-                    message: This server has less than 6 CPU cores
-                - fail:
-                    when: "count < 4"
-                    message: This server has less than 4 CPU cores
-                - pass:
-                    when: "count >= 6"
-                    message: This server has at least 6 CPU cores
-  ```
+  For links to the add-on YAML files, see [Finding the Add-on Host Preflight Checks](https://kurl.sh/docs/create-installer/host-preflights/#finding-the-add-on-host-preflight-checks) in the kURL documentation.
 
 1. (Optional) Set any of the following flags to customize host preflights:
 
@@ -144,77 +93,75 @@ To include host preflight checks:
       </tr>
     </table>
 
-1. (Optional) Add a `hostPreflights` specification to the Installer YAML file to define custom collectors and analyzers.
+1. (Optional) Add a `hostPreflights` specification to the Installer YAML file to define custom collectors and analyzers. The following example for the customized kURL specification shows:
 
-  The following example shows:
     - Default host preflight checks are disabled
     - Preflight failures and warnings will block the installation
     - Customized checks for an application that requires more CPUs than the default
     - Customized checks for accessing a website that is critical to the application
 
-  ```
-  apiVersion: "cluster.kurl.sh/v1beta1"
-  kind: "Installer"
-  metadata:
-    name: "latest"
-  spec:
-    kubernetes:
-      version: "1.23.x"
-    weave:
-      version: "2.6.x"
-    contour:
-      version: "1.21.x"
-    prometheus:
-      version: "0.57.x"
-    registry:
-      version: "2.7.x"
-    containerd:
-      version: "1.5.x"
-    kotsadm:
+    ```
+    apiVersion: "cluster.kurl.sh/v1beta1"
+    kind: "Installer"
+    metadata:
+      name: "latest"
+    spec:
+      kubernetes:
+        version: "1.23.x"
+      weave:
+        version: "2.6.x"
+      contour:
+        version: "1.21.x"
+      prometheus:
+        version: "0.57.x"
+      registry:
+        version: "2.7.x"
+      containerd:
+        version: "1.5.x"
+      kotsadm:
+          version: "latest"
+      ekco:
         version: "latest"
-    ekco:
-      version: "latest"
-    minio:
-      version: "2022-06-11T19-55-32Z"
-    longhorn:
-      version: "1.2.x"
-    kurl:
-      excludeBuiltinHostPreflights: true
-      hostPreflightIgnore: false
-      hostPreflightEnforceWarnings: true
-      hostPreflights:
-        apiVersion: troubleshoot.sh/v1beta2
-        kind: HostPreflight
-        spec:
-          collectors:
-            - cpu: {}
-            - http:
-                collectorName: Can Access A Website
-                get:
-                 Url: https://myFavoriteWebsite.com
-          analyzers:
-            - cpu:
-                checkName: Number of CPU check
-                outcomes:
-                  - fail:
-                      when: "count < 4"
-                      message: This server has less than 4 CPU cores
-                  - warn:
-                      when: "count < 6"
-                      message: This server has less than 6 CPU cores
-                  - pass:
-                      message: This server has at least 6 CPU cores
-            - http:
-                checkName: Can Access A Website
-                collectorName: Can Access A Website
-                outcomes:
-                  - warn:
-                      when: "error"
-                      message: Error connecting to https://myFavoriteWebsite.com
-                  - pass:
-                      when: "statuscode == 200"
-                      message: Connected to https://myFavoriteWebsite.com
-      ```
+      minio:
+        version: "2022-06-11T19-55-32Z"
+      longhorn:
+        version: "1.2.x"
+      kurl:
+        excludeBuiltinHostPreflights: true
+        hostPreflightEnforceWarnings: true
+        hostPreflights:
+          apiVersion: troubleshoot.sh/v1beta2
+          kind: HostPreflight
+          spec:
+            collectors:
+              - cpu: {}
+              - http:
+                  collectorName: Can Access A Website
+                  get:
+                   Url: https://myFavoriteWebsite.com
+            analyzers:
+              - cpu:
+                  checkName: Number of CPU check
+                  outcomes:
+                    - fail:
+                        when: "count < 4"
+                        message: This server has less than 4 CPU cores
+                    - warn:
+                        when: "count < 6"
+                        message: This server has less than 6 CPU cores
+                    - pass:
+                        message: This server has at least 6 CPU cores
+              - http:
+                  checkName: Can Access A Website
+                  collectorName: Can Access A Website
+                  outcomes:
+                    - warn:
+                        when: "error"
+                        message: Error connecting to https://myFavoriteWebsite.com
+                    - pass:
+                        when: "statuscode == 200"
+                        message: Connected to https://myFavoriteWebsite.com
+        ```
 
 1. Promote and test your installer in a development environment before sharing it with customers.
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -1,31 +1,30 @@
 # Defining Preflight Checks and Support Bundles
 
 This topic provides information about how to create preflight checks and support
-bundles and include them with your application.
+bundles to include with your application, and host preflight checks that you can include with the Kubernetes installer.
 
 ## About Preflight Checks and Support Bundles
 
-Preflight checks and support bundles are both available through the open source
-Replicated Troubleshoot project.
+Preflight checks and support bundles help to improve and troubleshoot customer deployments.
+
+* **Preflight checks**: Preflight checks allow you to define requirements and dependencies for the cluster
+on which a customer installs your application. Preflight checks provide clear
+feedback to your customer about any missing requirements or incompatibilities in
+the cluster before they install and deploy your application. This can reduce the number of support escalations during installation.
 
 * **Support bundles**: Support bundles allow you to collect and analyze troubleshooting data
 from your customers' clusters to help you diagnose problems with application
 deployments.
 
-* **Preflight checks**: Preflight checks allow you to define requirements and dependencies for the cluster
-on which a customer installs your application. Preflight checks provide clear
-feedback to your customer about any missing requirements or incompatibilities in
-the cluster before they install and deploy your application. This can reduce the number of support escaltions during installation.
+Preflight checks and support bundles are based on the open-source Troubleshoot project, which is maintained by Replicated.
 
-* **Strict preflight checks**: When an analyzer is marked as [`strict`](https://troubleshoot.sh/docs/analyze/#strict), any `fail` outcomes for that analyzer block the deployment of the release. This can be used to prevent users from deploying a release until vendor-specified requirements are met. When configuring `strict` preflight checks, vendors should consider the app manager [cluster privileges](../reference/custom-resource-application#requireminimalrbacprivileges).
-
-* **Host preflight checks**: Host preflight checks can be defined for Kubernetes installers to codify your infrastructure requirements and endure that everything needed to run Kubernetes successfully exists before Kubernetes is installed. You can also verify some of your application system requirements in advance of the Kubernetes installation. See [About Host Preflight Checks](#about-host-preflight-checks-for-kubernetes-installers).
-
-### Define Preflight Checks
+## Define Preflight Checks
 
 You define preflight checks by creating a `preflight.yaml`
 manifest file. This file specifies the cluster data that is collected and redacted as part of the preflight check.
 The manifest file also defines how the collected data is analyzed.
+
+When an analyzer is marked as [`strict`](https://troubleshoot.sh/docs/analyze/#strict), any `fail` outcomes for that analyzer block the deployment of the release. This can be used to prevent users from deploying a release until vendor-specified requirements are met. When configuring `strict` preflight checks, vendors should consider the app manager [cluster privileges](../reference/custom-resource-application#requireminimalrbacprivileges).
 
 You then add the `preflight.yaml` manifest file to the application that you are packaging and distributing with Replicated.    
 
@@ -37,29 +36,38 @@ For more information about defining preflight checks, see
 Troubleshoot documentation. There are also a number of basic examples for checking CPU, memory, and disk capacity under [Node Resources Analyzer](https://troubleshoot.sh/reference/analyzers/node-resources/).
 
 ## About Host Preflight Checks for Kubernetes Installers
-Kubernetes installers can include host preflight checks to verify that your infrastructure requirements are met before installing Kubernetes and to help ensure the ongoing health of the cluster. Host preflight checks can also verify that minimum requirements are met for kURL add-ons that are included in the installer.
+You can include host preflight checks with Kubernetes installers to verify that infrastructure requirements are met before installing Kubernetes for:
 
-You can codify some of your application requirements as part of the host preflight checks so that users get feedback before installing the application. For example, you can check that there are enough CPUs to run your application before Kubernetes is installed, which saves time and effort for your customer.
+- Kubernetes
+- kURL add-ons
+- Your application
 
-Default host preflight checks verify conditions such as operating system and disk usage. Default host preflight failures block the installation from continuing and exit with a non-zero return code. Customizations can include:
+This helps to ensure successful installation and the ongoing health of the cluster. You can codify some of your application requirements as part of the host preflight checks so that users get feedback even earlier in the installation process.
 
-- Bypassing failures
-- Blocking an installation for warnings
-- Excluding preflights under certain conditions, such as special license entitlements
-- Skipping the default host preflight checks and running only custom checks
-- Including unique messaging and links
+Default host preflight checks verify conditions such as operating system and disk usage. Default host preflight failures block the installation from continuing and exit with a non-zero return code. Users can then update their environment and re-run the host preflight checks.
 
-Host preflight checks can also vary, depending on whether the installation is new, a joining node, an air gap installation, and so on. For a complete list of default host preflight checks, see [Default Host Preflights](https://kurl.sh/docs/install-with-kurl/host-preflights#default-host-preflights) in the kURL documentation.
+Default host preflight checks run automatically and can vary, depending on whether the installation is new, an upgrade, a joining node, or an air gap installation. Additionally, some checks only run when certain add-ons are enabled or configured a certain way in the installer. For a complete list of default host preflight checks, see [Default Host Preflights](https://kurl.sh/docs/install-with-kurl/host-preflights#default-host-preflights) in the kURL documentation.
+
+Host preflight checks can be customized. For more information, see [Customize Host Preflight Checks](#customize-host-prefligt-checks).
+
 
 ### Customize Host Preflight Checks
 
-Default host preflight checks for Kubernetes installers can be disabled, added to, bypassed, or completely customized using advanced options. For more information about kURL advanced options, see [Advanced Options](https://kurl.sh/docs/install-with-kurl/advanced-options) in the kURL documentation.
+You can customize host preflight checks to:
+
+- Bypass failures
+- Block an installation for warnings
+- Exclude preflights under certain conditions, such as special license entitlements
+- Skip the default host preflight checks and run only custom checks
+- Include unique messaging and links
+
+For more information about kURL host preflight advanced options, see [Install With Kurl - Advanced Options](https://kurl.sh/docs/install-with-kurl/advanced-options) in the kURL documentation.
 
 To customize host preflight checks:
 
-1. Get the Kubernetes installer YAML (kind: Installer) from [kurl.sh](https://kurl.sh/).
+1. Get the Kubernetes installer YAML (kind: "Installer") from the landing page at [kurl.sh](https://kurl.sh/). To use Replicated app manager, you must include the KOTS add-on. The easiest way to do that is to select the KOTS add-on, and any other add-ons that you want to include, on the landing page to automatically add it to the installer YAML.
 
-1. Add `kurl` to the installer. The following example shows the `kurl` configuration for an air gap installation and the default host preflight checks.
+1. Add the `kurl` key to the installer. The following example shows a Kubernetes installer manifest with a `kurl` configuration for an air gap installation and the default host preflight keys set to the default values.
 
   ```
   apiVersion: "cluster.kurl.sh/v1beta1"
@@ -101,13 +109,30 @@ To customize host preflight checks:
       hostPreflightEnforceWarnings: false
   ```
 
-1. (Optional) Set `excludeBuiltinHostPreflights: true` to disable the default host preflights.
+1. (Optional) Set any of the following keys to customize host preflights:
 
-1. (Optional) Set `hostPreflightIgnore: true` to ignore host preflight failures and warnings.
+    <table>
+      <tr>
+        <th width="30%">Key: Value</th>
+        <th width="70%">Description</th>
+      </tr>
+      <tr>
+        <td>`excludeBuiltinHostPreflights: true`</td>
+        <td>Disables the default host preflights</td>
+      </tr>
+      <tr>
+        <td>`hostPreflightIgnore: true`</td>
+        <td>Ignores host preflight failures and warnings</td>
+      </tr>
+      <tr>
+        <td>`hostPreflightEnforceWarnings: true`</td>
+        <td>Blocks an installation by enforcing a warning</td>
+      </tr>
+    </table>
 
-1. (Optional) Set `hostPreflightEnforceWarnings: true` to block an installation by enforcing a warning.
-
-1. (Optional) Add a `hostPreflights` specification to the installer YAML file to define custom collectors and analyzers. The following example shows host preflight checks for CPUs for an application that requires more CPUs than the default, and a host preflight check to access a website that may be critical to a business.
+1. (Optional) Add a `hostPreflights` specification to the Installer YAML file to define custom collectors and analyzers. The following example shows host preflight checks and outcomes for:
+    - CPUs for an application that requires more CPUs than the default
+    - Accessing a website that is critical to the business
 
   ```
   apiVersion: "cluster.kurl.sh/v1beta1"

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -3,7 +3,7 @@
 This topic provides information about how to create preflight checks and support
 bundles and include them with your application.
 
-## About preflight checks and support bundles
+## About Preflight Checks and Support Bundles
 
 Preflight checks and support bundles are both available through the open source
 Replicated Troubleshoot project.
@@ -19,12 +19,14 @@ the cluster before they install and deploy your application. This can reduce the
 
 * **Strict preflight checks**: When an analyzer is marked as [`strict`](https://troubleshoot.sh/docs/analyze/#strict), any `fail` outcomes for that analyzer block the deployment of the release. This can be used to prevent users from deploying a release until vendor-specified requirements are met. When configuring `strict` preflight checks, vendors should consider the app manager [cluster privileges](../reference/custom-resource-application#requireminimalrbacprivileges).
 
-## Creating preflight checks
+* **Host preflight checks**: Host preflight checks can be defined for Kubernetes installers to codify your infrastructure requirements and some of your application system requirements before Kubernetes is installed. See [About Host Preflight Checks](#about-host-preflight-checks-for-kubernetes-installers).
+
+## Defining Preflight Checks
 
 You can create preflight checks with the `preflight` plugin for the `kubectl` Kubernetes command-line tool.
 
 You define preflight checks by creating a `preflight.yaml`
-manifest files. This file specifies the cluster data that is collected and redacted as part of the preflight check.
+manifest file. This file specifies the cluster data that is collected and redacted as part of the preflight check.
 The manifest file also defines how the collected data is analyzed.
 
 You then add the `preflight.yaml` manifest file to the application that you are packaging and distributing with Replicated.    
@@ -36,7 +38,141 @@ For more information about creating preflight checks, see
 [Preflight Checks](https://troubleshoot.sh/docs/preflight/introduction/) in the
 Troubleshoot documentation. There are also a number of basic examples for checking CPU, memory, and disk capacity under [Node Resources Analyzer](https://troubleshoot.sh/reference/analyzers/node-resources/).
 
-## Creating support bundles
+## About Host Preflight Checks for Kubernetes Installers
+Kubernetes installers can include host preflight checks to verify your infrastructure requirements are met before installing Kubernetes and help ensure the ongoing health of the cluster. Host preflight checks can also verify that minimum requirements are met for kURL add-ons.
+
+You can codify some of your application requirements as part of the host preflight checks so that users get feedback before installing the application. For example, you can check that there are enough CPUs to run your application before Kubernetes is installed, which saves time and effort for your customer.
+
+Default host preflight checks verify conditions such as operating system and disk usage. Default host preflight failures block the installation from continuing and exit with a non-zero return code. Customizations can include:
+
+- Bypassing failures
+- Blocking an installation for warnings
+- Skipping the default host preflight checks and running only custom checks
+
+Host preflight checks can also vary, depending on whether the installation is new, a joining node, an air gap installation, and so on. For a complete list of default host preflight checks, see [Default Host Preflights](https://kurl.sh/docs/install-with-kurl/host-preflights#default-host-preflights) in the kURL documentation.
+
+### Customize Host Preflight Checks
+
+Default host preflight checks for Kubrnetes installers can be disabled, added to, bypassed, or customized using advanced options. For more information about kURL advanced options, see [Advanced Options](https://kurl.sh/docs/install-with-kurl/advanced-options) in the kURL documentation.
+
+To customize host preflight checks:
+
+1. Add host preflights to your Kubernetes installer specification (kind: Installer). You can get the installer YAML from [kurl.sh](https://kurl.sh/).
+
+  **Example:**
+
+  ```
+  apiVersion: "cluster.kurl.sh/v1beta1"
+  kind: "Installer"
+  metadata:
+    name: "latest"
+  spec:
+    kubernetes:
+      version: "1.23.x"
+    weave:
+      version: "2.6.x"
+    contour:
+      version: "1.21.x"
+    prometheus:
+      version: "0.57.x"
+    registry:
+      version: "2.7.x"
+    containerd:
+      version: "1.5.x"
+    ekco:
+      version: "latest"
+    minio:
+      version: "2022-06-11T19-55-32Z"
+    longhorn:
+      version: "1.2.x"
+    kurl:
+      airgap: true
+      proxyAddress: http://10.128.0.70:3128
+      additionalNoProxyAddresses:
+      - .corporate.internal
+      noProxy: false
+      licenseURL: https://somecompany.com/license-agreement.txt
+      nameserver: 8.8.8.8
+      skipSystemPackageInstall: false
+      excludeBuiltinHostPreflights: false
+      hostPreflightIgnore: false
+      hostPreflightEnforceWarnings: false
+      hostPreflights:
+        apiVersion: troubleshoot.sh/v1beta2
+        kind: HostPreflight
+        spec:
+          collectors:
+            - cpu: {}
+          analyzers:
+            - cpu:
+                checkName: Number of CPU check
+                outcomes:
+                  - warn:
+                      when: "count < 6"
+                      message: This server has less than 6 CPU cores
+                  - fail:
+                      when: "count < 4"
+                      message: This server has less than 4 CPU cores
+                  - pass:
+                      when: "count >= 6"
+                      message: This server has at least 6 CPU cores
+  ```
+
+1. Set `excludeBuiltinHostPreflights: true` to disable the default host preflights.
+
+    This allows three options:
+    - Exclude host preflights entirely
+    - Run custom host preflights in addition to the defaults
+    - Completely customize host preflights 
+
+1. (Optional) Set `hostPreflightIgnore: true` to ignore host preflight failures and warnings.
+
+1. (Optional) Set `hostPreflightEnforceWarnings: true` to block an installation by enforcing a warning.
+
+1. (Optional) Define custom collectors and analyzers.
+
+  ```
+  kurl:
+    airgap: true
+    proxyAddress: http://10.128.0.70:3128
+    additionalNoProxyAddresses:
+    - .corporate.internal
+    noProxy: false
+    licenseURL: https://somecompany.com/license-agreement.txt
+    nameserver: 8.8.8.8
+    skipSystemPackageInstall: false
+    excludeBuiltinHostPreflights: true
+    hostPreflightIgnore: true
+    hostPreflightEnforceWarnings: true
+    hostPreflights:
+      apiVersion: troubleshoot.sh/v1beta2
+      kind: HostPreflight
+      spec:
+        collectors:
+          - cpu: {}
+          - http:
+       collectorName: Can Access My Application
+               get:
+           Url: https://myApplication.com
+        analyzers:
+          - cpu:
+              checkName: Number of CPU check
+              outcomes:
+                - warn:
+                    when: "count < 6"
+                    message: This server has less than 6 CPU cores
+                - fail:
+                    when: "count < 4"
+                    message: This server has less than 4 CPU cores
+                - pass:
+                    when: "count >= 6"
+                    message: This server has at least 6 CPU cores
+      Http:
+      checkName: Can Access My Application
+      collectorName: Can Access My Application
+      ```
+
+## Defining Support Bundles
 
 You can create support bundles with the `support-bundle` plugin for the `kubectl` Kubernetes command-line tool.
 
@@ -52,7 +188,7 @@ For more information about creating support bundles, see
 [Support Bundle](https://troubleshoot.sh/docs/support-bundle/introduction/) in the
 Troubleshoot documentation.
 
-### Bundling and Analyzing Logs with Support bundle
+### Bundling and Analyzing Logs with Support Bundle
 
 A robust support bundle is essential to minimizing back-and-forth when things go wrong.
 At a very minimum, every app's support bundle should contain logs for an application's core pods.

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -212,7 +212,7 @@ To customize host preflight checks:
                   - warn:
                       when: "error"
                       message: Error connecting to https://myFavoriteWebsite.com
-                      - pass:
+                  - pass:
                       when: "statuscode == 200"
                       message: Connected to https://myFavoriteWebsite.com
       ```

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -105,9 +105,9 @@ To customize host preflight checks:
       version: "1.2.x"
     kurl:
       excludeBuiltinHostPreflights: true
-      ```
+  ```
 
-1. (Optional) To keep the default host preflight checks and add customized host preflights, you add a `hostPreflights` field to the `kurl` or add-on specification in the Installer manifest. Then add a host preflight specification (`kind: HostPreflight`) with your customizations. You only need to specify your customizations because the default host preflights will run automatically.
+1. (Optional) To keep the default host preflight checks and add customized host preflights, add a `hostPreflights` field to the `kurl` or add-on specification in the Installer manifest. Under the `hostPreflights` field, add a host preflight specification (`kind: HostPreflight`) with your customizations. You only need to specify your customizations because the default host preflights will run automatically.
 
   The following example shows customized `kurl` host preflight checks for:
 
@@ -172,8 +172,8 @@ To customize host preflight checks:
 
 1. (Optional) To completely customize your host preflight collectors and analyzers:
 
-    - Disable the default host preflight checks using `excludeBuiltinHostPreflights: true`
-    - Copy the default `host-preflights.yaml` specification for kURL or an add-on from GitHub to the Installer YAML in the vendor portal. Copying the default specifications lets you use the best practices provided by Replicated as a template to help ensure that your customizations run successfully.
+    1. Disable the default host preflight checks using `excludeBuiltinHostPreflights: true`
+    1. Copy the default `host-preflights.yaml` specification for kURL or an add-on from GitHub to the Installer YAML in the vendor portal. Copying the default specifications lets you use the best practices provided by Replicated as a template to help ensure that your customizations run successfully.
 
       For the default kURL host preflights YAML, see [host-preflights.yaml](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL repository.
 
@@ -198,9 +198,9 @@ To customize host preflight checks:
 
     The following example shows:
 
-    - The default host preflights checks are disabled
-    - The installation will be blocked if there is a warning
+    - Default host preflights checks are disabled
     - Customized host preflight checks will run
+    - The installation will be blocked if there is a warning
 
     ```yaml
     apiVersion: "cluster.kurl.sh/v1beta1"

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -84,7 +84,7 @@ To customize host preflight checks:
         <td>Disables the default host preflights for Kubernetes and any included add-ons</td>
       </tr>
       <tr>
-        <td><code>`hostPreflightIgnore: true`</code></td>
+        <td><code>hostPreflightIgnore: true</code></td>
         <td>Ignores host preflight failures and warnings</td>
       </tr>
       <tr>

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -53,7 +53,7 @@ Host preflight checks can also vary, depending on whether the installation is ne
 
 ### Customize Host Preflight Checks
 
-Default host preflight checks for Kubernetes installers can be disabled, added to, bypassed, or customized using advanced options. For more information about kURL advanced options, see [Advanced Options](https://kurl.sh/docs/install-with-kurl/advanced-options) in the kURL documentation.
+Default host preflight checks for Kubernetes installers can be disabled, added to, bypassed, or completely customized using advanced options. For more information about kURL advanced options, see [Advanced Options](https://kurl.sh/docs/install-with-kurl/advanced-options) in the kURL documentation.
 
 To customize host preflight checks:
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -50,12 +50,12 @@ Default host preflight checks verify conditions such as operating system and dis
 
 Host preflight checks run automatically. Default checks can vary, depending on whether the installation is new, an upgrade, joining a node, or an air gap installation. Additionally, some checks only run when certain add-ons are enabled or configured a certain way in the installer. For a complete list of default host preflight checks, see [Default Host Preflights](https://kurl.sh/docs/install-with-kurl/host-preflights#default-host-preflights) in the kURL documentation.
 
-Host preflight checks can be partially or completely customized. For more information about customizing kURL host preflights, see [Customizing Host Preflights](https://kurl.sh/docs/create-installer/host-preflights/) in the kURL documentation.
+There are general kURL host preflight checks that run with all installers. There are also host preflight checks included with certain add-ons. You can partially or completely customize any of these host preflights. For more information about customizing host preflights, see [Customize Host Preflight Checks](#customize-host-preflight-checks).
 
 
 ## Customize Host Preflight Checks
 
-The default host preflights run automatically as part of your Kubernetes installer. There are general kURL host preflight checks that run with all installers. There are also host preflight checks included with certain add-ons. You can customize any of these host preflights if needed. Customizations include the ability to:
+The default host preflights run automatically as part of your Kubernetes installer. Customizations include the ability to:
 
 - Bypass failures
 - Block an installation for warnings

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -101,7 +101,6 @@ To include host preflight checks:
     longhorn:
       version: "1.2.x"
     kurl:
-      skipSystemPackageInstall: false
       excludeBuiltinHostPreflights: false
       hostPreflightIgnore: false
       hostPreflightEnforceWarnings: false
@@ -183,7 +182,6 @@ To include host preflight checks:
     longhorn:
       version: "1.2.x"
     kurl:
-      skipSystemPackageInstall: false
       excludeBuiltinHostPreflights: true
       hostPreflightIgnore: false
       hostPreflightEnforceWarnings: true

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -44,7 +44,7 @@ You can include host preflight checks with Kubernetes installers to verify that 
 
 This helps to ensure successful installation and the ongoing health of the cluster. You can codify some of your application requirements as part of the host preflight checks so that users get feedback even earlier in the installation process.
 
-Default host preflight checks verify conditions such as operating system and disk usage. Default host preflight failures block the installation from continuing and exit with a non-zero return code. Users can then update their environment and re-run the host preflight checks.
+Default host preflight checks verify conditions such as operating system and disk usage. Default host preflight failures block the installation from continuing and exit with a non-zero return code. Users can then update their environment and run the Kubernetes installer again to re-run the host preflight checks.
 
 Host preflight checks run automatically. Default checks can vary, depending on whether the installation is new, an upgrade, a joining node, or an air gap installation. Additionally, some checks only run when certain add-ons are enabled or configured a certain way in the installer. For a complete list of default host preflight checks, see [Default Host Preflights](https://kurl.sh/docs/install-with-kurl/host-preflights#default-host-preflights) in the kURL documentation.
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -109,7 +109,7 @@ To customize host preflight checks:
 
 1. (Optional) To keep the default host preflight checks and add customized host preflights, you add a `hostPreflights` field to the `kurl` or add-on specification in the Installer manifest. Then add a host preflight specification (`kind: HostPreflight`) with your customizations. You only need to specify your customizations because the default host preflights will run automatically.
 
-  The following example shows customize host preflight checks for:
+  The following example shows customized `kurl` host preflight checks for:
 
     - An application that requires more CPUs than the default
     - Accessing a website that is critical to the application
@@ -170,11 +170,14 @@ To customize host preflight checks:
                       message: Connected to https://myFavoriteWebsite.com
   ```
 
-1. (Optional) To completely customize your host preflight collectors and analyzers, copy the default `host-preflights.yaml` specification for kURL or an add-on from GitHub to the Installer YAML in the vendor portal. Copying the default specifications lets you use the best practices provided by Replicated as a template to help ensure that your customizations run successfully.
+1. (Optional) To completely customize your host preflight collectors and analyzers:
 
-  For the default kURL host preflights YAML, see [host-preflights.yaml](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL repository.
+    - Disable the default host preflight checks using `excludeBuiltinHostPreflights: true`
+    - Copy the default `host-preflights.yaml` specification for kURL or an add-on from GitHub to the Installer YAML in the vendor portal. Copying the default specifications lets you use the best practices provided by Replicated as a template to help ensure that your customizations run successfully.
 
-  For links to the add-on YAML files, see [Finding the Add-on Host Preflight Checks](https://kurl.sh/docs/create-installer/host-preflights/#finding-the-add-on-host-preflight-checks) in the kURL documentation.
+      For the default kURL host preflights YAML, see [host-preflights.yaml](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL repository.
+
+      For links to the add-on YAML files, see [Finding the Add-on Host Preflight Checks](https://kurl.sh/docs/create-installer/host-preflights/#finding-the-add-on-host-preflight-checks) in the kURL documentation.
 
 1. (Optional) Set either of the following flags to customize the outcome of your host preflight checks:
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -93,7 +93,7 @@ To customize host preflight checks:
       </tr>
     </table>
 
-1. (Optional) Add a `hostPreflights` specification to the Installer YAML file to define custom collectors and analyzers. The following example for the customized kURL specification shows:
+1. (Optional) Add a host preflight specification (`kind: HostPreflight`) to the Installer YAML file to define custom collectors and analyzers. The following example for the customized kURL specification shows:
 
     - Default host preflight checks are disabled
     - Preflight failures and warnings will block the installation

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -137,9 +137,12 @@ To customize host preflight checks:
 
 1. (Optional) Add a `hostPreflights` specification to the Installer YAML file to define custom collectors and analyzers.
 
-  The following example shows custom host preflight checks and outcomes for:
-    - CPUs for an application that requires more CPUs than the default
-    - Accessing a website that is critical to the business
+  The following example shows:
+    - Default host preflight checks are disabled
+    - Preflight failures and warnings will be enforced
+    - Installation will be blocked for warnings
+    - Customized checks for an application that requires more CPUs than the default
+    - Customized checks for accessing a website that is critical to the business
 
   ```
   apiVersion: "cluster.kurl.sh/v1beta1"
@@ -177,7 +180,7 @@ To customize host preflight checks:
       nameserver: 8.8.8.8
       skipSystemPackageInstall: false
       excludeBuiltinHostPreflights: true
-      hostPreflightIgnore: true
+      hostPreflightIgnore: false
       hostPreflightEnforceWarnings: true
       hostPreflights:
         apiVersion: troubleshoot.sh/v1beta2

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -48,7 +48,7 @@ While host preflights are intended to ensure requirements are met for running th
 
 Default host preflight checks verify conditions such as operating system and disk usage. Default host preflight failures block the installation from continuing and exit with a non-zero return code. Users can then update their environment and run the Kubernetes installer again to re-run the host preflight checks.
 
-Host preflight checks run automatically. Default checks can vary, depending on whether the installation is new, an upgrade, joining a node, or an air gap installation. Additionally, some checks only run when certain add-ons are enabled or configured a certain way in the installer. For a complete list of default host preflight checks, see [Default Host Preflights](https://kurl.sh/docs/install-with-kurl/host-preflights#default-host-preflights) in the kURL documentation.
+Host preflight checks run automatically. The default host preflight checks that run can vary, depending on whether the installation is new, an upgrade, joining a node, or an air gap installation. Additionally, some checks only run when certain add-ons are enabled or configured a certain way in the installer. For a complete list of default host preflight checks, see [Default Host Preflights](https://kurl.sh/docs/install-with-kurl/host-preflights#default-host-preflights) in the kURL documentation.
 
 There are general kURL host preflight checks that run with all installers. There are also host preflight checks included with certain add-ons. You can partially or completely customize any of these host preflights. For more information about customizing host preflights, see [Customize Host Preflight Checks](#customize-host-preflight-checks).
 
@@ -64,9 +64,9 @@ The default host preflights run automatically as part of your Kubernetes install
 
 To customize host preflight checks:
 
-1. Get the Kubernetes installer YAML (kind: "Installer") and add-ons from the landing page at [kurl.sh](https://kurl.sh/). To use Replicated app manager, you must include the KOTS add-on.
+1. Create a Kubernetes installer. For more information, see [Creating a Kubernetes Installer](https://docs.replicated.com/vendor/packaging-embedded-kubernetes).
 
-1. Copy the default kURL `host-preflights.yaml` specification or the add-on specification that you want to customize to the installer YAML. Copying the default specifications lets you leverage the best practices provided by Replicated and just customize the parts that you need to.
+1. From the kurl.sh site, copy the default `host-preflights.yaml` specification for kURL or an add-on to the Installer YAML in the vendor portal. Copying the default specifications lets you use the best practices provided by Replicated and customize the parts that you need to.
 
   For the default kURL host preflights YAML, see [host-preflights.yaml](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL repository.
 
@@ -80,15 +80,15 @@ To customize host preflight checks:
         <th width="70%">Description</th>
       </tr>
       <tr>
-        <td>`excludeBuiltinHostPreflights: true`</td>
+        <td><code>`excludeBuiltinHostPreflights: true`</code></td>
         <td>Disables the default host preflights for Kubernetes and any included add-ons</td>
       </tr>
       <tr>
-        <td>`hostPreflightIgnore: true`</td>
+        <td><code>`hostPreflightIgnore: true`</code></td>
         <td>Ignores host preflight failures and warnings</td>
       </tr>
       <tr>
-        <td>`hostPreflightEnforceWarnings: true`</td>
+        <td><code>`hostPreflightEnforceWarnings: true`</code></td>
         <td>Blocks an installation if the results include a warning</td>
       </tr>
     </table>
@@ -100,7 +100,7 @@ To customize host preflight checks:
     - Customized checks for an application that requires more CPUs than the default
     - Customized checks for accessing a website that is critical to the application
 
-    ```
+    ```yaml
     apiVersion: "cluster.kurl.sh/v1beta1"
     kind: "Installer"
     metadata:
@@ -161,7 +161,7 @@ To customize host preflight checks:
                     - pass:
                         when: "statuscode == 200"
                         message: Connected to https://myFavoriteWebsite.com
-        ```
+    ```
 
 1. Promote and test your installer in a development environment before sharing it with customers.
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -66,7 +66,7 @@ To include host preflight checks:
 
 1. Get the Kubernetes installer YAML (kind: "Installer") and add-ons from the landing page at [kurl.sh](https://kurl.sh/). To use Replicated app manager, you must include the KOTS add-on.
 
-1. Add the default `host-preflights.yaml` specification for each add-on to the installer YAML. You must add the appropriate version for each add-on. For the links to the YAML files for each add-on, see [Finding the Add-on Host Preflight Checks](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL documentation.
+1. Add the default `host-preflights.yaml` specification for each add-on to the installer YAML. You must add the appropriate version for each add-on. For the links to the add=on YAML files, see [Finding the Add-on Host Preflight Checks](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL documentation.
 
 1. Add the default kURL host preflights YAML to the installer YAML. See [host-preflights.yaml](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL repository.
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -32,7 +32,7 @@ You then add the `preflight.yaml` manifest file to the application that you are 
 For more information about installing the `preflight` plugin,
 see [Getting Started](https://troubleshoot.sh/docs/) in the Troubleshoot documentation.
 
-For more information about creating preflight checks, see
+For more information about defining preflight checks, see
 [Preflight Checks](https://troubleshoot.sh/docs/preflight/introduction/) in the
 Troubleshoot documentation. There are also a number of basic examples for checking CPU, memory, and disk capacity under [Node Resources Analyzer](https://troubleshoot.sh/reference/analyzers/node-resources/).
 
@@ -194,7 +194,7 @@ You then add the `support-bundle.yaml` manifest file to the application that you
 For more information about installing `support-bundle` plugin,
 see [Getting Started](https://troubleshoot.sh/docs/) in the Troubleshoot documentation.
 
-For more information about creating support bundles, see
+For more information about defining support bundles, see
 [Support Bundle](https://troubleshoot.sh/docs/support-bundle/introduction/) in the
 Troubleshoot documentation.
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -150,10 +150,9 @@ To include host preflight checks:
 
   The following example shows:
     - Default host preflight checks are disabled
-    - Preflight failures and warnings will be enforced
-    - Installation will be blocked for warnings
+    - Preflight failures and warnings will block the installation
     - Customized checks for an application that requires more CPUs than the default
-    - Customized checks for accessing a website that is critical to the business
+    - Customized checks for accessing a website that is critical to the application
 
   ```
   apiVersion: "cluster.kurl.sh/v1beta1"

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -62,7 +62,7 @@ You can customize host preflight checks to:
 - Exclude certain preflights under specific conditions, such as when a particular license entitlement is enabled
 - Skip the default host preflight checks and run only custom checks
 
-For more information about kURL host preflight advanced options, see [Install With Kurl - Advanced Options](https://kurl.sh/docs/install-with-kurl/advanced-options) in the kURL documentation.
+For more information about customizing kURL host preflights, see [Customizing Host Preflights](https://kurl.sh/docs/create-installer/host-preflights/) in the kURL documentation.
 
 To customize host preflight checks:
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -42,7 +42,9 @@ You can include host preflight checks with Kubernetes installers to verify that 
 - kURL add-ons
 - Your application
 
-This helps to ensure successful installation and the ongoing health of the cluster. You can codify some of your application requirements as part of the host preflight checks so that users get feedback even earlier in the installation process.
+This helps to ensure successful installation and the ongoing health of the cluster.
+
+While host preflights are intended to ensure requirements are met for running the cluster, you can also use them to codify some of your application requirements so that users get feedback even earlier in the installation process, rather than waiting to run preflights after the cluster is already installed.
 
 Default host preflight checks verify conditions such as operating system and disk usage. Default host preflight failures block the installation from continuing and exit with a non-zero return code. Users can then update their environment and run the Kubernetes installer again to re-run the host preflight checks.
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -66,7 +66,7 @@ To customize host preflight checks:
 
 1. Create a Kubernetes installer. For more information, see [Creating a Kubernetes Installer](https://docs.replicated.com/vendor/packaging-embedded-kubernetes).
 
-1. From the kurl.sh site, copy the default `host-preflights.yaml` specification for kURL or an add-on to the Installer YAML in the vendor portal. Copying the default specifications lets you use the best practices provided by Replicated and customize the parts that you need to.
+1. Copy the default `host-preflights.yaml` specification for kURL or an add-on from GitHub to the Installer YAML in the vendor portal. Copying the default specifications lets you use the best practices provided by Replicated and customize the parts that you need to.
 
   For the default kURL host preflights YAML, see [host-preflights.yaml](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL repository.
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -50,29 +50,133 @@ Default host preflight checks verify conditions such as operating system and dis
 
 Host preflight checks run automatically. The default host preflight checks that run can vary, depending on whether the installation is new, an upgrade, joining a node, or an air gap installation. Additionally, some checks only run when certain add-ons are enabled or configured a certain way in the installer. For a complete list of default host preflight checks, see [Default Host Preflights](https://kurl.sh/docs/install-with-kurl/host-preflights#default-host-preflights) in the kURL documentation.
 
-There are general kURL host preflight checks that run with all installers. There are also host preflight checks included with certain add-ons. You can partially or completely customize any of these host preflights. For more information about customizing host preflights, see [Customize Host Preflight Checks](#customize-host-preflight-checks).
+There are general kURL host preflight checks that run with all installers. There are also host preflight checks included with certain add-ons. Customizations include the ability to:
+
+  - Bypass failures
+  - Block an installation for warnings
+  - Exclude certain preflights under specific conditions, such as when a particular license entitlement is enabled
+  - Skip the default host preflight checks and run only custom checks
+  - Add custom checks to the default host preflight checks
+
+For more information about customizing host preflights, see [Customize Host Preflight Checks](#customize-host-preflight-checks).
 
 
 ## Customize Host Preflight Checks
 
-The default host preflights run automatically as part of your Kubernetes installer. Customizations include the ability to:
+The default host preflights run automatically as part of your Kubernetes installer. You can customize the host preflight checks by disabling them entirely, adding customizations to the default checks to make them more restrictive, or completely customizing them. You can also customize the outcomes to enforce warnings or ignore failures.
 
-- Bypass failures
-- Block an installation for warnings
-- Exclude certain preflights under specific conditions, such as when a particular license entitlement is enabled
-- Skip the default host preflight checks and run only custom checks
+This procedure gives examples of the customization options.
 
 To customize host preflight checks:
 
-1. Create a Kubernetes installer. For more information, see [Creating a Kubernetes Installer](https://docs.replicated.com/vendor/packaging-embedded-kubernetes).
+1. Create a Kubernetes installer (`kind: Installer`). For more information, see [Creating a Kubernetes Installer](https://docs.replicated.com/vendor/packaging-embedded-kubernetes).
 
-1. Copy the default `host-preflights.yaml` specification for kURL or an add-on from GitHub to the Installer YAML in the vendor portal. Copying the default specifications lets you use the best practices provided by Replicated and customize the parts that you need to.
+1. (Optional) To disable the default host preflight checks for Kubernetes and any add-ons, add the `kurl` field to your Installer manifest and add the `excludeBuiltinHostPreflights` set to `true`.
+
+  This is an aggregate flag, so setting it in one specification disables default host preflights in all of the specifications.
+
+  **Example:**
+
+  ```yaml
+  apiVersion: "cluster.kurl.sh/v1beta1"
+  kind: "Installer"
+  metadata:
+    name: "latest"
+  spec:
+    kubernetes:
+      version: "1.23.x"
+    weave:
+      version: "2.6.x"
+    contour:
+      version: "1.21.x"
+    prometheus:
+      version: "0.57.x"
+    registry:
+      version: "2.7.x"
+    containerd:
+      version: "1.5.x"
+    kotsadm:
+        version: "latest"
+    ekco:
+      version: "latest"
+    minio:
+      version: "2022-06-11T19-55-32Z"
+    longhorn:
+      version: "1.2.x"
+    kurl:
+      excludeBuiltinHostPreflights: true
+      ```
+
+1. (Optional) To keep the default host preflight checks and add customized host preflights, you add a `hostPreflights` field to the `kurl` or add-on specification in the Installer manifest. Then add a host preflight specification (`kind: HostPreflight`) with your customizations. You only need to specify your customizations because the default host preflights will run automatically.
+
+  The following example shows customize host preflight checks for:
+
+    - An application that requires more CPUs than the default
+    - Accessing a website that is critical to the application
+
+  ```yaml
+    kubernetes:
+      version: "1.23.x"
+    weave:
+      version: "2.6.x"
+    contour:
+      version: "1.21.x"
+    prometheus:
+      version: "0.57.x"
+    registry:
+      version: "2.7.x"
+    containerd:
+      version: "1.5.x"
+    kotsadm:
+        version: "latest"
+    ekco:
+      version: "latest"
+    minio:
+      version: "2022-06-11T19-55-32Z"
+    longhorn:
+      version: "1.2.x"
+    kurl:
+      hostPreflights:
+        apiVersion: troubleshoot.sh/v1beta2
+        kind: HostPreflight
+        spec:
+          collectors:
+            - cpu: {}
+            - http:
+                collectorName: Can Access A Website
+                get:
+                 Url: https://myFavoriteWebsite.com
+          analyzers:
+            - cpu:
+                checkName: Number of CPU check
+                outcomes:
+                  - fail:
+                      when: "count < 4"
+                      message: This server has less than 4 CPU cores
+                  - warn:
+                      when: "count < 6"
+                      message: This server has less than 6 CPU cores
+                  - pass:
+                      message: This server has at least 6 CPU cores
+            - http:
+                checkName: Can Access A Website
+                collectorName: Can Access A Website
+                outcomes:
+                  - warn:
+                      when: "error"
+                      message: Error connecting to https://myFavoriteWebsite.com
+                  - pass:
+                      when: "statuscode == 200"
+                      message: Connected to https://myFavoriteWebsite.com
+  ```
+
+1. (Optional) To completely customize your host preflight collectors and analyzers, copy the default `host-preflights.yaml` specification for kURL or an add-on from GitHub to the Installer YAML in the vendor portal. Copying the default specifications lets you use the best practices provided by Replicated as a template to help ensure that your customizations run successfully.
 
   For the default kURL host preflights YAML, see [host-preflights.yaml](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL repository.
 
   For links to the add-on YAML files, see [Finding the Add-on Host Preflight Checks](https://kurl.sh/docs/create-installer/host-preflights/#finding-the-add-on-host-preflight-checks) in the kURL documentation.
 
-1. (Optional) Set any of the following flags to customize host preflights:
+1. (Optional) Set either of the following flags to customize the outcome of your host preflight checks:
 
     <table>
       <tr>
@@ -80,25 +184,20 @@ To customize host preflight checks:
         <th width="70%">Description</th>
       </tr>
       <tr>
-        <td><code>excludeBuiltinHostPreflights: true</code></td>
-        <td>Disables the default host preflights for Kubernetes and any included add-ons</td>
-      </tr>
-      <tr>
         <td><code>hostPreflightIgnore: true</code></td>
-        <td>Ignores host preflight failures and warnings</td>
+        <td>Ignores host preflight failures and warnings. The installation will proceed.</td>
       </tr>
       <tr>
         <td><code>hostPreflightEnforceWarnings: true</code></td>
-        <td>Blocks an installation if the results include a warning</td>
+        <td>Blocks an installation if the results include a warning.</td>
       </tr>
     </table>
 
-1. (Optional) Add a host preflight specification (`kind: HostPreflight`) to the Installer YAML file to define custom collectors and analyzers. The following example for the customized kURL specification shows:
+    The following example shows:
 
-    - Default host preflight checks are disabled
-    - Preflight failures and warnings will block the installation
-    - Customized checks for an application that requires more CPUs than the default
-    - Customized checks for accessing a website that is critical to the application
+    - The default host preflights checks are disabled
+    - The installation will be blocked if there is a warning
+    - Customized host preflight checks will run
 
     ```yaml
     apiVersion: "cluster.kurl.sh/v1beta1"

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -88,7 +88,7 @@ To customize host preflight checks:
         <td>Ignores host preflight failures and warnings</td>
       </tr>
       <tr>
-        <td><code>`hostPreflightEnforceWarnings: true`</code></td>
+        <td><code>hostPreflightEnforceWarnings: true</code></td>
         <td>Blocks an installation if the results include a warning</td>
       </tr>
     </table>

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -66,7 +66,7 @@ To customize host preflight checks:
 
 1. Get the Kubernetes installer YAML (kind: "Installer") and add-ons from the landing page at [kurl.sh](https://kurl.sh/). To use Replicated app manager, you must include the KOTS add-on.
 
-1. Copy the default `host-preflights.yaml` specification to the installer YAML for kURL or any add-on that you want to customize. This lets you leverage the Replicated best practices supplied in the add-on code and just customize the parts that you need to.
+1. Copy the default kURL `host-preflights.yaml` specification or the add-on specification that you want to customize to the installer YAML. Copying the default specifications lets you leverage the best practices supplied by Replicated and just customize the parts that you need to.
 
   For the default kURL host preflights YAML, see [host-preflights.yaml](https://github.com/replicatedhq/kURL/blob/main/pkg/preflight/assets/host-preflights.yaml) in the kURL repository.
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -48,7 +48,7 @@ While host preflights are intended to ensure requirements are met for running th
 
 Default host preflight checks verify conditions such as operating system and disk usage. Default host preflight failures block the installation from continuing and exit with a non-zero return code. Users can then update their environment and run the Kubernetes installer again to re-run the host preflight checks.
 
-Host preflight checks run automatically. Default checks can vary, depending on whether the installation is new, an upgrade, a joining node, or an air gap installation. Additionally, some checks only run when certain add-ons are enabled or configured a certain way in the installer. For a complete list of default host preflight checks, see [Default Host Preflights](https://kurl.sh/docs/install-with-kurl/host-preflights#default-host-preflights) in the kURL documentation.
+Host preflight checks run automatically. Default checks can vary, depending on whether the installation is new, an upgrade, joining a node, or an air gap installation. Additionally, some checks only run when certain add-ons are enabled or configured a certain way in the installer. For a complete list of default host preflight checks, see [Default Host Preflights](https://kurl.sh/docs/install-with-kurl/host-preflights#default-host-preflights) in the kURL documentation.
 
 Host preflight checks can be customized. For more information, see [Customize Host Preflight Checks](#customize-host-prefligt-checks).
 

--- a/docs/vendor/tutorial-installing-air-gap-existing-cluster-gcp.md
+++ b/docs/vendor/tutorial-installing-air-gap-existing-cluster-gcp.md
@@ -467,7 +467,7 @@ To connect to the app manager:
 
 1. Open `localhost:${PORT}` in your browser to access the Replicated admin console. Proceed with the installation from the the admin console.
 
-  Vendors can optionally configure `strict` preflight checks that cause the application deployment to fail if specific requirements are not met. For more information about preflight checks, see [Creating Preflight Checks and Support Bundles](preflight-support-bundle-creating).
+  Vendors can optionally configure `strict` preflight checks that cause the application deployment to fail if specific requirements are not met. For more information about preflight checks, see [Defining Preflight Checks and Support Bundles](preflight-support-bundle-creating).
 
   Additionally, when installing with minimal role-based access control (RBAC), preflight checks can fail due to insufficient privileges.
 

--- a/docs/vendor/tutorial-installing-air-gap-existing-cluster-gcp.md
+++ b/docs/vendor/tutorial-installing-air-gap-existing-cluster-gcp.md
@@ -467,7 +467,7 @@ To connect to the app manager:
 
 1. Open `localhost:${PORT}` in your browser to access the Replicated admin console. Proceed with the installation from the the admin console.
 
-  Vendors can optionally configure `strict` preflight checks that cause the application deployment to fail if specific requirements are not met. For more information about preflight checks, see [Defining Preflight Checks and Support Bundles](preflight-support-bundle-creating).
+  Vendors can optionally configure strict preflight checks that cause the application deployment to fail if specific requirements are not met. For more information about preflight checks, see [Defining Preflight Checks and Support Bundles](preflight-support-bundle-creating).
 
   Additionally, when installing with minimal role-based access control (RBAC), preflight checks can fail due to insufficient privileges.
 

--- a/docs/vendor/tutorial-installing-air-gap.md
+++ b/docs/vendor/tutorial-installing-air-gap.md
@@ -149,7 +149,7 @@ To upload the bundle and license:
 
   After the bundle is uploaded, the preflight checks begin. After all of the checks pass, the application is automatically deployed.
 
-  Vendors can optionally configure `strict` preflight checks that cause the application deployment to fail if specific requirements are not met. For more information about preflight checks, see [Creating Preflight Checks and Support Bundles](preflight-support-bundle-creating).
+  Vendors can optionally configure `strict` preflight checks that cause the application deployment to fail if specific requirements are not met. For more information about preflight checks, see [Defining Preflight Checks and Support Bundles](preflight-support-bundle-creating).
 
   Additionally, when installing with minimal role-based access control (RBAC), the preflight checks can fail due to insufficient privileges.
 

--- a/docs/vendor/tutorial-installing-with-cli.md
+++ b/docs/vendor/tutorial-installing-with-cli.md
@@ -417,7 +417,7 @@ To install the application:
 
 1. Click **Continue**. If there are failing checks, dismiss the warning to continue. Preflight checks are designed to help ensure this server has the minimum system and software requirements to run the application. Depending on your YAML configuration in `preflight.yaml`, you can see some of the example preflight checks fail.
 
-    Vendors can optionally configure `strict` preflight checks that cause the application deployment to fail if specific requirements are not met. For more information about preflight checks, see [Defining Preflight Checks and Support Bundles](preflight-support-bundle-creating).
+    Vendors can optionally configure strict preflight checks that cause the application deployment to fail if specific requirements are not met. For more information about preflight checks, see [Defining Preflight Checks and Support Bundles](preflight-support-bundle-creating).
 
     Additionally, when installing with minimal role-based access control (RBAC), the preflight checks can fail due to insufficient privileges.
 

--- a/docs/vendor/tutorial-installing-with-cli.md
+++ b/docs/vendor/tutorial-installing-with-cli.md
@@ -417,7 +417,7 @@ To install the application:
 
 1. Click **Continue**. If there are failing checks, dismiss the warning to continue. Preflight checks are designed to help ensure this server has the minimum system and software requirements to run the application. Depending on your YAML configuration in `preflight.yaml`, you can see some of the example preflight checks fail.
 
-    Vendors can optionally configure `strict` preflight checks that cause the application deployment to fail if specific requirements are not met. For more information about preflight checks, see [Creating Preflight Checks and Support Bundles](preflight-support-bundle-creating).
+    Vendors can optionally configure `strict` preflight checks that cause the application deployment to fail if specific requirements are not met. For more information about preflight checks, see [Defining Preflight Checks and Support Bundles](preflight-support-bundle-creating).
 
     Additionally, when installing with minimal role-based access control (RBAC), the preflight checks can fail due to insufficient privileges.
 

--- a/docs/vendor/tutorial-installing-with-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-with-existing-cluster.md
@@ -178,7 +178,7 @@ To install the application:
 
 1. Click **Continue** and ignore the warnings. Preflight checks are designed to ensure this server has the minimum system and software requirements to run the application. By default, we included some preflight checks that are expected to fail so that you can see what failing checks might look like for a customer.
 
-    Vendors can optionally configure `strict` preflight checks that cause the application deployment to fail if specific requirements are not met. For more information about preflight checks, see [Creating Preflight Checks and Support Bundles](preflight-support-bundle-creating).
+    Vendors can optionally configure `strict` preflight checks that cause the application deployment to fail if specific requirements are not met. For more information about preflight checks, see [Defining Preflight Checks and Support Bundles](preflight-support-bundle-creating).
 
     Additionally, when installing with minimal role-based access control (RBAC), the preflight checks can fail due to insufficient privileges.
 

--- a/docs/vendor/tutorial-installing-with-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-with-existing-cluster.md
@@ -178,7 +178,7 @@ To install the application:
 
 1. Click **Continue** and ignore the warnings. Preflight checks are designed to ensure this server has the minimum system and software requirements to run the application. By default, we included some preflight checks that are expected to fail so that you can see what failing checks might look like for a customer.
 
-    Vendors can optionally configure `strict` preflight checks that cause the application deployment to fail if specific requirements are not met. For more information about preflight checks, see [Defining Preflight Checks and Support Bundles](preflight-support-bundle-creating).
+    Vendors can optionally configure strict preflight checks that cause the application deployment to fail if specific requirements are not met. For more information about preflight checks, see [Defining Preflight Checks and Support Bundles](preflight-support-bundle-creating).
 
     Additionally, when installing with minimal role-based access control (RBAC), the preflight checks can fail due to insufficient privileges.
 

--- a/docs/vendor/tutorial-installing-without-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-without-existing-cluster.md
@@ -214,7 +214,7 @@ To install the application:
 
 1. Click **Continue**. If you have failing checks, dismiss the warning to continue. Preflight checks are designed to help ensure that this server has the minimum system and software requirements to run the application. Depending on your YAML configuration in the `preflight.yaml` file, you can see some of the example preflight checks fail.
 
-  Vendors can optionally configure `strict` preflight checks that cause the application deployment to fail if specific requirements are not met. For more information about preflight checks, see [Creating Preflight Checks and Support Bundles](preflight-support-bundle-creating).
+  Vendors can optionally configure `strict` preflight checks that cause the application deployment to fail if specific requirements are not met. For more information about preflight checks, see [Defining Preflight Checks and Support Bundles](preflight-support-bundle-creating).
 
   Additionally, when installing with minimal role-based access control (RBAC), the app manager recognizes if the preflight checks have failed due to insufficient privileges.
 

--- a/docs/vendor/tutorial-installing-without-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-without-existing-cluster.md
@@ -214,7 +214,7 @@ To install the application:
 
 1. Click **Continue**. If you have failing checks, dismiss the warning to continue. Preflight checks are designed to help ensure that this server has the minimum system and software requirements to run the application. Depending on your YAML configuration in the `preflight.yaml` file, you can see some of the example preflight checks fail.
 
-  Vendors can optionally configure `strict` preflight checks that cause the application deployment to fail if specific requirements are not met. For more information about preflight checks, see [Defining Preflight Checks and Support Bundles](preflight-support-bundle-creating).
+  Vendors can optionally configure strict preflight checks that cause the application deployment to fail if specific requirements are not met. For more information about preflight checks, see [Defining Preflight Checks and Support Bundles](preflight-support-bundle-creating).
 
   Additionally, when installing with minimal role-based access control (RBAC), the app manager recognizes if the preflight checks have failed due to insufficient privileges.
 


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/41574/content-gap-make-it-easy-for-vendors-to-understand-host-preflights-and-how-to-customize-them-as-part-of-kubernetes-installer

Previews: 

- https://deploy-preview-428--replicated-docs.netlify.app/vendor/preflight-support-bundle-creating#about-host-preflight-checks-for-kubernetes-installers
- https://deploy-preview-428--replicated-docs.netlify.app/vendor/distributing-workflow#iterating-your-releases
- https://deploy-preview-428--replicated-docs.netlify.app/vendor/packaging-rbac#strict-preflight-checks
- https://deploy-preview-428--replicated-docs.netlify.app/vendor/tutorial-installing-without-existing-cluster#install-the-application
- https://deploy-preview-428--replicated-docs.netlify.app/vendor/tutorial-installing-with-existing-cluster#install-the-application
- https://deploy-preview-428--replicated-docs.netlify.app/vendor/tutorial-installing-with-cli#install-the-application
- https://deploy-preview-428--replicated-docs.netlify.app/vendor/tutorial-installing-air-gap-existing-cluster-gcp#connect-to-the-app-manager
- https://deploy-preview-428--replicated-docs.netlify.app/vendor/tutorial-installing-air-gap#upload-the-air-gap-bundle-and-license