### PR TITLE
[sc-49457] prevent scrape jobs from walking on each other

### DIFF
--- a/.github/workflows/algolia-crawl.yml
+++ b/.github/workflows/algolia-crawl.yml
@@ -1,8 +1,9 @@
 name: scrape
-on: 
+concurrency: scrape
+on:
   push:
     branches:
-      main
+      - main
   workflow_dispatch:
 jobs:
   scrape:


### PR DESCRIPTION
Add a concurrency group to prevent the scrape jobs from walking on each other