### PR TITLE
Add user group permission requirements for Host Path and NFS destinations

### DIFF
--- a/docs/enterprise/snapshots-configuring-hostpath.md
+++ b/docs/enterprise/snapshots-configuring-hostpath.md
@@ -11,7 +11,7 @@ The following are requirements for using a host path as the storage destination:
 * The host path must be a dedicated directory. Do not use a partition used by a service like Docker or Kubernetes for ephemeral storage.
 * The host path must exist and be writable by the user:group 1001:1001 on all nodes in the cluster.
 
-   If you use a mounted directory for the storage destination, such as one that is created with the Common Internet File System (CIFS) or Server Message Block (SMB) protocols, ensure that you configure the user:group 1001:1001 permissions on all nodes in the cluster from the server side and not the client side.
+   If you use a mounted directory for the storage destination, such as one that is created with the Common Internet File System (CIFS) or Server Message Block (SMB) protocols, ensure that you configure the user:group 1001:1001 permissions on all nodes in the cluster and from the server side as well.
 
    You cannot change the permissions of a mounted network shared filesystem from the client side. To reassign the user:group to 1001:1001 for a directory that is already mounted, you must remount the directory. For example, for a CIFS mounted directory, specify the `uid=1001,gid=1001` mount options in the CIFS mount command.
 

--- a/docs/enterprise/snapshots-configuring-hostpath.md
+++ b/docs/enterprise/snapshots-configuring-hostpath.md
@@ -4,7 +4,17 @@
 
 You can configure a host path as your snapshots storage destination. For more information about snapshot storage destinations, see [Storage destinations](snapshots-storage-destinations).
 
-If you use a host path as the snapshots storage destination, you must ensure that the host path exists and is writable by the user:group 1001:1001 on all the nodes in the cluster.
+## Requirements
+
+The following are requirements for using a host path as the storage destination:
+
+* The host path must be a dedicated directory. Do not use a partition used by a service like Docker or Kubernetes for ephemeral storage.
+* The host path must exist and be writable by the user:group 1001:1001 on all nodes in the cluster.
+
+   If you use a mounted directory for the storage destination, such as one that is created with the Common Internet File System (CIFS) or Server Message Block (SMB) protocols, ensure that you configure the user:group 1001:1001 permissions on all nodes in the cluster from the server side and not the client side.
+
+   You cannot change the permissions of a mounted network shared filesystem from the client side. To reassign the user:group to 1001:1001 for a directory that is already mounted, you must remount the directory. For example, for a CIFS mounted directory, specify the `uid=1001,gid=1001` mount options in the CIFS mount command.
+
 
 ## Configure a Host Path on Kubernetes Installer-created Clusters
 

--- a/docs/enterprise/snapshots-configuring-nfs.md
+++ b/docs/enterprise/snapshots-configuring-nfs.md
@@ -10,7 +10,7 @@ The following are requirements for configuring a NFS as the storage destination:
 
 * The NFS server must be configured to allow access from all the nodes in the cluster.
 
-* The NFS directory must be writable by the user:group 1001:1001 on all nodes in the cluster.
+* The NFS directory must be writable by the user:group 1001:1001.
 
    Ensure that you configure the user:group 1001:1001 permissions for the directory on the NFS server.
 

--- a/docs/enterprise/snapshots-configuring-nfs.md
+++ b/docs/enterprise/snapshots-configuring-nfs.md
@@ -10,7 +10,7 @@ The following are requirements for configuring a NFS as the storage destination:
 
 * The NFS server must be configured to allow access from all the nodes in the cluster.
 
-* The NFS must be writable by the user:group 1001:1001 on all nodes in the cluster.
+* The NFS directory must be writable by the user:group 1001:1001 on all nodes in the cluster.
 
    Ensure that you configure the user:group 1001:1001 permissions on the NFS server and not from the mounted directory on the client side.
 

--- a/docs/enterprise/snapshots-configuring-nfs.md
+++ b/docs/enterprise/snapshots-configuring-nfs.md
@@ -14,8 +14,6 @@ The following are requirements for configuring a NFS as the storage destination:
 
    Ensure that you configure the user:group 1001:1001 permissions for the directory on the NFS server.
 
-   You cannot change the permissions of a mounted NFS directory from the client side. To reassign the user:group to 1001:1001 on a NFS directory that is already mounted, you must remount the directory.
-
 * All the nodes in the cluster must have the necessary NFS client packages installed to be able to communicate with the NFS server.
 For example, the `nfs-common` package is a common package used on Ubuntu.
 

