### PR TITLE
pre-filled issue title and body when providing feedback

### DIFF
--- a/src/theme/EditThisPage/index.js
+++ b/src/theme/EditThisPage/index.js
@@ -12,6 +12,9 @@ import PullRequestIcon from "../../../static/images/git-pull-request.svg";
 import styles from "./styles.module.css";
 
 export default function EditThisPage({ editUrl }) {
+  const url = window.location.href;
+  const issueTitle = url.substring(url.lastIndexOf("/") + 1);
+
   return (
     <div className={styles.githubLinksWrapper}>
       <a
@@ -32,7 +35,7 @@ export default function EditThisPage({ editUrl }) {
         </div>
       </a>
       <a
-        href={"https://github.com/replicatedhq/replicated-docs/issues/new"}
+        href={`https://github.com/replicatedhq/replicated-docs/issues/new?title=Docs%20feedback%20on%20${issueTitle}&body=URL:%20${url}%0AFeedback%20details:`}
         target="_blank"
         rel="noreferrer noopener"
         className={ThemeClassNames.common.editThisPage}


### PR DESCRIPTION
Upon clicking the provide feedback button on the docs, the new github issue that opens will already have the title filled in with "Docs feedback on _title here_" and the body with URL: _url_ Feedback details:

<img width="965" alt="Screen Shot 2022-07-11 at 4 15 27 PM" src="https://user-images.githubusercontent.com/48685700/178368681-686ad5d7-5fea-4ecf-ae63-45669a9360d8.png">
