### PR TITLE
fix release ordering for v1.76.1

### DIFF
--- a/docs/release-notes/rn-app-manager.md
+++ b/docs/release-notes/rn-app-manager.md
@@ -4,18 +4,6 @@ toc_max_heading_level: 2
 
 # App Manager Release Notes
 
-## 1.76.0
-
-Released on July 12, 2022
-
-Support for Kubernetes: 1.21, 1.22, 1.23, and 1.24
-
-### New Features {#new-features-1-76-0}
-* Displays license information on the admin console Dashboard and License page for Helm charts when running in Helm-managed mode (Alpha). For more information, see [Using Helm to Install an Application (Alpha)](/vendor/helm-install)
-
-### Bug Fixes {#bug-fixes-1-76-0}
-* Fixes a bug that causes links defined in the [SIG Application custom resource](/reference/custom-resource-sig-application) to not be rewritten to the hostname used in the browser.
-
 ## 1.76.1
 
 Released on July 15, 2022
@@ -29,6 +17,17 @@ Support for Kubernetes: 1.21, 1.22, 1.23, and 1.24
 * Updates the local-volume-provider image to address CVE-2021-38561 with high severity.
 * Updates the MinIO image to address CVE-2022-1271 with high severity.
 
+## 1.76.0
+
+Released on July 12, 2022
+
+Support for Kubernetes: 1.21, 1.22, 1.23, and 1.24
+
+### New Features {#new-features-1-76-0}
+* Displays license information on the admin console Dashboard and License page for Helm charts when running in Helm-managed mode (Alpha). For more information, see [Using Helm to Install an Application (Alpha)](/vendor/helm-install)
+
+### Bug Fixes {#bug-fixes-1-76-0}
+* Fixes a bug that causes links defined in the [SIG Application custom resource](/reference/custom-resource-sig-application) to not be rewritten to the hostname used in the browser.
 
 ## 1.75.0
 


### PR DESCRIPTION
1.76.0 was showing before 1.76.1.  This PR moves 1.76.1 to the top.