--- a/docs/enterprise/snapshots-configuring-nfs.md
+++ b/docs/enterprise/snapshots-configuring-nfs.md
@@ -14,7 +14,7 @@ The following are requirements for configuring a NFS as the storage destination:
 
    Ensure that you configure the user:group 1001:1001 permissions on the NFS server and not from the mounted directory on the client side.
 
-   You cannot change the permissions of a mounted NFS directory from the client side. To reassign the user:group to 1001:1001 on a NFS server for a directory that is already mounted, you must remount the directory.
+   You cannot change the permissions of a mounted NFS directory from the client side. To reassign the user:group to 1001:1001 on a NFS directory that is already mounted, you must remount the directory.
 
 * All the nodes in the cluster must have the necessary NFS client packages installed to be able to communicate with the NFS server.
 For example, the `nfs-common` package is a common package used on Ubuntu.

--- a/docs/enterprise/snapshots-configuring-nfs.md
+++ b/docs/enterprise/snapshots-configuring-nfs.md
@@ -12,7 +12,7 @@ The following are requirements for configuring a NFS as the storage destination:
 
 * The NFS directory must be writable by the user:group 1001:1001 on all nodes in the cluster.
 
-   Ensure that you configure the user:group 1001:1001 permissions on the NFS server and not from the mounted directory on the client side.
+   Ensure that you configure the user:group 1001:1001 permissions for the directory on the NFS server.
 
    You cannot change the permissions of a mounted NFS directory from the client side. To reassign the user:group to 1001:1001 on a NFS directory that is already mounted, you must remount the directory.
 

--- a/docs/enterprise/snapshots-configuring-nfs.md
+++ b/docs/enterprise/snapshots-configuring-nfs.md
@@ -1,15 +1,25 @@
-# Configuring NFS
+# Configuring a NFS
 
 > Introduced in the Replicated app manager v1.33.0
 
 You can configure a Network File System (NFS) as your snapshots storage destination. For more information about snapshot storage destinations, see [Storage destinations](snapshots-storage-destinations).
 
-Prerequisites:
+## Requirements
 
-* Make sure that you have the NFS server already set up and configured to allow access from all the nodes in the cluster.
-* Make sure all the nodes in the cluster have the necessary NFS client packages installed to be able to communicate with the NFS server.
+The following are requirements for configuring a NFS as the storage destination:
+
+* The NFS server must be configured to allow access from all the nodes in the cluster.
+
+* The NFS must be writable by the user:group 1001:1001 on all nodes in the cluster.
+
+   Ensure that you configure the user:group 1001:1001 permissions on the NFS server and not from the mounted directory on the client side.
+
+   You cannot change the permissions of a mounted NFS directory from the client side. To reassign the user:group to 1001:1001 on a NFS server for a directory that is already mounted, you must remount the directory.
+
+* All the nodes in the cluster must have the necessary NFS client packages installed to be able to communicate with the NFS server.
 For example, the `nfs-common` package is a common package used on Ubuntu.
-* Make sure that any firewalls are properly configured to allow traffic between the NFS server and clients (cluster nodes).
+
+* Any firewalls must be properly configured to allow traffic between the NFS server and clients (cluster nodes).
 
 ## Configure NFS on Kubernetes Installer-created Clusters
 


### PR DESCRIPTION
**Stories**:
- https://app.shortcut.com/replicated/story/54086/clarify-user-group-permissions-1001-1001-for-hostpath-and-nfs-destinations
- https://app.shortcut.com/replicated/story/54087/add-more-detail-to-hostpath-limitations

**Previews**: 

NFS Requirements: https://deploy-preview-484--replicated-docs.netlify.app/enterprise/snapshots-configuring-nfs#requirements

<img width="500" alt="Screen Shot 2022-07-26 at 11 17 54 AM" src="https://user-images.githubusercontent.com/11523028/181070268-c673870a-248f-4042-acba-0898ec2a97d0.png">

Host Path Requirements: https://deploy-preview-484--replicated-docs.netlify.app/enterprise/snapshots-configuring-hostpath#requirements

<img width="500" alt="Screen Shot 2022-07-26 at 11 17 38 AM" src="https://user-images.githubusercontent.com/11523028/181070274-eedfa34d-46b4-44f3-b6e8-b665317359ca.png">