### PR TITLE
Adds link to Security at Replicated webpage in Policies section

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -474,6 +474,11 @@ const sidebars = {
         'vendor/policies-vulnerability-patch',
         'vendor/policies-support-lifecycle',
         'vendor/policies-data-transmission',
+        {
+          type: 'link',
+          label: 'Security at Replicated',
+          href: 'https://www.replicated.com/security/'
+        },
       ],
     },
     {


### PR DESCRIPTION
Adds an external link to the Security at Replicated page on the marketing site in the Policies section of the docs site. 