### PR TITLE
Replace "snapshots" with "Backup and Restore"

### DIFF
--- a/docs/enterprise/snapshots-understanding.md
+++ b/docs/enterprise/snapshots-understanding.md
@@ -1,17 +1,19 @@
-# Understanding Snapshots
+# About Backup and Restore
 
-An important part of the lifecycle of an application is backup and restore. The Replicated admin console can be used to create and manage your storage destination and schedule, and to perform and monitor the backup and restore process. This feature is only available for licenses that have the Allow Snapshots feature enabled.
+An important part of the lifecycle of an application is backup and restore. The Replicated admin console can be used to create and manage your storage destination and schedule, and to perform and monitor the backup and restore process.
+
+The admin console backup and restore feature is called snapshots. The snapshots feature is available only for licenses that have the Allow Snapshots feature enabled.
 
 There are two types of snapshots:
-  * Full snapshots (Instance)
-  * Partial snapshots (Application)
+  * **Full snapshots (Recommended)**: Back up the admin console and all application data. See [Full Snaphots](#full).
+  * **Partial snapshots**: Back up the application volumes and manifest files. See [Partial Snaphots](#partial).
 
 Snapshots are useful for rollback and disaster recovery scenarios. They are not intended to be used for application migration scenarios.
 
-## Full Snapshots (recommended)
+## Full Snapshots (Recommended) {#full}
 
 Full snapshots back up the admin console and all application data.
-They can be used for full Disaster Recovery; by restoring over the same instance, or into a new cluster.
+They can be used for full Disaster Recovery by restoring over the same instance or into a new cluster.
 
 There are two ways to create a full snapshot. First, make sure that your license has the snapshots feature enabled, then:
 
@@ -27,9 +29,9 @@ There are two available options for doing a restore. You can either do a full re
 
 If you have multiple applications within the admin console, each application should have a backup resource in order to be included in the full snapshot backup. For more information, see [Backup](../reference/custom-resource-backup) in the _Custom resources_ section.
 
-## Partial Snapshots
+## Partial Snapshots {#partial}
 
-Partial snapshots only back up applications volumes and application manifests; they do not back up the admin console or the metadata about an application.
+Partial snapshots only back up application volumes and application manifests; they do not back up the admin console or the metadata about an application.
 They are useful for capturing information before deploying a new release, in case you need to roll back, but they are not suitable for full disaster recovery.
 For backups that give you the ability to do full disaster recovery, use full snapshots. For more information, see [Full snapshots (recommended)](#full-snapshots-recommended) above.
 

--- a/docs/vendor/snapshots-overview.md
+++ b/docs/vendor/snapshots-overview.md
@@ -1,19 +1,22 @@
-# Snapshots Overview
+# About Backup and Restore
 
-Snapshots is the backup and restore feature for applications. This is an optional feature.
+Replicated's backup and restore feature for applications is called snapshots. You can optionally enable snapshots to support backup and restore for your users.
 
-To enable snapshots, the Replicated app manager uses the Velero open source project on the backend to back up Kubernetes manifests and persistent volumes. Velero is a mature, fully-featured application. For more information, see the [Velero documentation](https://velero.io/docs/).
+Snapshots use the Velero open source project as the backend to back up Kubernetes manifests and persistent volumes. Velero is a mature, fully-featured application. For more information, see the [Velero documentation](https://velero.io/docs/).
 
-In addition to the default functionality that Velero provides, the app manager provides a detailed interface in the [admin console](../enterprise/snapshots-scheduling) where end users can manage the storage destination and schedule, and perform and monitor the backup process. These details can also be managed using the kots CLI, the CLI for the app manager.
+In addition to the default functionality that Velero provides, the Replicated admin console provides a detailed interface where your users can manage storage destinations, schedule snapshots, and perform and monitor the backup process. For more information, see [About Backup and Restore]((/enterprise/snapshots-understanding) in the _Enterprise_ documentation.
+
+These details can also be managed using the kots CLI, the CLI for the app manager.
+
 :::note
 The restore process is managed through the kots CLI only.
 :::
 
-The app manager also exposes hooks that can be used to inject scripts to execute with Snapshots both [before and after a backup](snapshots-configuring-backups) and [before and after a restore](../enterprise/snapshots-understanding).
+The app manager also exposes hooks that can be used to inject scripts to execute with snapshots both [before and after a backup](snapshots-configuring-backups) and [before and after a restore](../enterprise/snapshots-understanding).
 
-## How to Implement Snapshots
+## How to Enable Backup and Restore
 
-To implement this feature you must:
+To enable the snapshots backup and restore feature for your users, you must:
 
 - Have the snapshots entitlement enabled in your Replicated vendor account. For account entitlements, contact the Replicated TAM team.
 - Define a manifest for executing snapshots and restoring previous snapshots. For more information, see [Configuring Backups](snapshots-configuring-backups).

--- a/sidebars.js
+++ b/sidebars.js
@@ -260,12 +260,18 @@ const sidebars = {
         },
         {
           type: 'category',
-          label: 'Snapshots',
+          label: 'Managing Backup and Restore',
           items: [
             'enterprise/snapshots-understanding',
-            'enterprise/snapshots-storage-destinations',
-            'enterprise/snapshots-configuring-nfs',
-            'enterprise/snapshots-configuring-hostpath',
+            {
+              type: 'category',
+              label: 'Configuring Storage Destinations',
+              items: [
+                'enterprise/snapshots-storage-destinations',
+                'enterprise/snapshots-configuring-nfs',
+                'enterprise/snapshots-configuring-hostpath',
+              ],
+            },
             'enterprise/snapshots-scheduling',
             'enterprise/snapshots-restoring-full',
             'enterprise/snapshots-restoring-partial',


### PR DESCRIPTION
**Story**: https://app.shortcut.com/replicated/story/54106/replace-snapshots-in-titles-and-headings-with-backup-and-restore 

According to this request from the support team, users are struggling to find information about backup and restore in the docs because they don't know what "snapshot" means. We should rename this in the TOC, titles, and headings to make it easier to find, while explaining the snapshots is the name of the feature in the page content.

**Previews**:

Edited some of the titles/headings in this section of the vendor docs: https://deploy-preview-489--replicated-docs.netlify.app/vendor/snapshots-overview

Also edited titles/headings in these enterprise docs (some light rewording in the content of the topics as well. I couldn't resist): https://deploy-preview-489--replicated-docs.netlify.app/enterprise/snapshots-understanding