### PR TITLE
51930: Added Admin Console Install steps to Air Gap Install Section

### DIFF
--- a/docs/enterprise/installing-embedded-cluster.md
+++ b/docs/enterprise/installing-embedded-cluster.md
@@ -53,6 +53,23 @@ To install the admin console and an application in an air gapped environment:
     You can construct the URL for the air gap bundle by prefixing the URL path for online installations with `/bundle` and adding `.tar.gz` to the end. For more information, see [Install in an Online Environment](#install-in-an-online-environment).
     :::
 
+  1. Install the application with the application `.airgap` bundle:
+
+    ```
+      kubectl kots install APP_NAME \
+      --airgap-bundle PATH_TO_AIRGAP_BUNDLE \
+      --license-file PATH_TO_LICENSE_FILE \
+        --config-values PATH_TO_CONFIG_VALUES \
+        --namespace default \
+        --shared-password PASSWORD
+    ```
+    Replace:
+      * `APP_NAME` with the name for the application.
+      * `PATH_TO_AIRGAP_BUNDLE` with the path to the `.airgap` bundle file.
+      * `PATH_TO_LICENSE_FILE` with the path to the license file.
+      * `PATH_TO_CONFIG_VALUES` with the path to the ConfigValues manifest file.
+      * `PASSWORD` with a shared password.
+
     For more information about the `kots install` command, see [install](../reference/kots-cli-install) in the kots CLI documentation.
 
 ## Installing with High Availability Mode


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/51930/embedded-cluster-install-procedure-missing-kots-install-command-for-air-gap

Preview: https://deploy-preview-444--replicated-docs.netlify.app/enterprise/installing-embedded-cluster#install-in-air-gapped-environments