### PR TITLE
Add procedure for using private registry

### DIFF
--- a/docs/vendor/helm-install.md
+++ b/docs/vendor/helm-install.md
@@ -211,7 +211,7 @@ Using a private image registry for your application requires an image pull secre
 
 When users install with the kots CLI or the Kubernetes installer, Replicated automatically uses the customer license to create and inject an image pull secret that grants proxy access to a private registry. Instances of your application can then pull private images through the Replicated proxy service. For more information, see [About Connecting to an External Registry](packaging-private-images#about-connecting-to-an-external-registry).
 
-For installations with the helm CLI, Replicated cannot automatically inject an image pull secret into the Helm chart for your application. To support the use of private images for helm CLI installations, use the Replicated `LicenseDockerCfg` template function to render a value based on the unique customer license file. Write the value to a pull secret, then reference the pull secret in the `templates/deployment.yaml` file for the Helm chart.
+For installations with the helm CLI, Replicated cannot automatically inject an image pull secret into the Helm chart for your application. To support the use of private images for helm CLI installations, use the Replicated `LicenseDockerCfg` template function to render a value based on the unique customer license file. Write the value to a pull secret, then reference the pull secret in the necessary template files for the Helm chart.
 
 For more information about the `LicenseDockerCfg` template function, see [LicenseDockerCfg](/reference/template-functions-license-context#licensedockercfg) in _License Context_.
 

--- a/docs/vendor/helm-install.md
+++ b/docs/vendor/helm-install.md
@@ -288,7 +288,7 @@ To deliver customer-specific image pull secrets for a private registry:
         ...
         image: {{ .Values.images.myapp.repository }}{{ .Values.images.myapp.tag }}
         imagePullPolicy: {{ .Values.images.myapp.pullPolicy }}
-        {{ if .Values.images.pullSecrets.replicated }}
+        {{ if .Values.images.pullSecrets.replicated.dockerconfigjson }}
         imagePullSecrets:
           - name: replicated
         {{ end }}

--- a/docs/vendor/helm-install.md
+++ b/docs/vendor/helm-install.md
@@ -235,7 +235,7 @@ To deliver customer-specific image pull secrets for a private registry:
    images:
      pullSecrets:
        replicated:
-         dockerconfigjson: {{repl LicenseDockerCfg }}
+         dockerconfigjson: "repl{{ LicenseDockerCfg }}"
      myapp:
        repository: registry.replicated.com/my-app/my-image
        tag: 0.0.1

--- a/docs/vendor/helm-install.md
+++ b/docs/vendor/helm-install.md
@@ -211,7 +211,7 @@ Using an external private image registry or the Replicated private registry for 
 
 When users install with the kots CLI or the Kubernetes installer, Replicated automatically uses the customer license to create and inject an image pull secret. For more information about this process, see [Connecting to an External Registry](packaging-private-images).
 
-For installations with the helm CLI, Replicated cannot automatically inject an image pull secret into the Helm chart for your application. To support the use of private images for helm CLI installations, use the Replicated `LicenseDockerCfg` template function to render a value based on the unique customer license file. Replicated renders the `LicenseDockerCfg` template function when the chart is pulled. This allows the customer's license-specific credentials to be injected into `values.yaml`. Write the value from the the `LicenseDockerCfg` template function to a pull secret, then reference the pull secret in the necessary template files for the Helm chart.
+For installations with the helm CLI, Replicated cannot automatically inject an image pull secret into the Helm chart for your application. To support the use of private images for helm CLI installations, add the Replicated `LicenseDockerCfg` template function to the Helm chart `values.yaml` file. The `LicenseDockerCfg` template function renders a value based on the unique customer license file when the Helm chart is pulled. Write this rendered value to a pull secret, then reference the pull secret in the necessary template files for the Helm chart.
 
 For more information about the `LicenseDockerCfg` template function, see [LicenseDockerCfg](/reference/template-functions-license-context#licensedockercfg) in _License Context_.
 
@@ -241,7 +241,8 @@ To deliver customer-specific image pull secrets for a private registry:
    kind: Secret
    metadata:
      name: SECRET_NAME
-   # Kubernetes clusters use the kubernetes.io/dockerconfigjson Secret type to authenticate with a private image registry.
+   # Kubernetes clusters use the kubernetes.io/dockerconfigjson Secret type
+   # to authenticate with a private image registry.
    type: kubernetes.io/dockerconfigjson
    data:
      .dockerconfigjson: {{ .Values.FIELD_NAME }}
@@ -276,8 +277,8 @@ To deliver customer-specific image pull secrets for a private registry:
         {{ end }}
    ```
    Replace:
-   * `FIELD_NAME` with the name of the field where you where you added `"repl{{ LicenseDockerCfg }}"`. 
-   * `SECRET_NAME` with the same name that you created in the previous step.
+   * `FIELD_NAME` with the name of the field where you where you added `"repl{{ LicenseDockerCfg }}"`.
+   * `SECRET_NAME` with the `name:` of the Secret that you created in the previous step.
 
    **Example:**
 
@@ -297,7 +298,7 @@ To deliver customer-specific image pull secrets for a private registry:
           name: http
     ```
 
-1. Package your Helm chart, and add the packaged chart to a release in the Replicated vendor portal. For more information, see [Add a Helm Chart to a Release](helm-release#add-a-helm-chart-to-a-release).
+1. Package your Helm chart and add the packaged chart to a release in the Replicated vendor portal. For more information, see [Add a Helm Chart to a Release](helm-release#add-a-helm-chart-to-a-release).
 
 1. Save and promote the release to a development environment to test your changes.  
 

--- a/docs/vendor/helm-install.md
+++ b/docs/vendor/helm-install.md
@@ -225,7 +225,7 @@ To deliver customer-specific image pull secrets for a private registry:
        replicated:
          dockerconfigjson: "repl{{ LicenseDockerCfg }}"
    ```   
-   Replicated renders the `LicenseDockerCfg` template function on `helm install` or `helm pull`. This allows the customer's license-specific credentials to be injected into `values.yaml`.
+   Replicated renders the `LicenseDockerCfg` template function when the chart is pulled. This allows the customer's license-specific credentials to be injected into `values.yaml`.
 
    **Example:**
 

--- a/docs/vendor/helm-install.md
+++ b/docs/vendor/helm-install.md
@@ -257,7 +257,7 @@ To deliver customer-specific image pull secrets for a private registry:
    {{ end }}
    ```
 
-1. Add the following to the `templates/deployment.yaml` to inject the pull secret that you created in the previous step when the `.Values.images.pullSecrets.replicated` field is present:
+1. Add the following to any manifests in the `templates` directory that reference private images, to inject the pull secret that you created in the previous step when the `.Values.images.pullSecrets.replicated` field is present. Ensure that the name of the pull secret matches.
 
    ```yaml
         ...

--- a/docs/vendor/helm-install.md
+++ b/docs/vendor/helm-install.md
@@ -233,7 +233,7 @@ To deliver customer-specific image pull secrets for a private registry:
          dockerconfigjson: "repl{{ LicenseDockerCfg }}"
    ```   
 
-1. In the `templates` directory of your Helm chart, create a Kubernetes Secret manifest file (`kind: Secret`). Add the following YAML to the file to evaluate if the `LicenseDockerCfg` template function renders a value for the customer, then write the rendered value into a Secret on the cluster:
+1. In the `templates` directory of your Helm chart, create a Kubernetes Secret manifest file (`kind: Secret`). Add the following YAML to the file to evaluate if the secret value is set, and then write the rendered value into a Secret on the cluster:
 
    ```yaml
    {{ if .Values.FIELD_NAME }}

--- a/docs/vendor/helm-install.md
+++ b/docs/vendor/helm-install.md
@@ -222,7 +222,7 @@ To deliver customer-specific image pull secrets for a private registry:
    ```yaml
    FIELD_NAME: "repl{{ LicenseDockerCfg }}"
    ```
-   Replace `FIELD_NAME` with any name for the field.
+   Replace `FIELD_NAME` with any name for the field. You can add `"repl{{ LicenseDockerCfg }}"` as a flat or nested value. For more information, see [Flat or Nested Values](https://helm.sh/docs/chart_best_practices/values/#flat-or-nested-values) in the Helm documentation.
 
    **Example:**
 
@@ -233,7 +233,7 @@ To deliver customer-specific image pull secrets for a private registry:
          dockerconfigjson: "repl{{ LicenseDockerCfg }}"
    ```   
 
-1. In the `templates` directory of your Helm chart, create a Secret custom resource manifest file (`kind: Secret`). Add the following YAML to the file to evaluate if the `LicenseDockerCfg` template function renders a value for the customer, then write the rendered value into a Secret on the cluster:
+1. In the `templates` directory of your Helm chart, create a Kubernetes Secret manifest file (`kind: Secret`). Add the following YAML to the file to evaluate if the `LicenseDockerCfg` template function renders a value for the customer, then write the rendered value into a Secret on the cluster:
 
    ```yaml
    {{ if .Values.FIELD_NAME }}

--- a/docs/vendor/helm-install.md
+++ b/docs/vendor/helm-install.md
@@ -289,52 +289,6 @@ To deliver customer-specific image pull secrets for a private registry:
 
 1. Save and promote the release to a development environment to test your changes.  
 
-### Example: Delivering Image Pull Secrets for Private Images
-
-   `values.yaml`
-
-   ```yaml
-   images:
-     pullSecrets:
-       replicated:
-         dockerconfigjson: {{repl LicenseDockerCfg }}
-     myapp:
-       repository: registry.replicated.com/my-app/my-image
-       tag: 0.0.1
-       pullPolicy: IfNotPresent
-       pullSecret: replicated
-   ```
-
-   `templates/imagepullsecret.yaml`
-
-   ```yaml
-   {{ if .Values.images.pullSecrets.replicated.dockerconfigjson }}
-   apiVersion: v1
-   kind: Secret
-   metadata:
-     name: replicated
-   type: kubernetes.io/dockerconfigjson
-   data:
-     .dockerconfigjson: {{ .Values.images.pullSecrets.replicated.dockerconfigjson }}
-   {{ end }}
-   ```
-
-   `templates/deployment.yaml`
-
-   ```yaml
-           ...
-           image: {{ .Values.images.myapp.repository }}{{ .Values.images.myapp.tag }}
-           imagePullPolicy: {{ .Values.images.myapp.pullPolicy }}
-           {{ if .Values.images.pullSecrets.replicated }}
-           imagePullSecrets:
-             - name: replicated
-           {{ end }}
-           name: myapp
-           ports:
-           - containerPort: 3000
-             name: http
-   ```          
-
 ## Example: Delivering Custom License Fields
 
 `values.yaml`

--- a/docs/vendor/helm-install.md
+++ b/docs/vendor/helm-install.md
@@ -18,7 +18,7 @@ When a new version of a chart is uploaded, Replicated renders and cache that ver
 
 When a license field changes for a customer, Replicated invalidates all rendered and cached charts. This causes the charts to be rebuilt the next time they are pulled.
 
-The `values.yaml` in your Chart is rendered with the customer provided license. Each customer logs in with unique credentials, and our registry is able to identify which customer is pulling the chart. This creates a way to pass custom license fields and other customer-specific data into the `values.yaml` as defaults, and consume them in Helm templates.
+The `values.yaml` in your Chart is rendered with a customer-specific license. Each customer logs in with unique credentials, and our registry is able to identify which customer is pulling the chart. This creates a way to pass custom license fields and other customer-specific data into the `values.yaml` as defaults, and consume them in Helm templates.
 
 When Replicated renders the `values.yaml`, it is not assumed to be a valid YAML format in order to allow flow-control and conditional template functions to optionally write some fields to the `values.yaml` file. Replicated renders template functions in the `values.yaml` for each customer, as the Helm chart is served to the customer.
 

--- a/docs/vendor/helm-install.md
+++ b/docs/vendor/helm-install.md
@@ -223,7 +223,7 @@ To deliver customer-specific image pull secrets for a private registry:
    images:
      pullSecrets:
        replicated:
-         dockerconfigjson: {{repl LicenseDockerCfg }}
+         dockerconfigjson: "repl{{ LicenseDockerCfg }}"
    ```   
    Replicated renders the `LicenseDockerCfg` template function on `helm install` or `helm pull`. This allows the customer's license-specific credentials to be injected into `values.yaml`.
 

--- a/docs/vendor/helm-install.md
+++ b/docs/vendor/helm-install.md
@@ -20,7 +20,7 @@ When a license field changes for a customer, Replicated invalidates all rendered
 
 The `values.yaml` in your Chart is rendered with a customer-specific license. Each customer logs in with unique credentials, and our registry is able to identify which customer is pulling the chart. This creates a way to pass custom license fields and other customer-specific data into the `values.yaml` as defaults, and consume them in Helm templates.
 
-When Replicated renders the `values.yaml`, it is not assumed to be a valid YAML format in order to allow flow-control and conditional template functions to optionally write some fields to the `values.yaml` file. Replicated renders template functions in the `values.yaml` for each customer, as the Helm chart is served to the customer.
+Before Replicated renders the `values.yaml`, it is not assumed to be a valid YAML format in order to allow flow control and conditional template functions to optionally write some fields to the `values.yaml` file. Replicated renders template functions in the `values.yaml` for each customer, as the Helm chart is served to the customer.
 
 ## Requirement
 

--- a/docs/vendor/helm-install.md
+++ b/docs/vendor/helm-install.md
@@ -278,7 +278,7 @@ To deliver customer-specific image pull secrets for a private registry:
    ```
    Replace:
    * `FIELD_NAME` with the name of the field where you where you added `"repl{{ LicenseDockerCfg }}"`.
-   * `SECRET_NAME` with the `name:` of the Secret that you created in the previous step.
+   * `SECRET_NAME` with the name of the Secret that you created in the previous step.
 
    **Example:**
 

--- a/docs/vendor/helm-install.md
+++ b/docs/vendor/helm-install.md
@@ -250,10 +250,10 @@ To deliver customer-specific image pull secrets for a private registry:
    apiVersion: v1
    kind: Secret
    metadata:
-    name: replicated
+     name: replicated
    type: kubernetes.io/dockerconfigjson
    data:
-    .dockerconfigjson: {{ .Values.images.pullSecrets.replicated.dockerconfigjson }}
+     .dockerconfigjson: {{ .Values.images.pullSecrets.replicated.dockerconfigjson }}
    {{ end }}
    ```
 


### PR DESCRIPTION
Story: https://app.shortcut.com/replicated/story/54157/add-procedure-for-using-private-images-to-alpha-topic

Preview: https://deploy-preview-485--replicated-docs.netlify.app/vendor/helm-install#private-images

I based this procedure on the [Example: Delivering Image Pull Secrets for Private Images](https://docs.replicated.com/vendor/helm-install#example-delivering-image-pull-secrets-for-private-images) content that is in the currently-published version of this topic. I also used the generic procedure provided in the [Helm Installation (Alpha)](https://docs.google.com/document/d/1P4oCUtkM8IileNNw83NepEsyq14rTTS9w-64T-uwmeA/edit#heading=h.l11cvyaz20lx) google doc.