### PR TITLE
Add timeout troubleshooting description

### DIFF
--- a/docs/enterprise/snapshots-troubleshooting-backup-restore.md
+++ b/docs/enterprise/snapshots-troubleshooting-backup-restore.md
@@ -34,9 +34,9 @@ If this is the case, Replicated recommends that you validate the access key / se
 
 ### Invalid Top-level Directories
 
-Another commonly seen problem in Velero starting is a reconfigured or re-used bucket.
-When configuring Velero to use a bucket, the bucket cannot contain other data, or Velero will crash.  
-In this case, the error in the Velero logs will be:
+#### Symptom
+
+You see the following error message when Velero is starting:
 
 ```shell
 time="2020-04-10T14:12:42Z" level=info msg="Checking existence of namespace" logSource="pkg/cmd/server/server.go:337" namespace=velero
@@ -46,6 +46,16 @@ time="2020-04-10T14:12:44Z" level=info msg="All Velero custom resource definitio
 time="2020-04-10T14:12:44Z" level=info msg="Checking that all backup storage locations are valid" logSource="pkg/cmd/server/server.go:413"
 An error occurred: some backup storage locations are invalid: backup store for location "default" is invalid: Backup store contains invalid top-level directories: [other-directory]
 ```
+
+#### Cause
+
+This error message is caused when Velero is attempting to start, and it is configured to use a reconfigured or re-used bucket.
+
+When configuring Velero to use a bucket, the bucket cannot contain other data, or Velero will crash.
+
+#### Solution
+
+Configure Velero to use a bucket that does not contain other data.
 
 ## Snapshot Restore is Failing
 

--- a/docs/enterprise/snapshots-troubleshooting-backup-restore.md
+++ b/docs/enterprise/snapshots-troubleshooting-backup-restore.md
@@ -127,3 +127,7 @@ kubectl patch deployment velero -n velero --type json -p '[{"op":"add","path":"/
 ```
 
 Replace `TIMEOUT_LIMIT` with a length of time for the restic Pod operation timeout in hours, minutes, and seconds. Use the format `0h0m0s`. For example, `48h30m0s`.
+
+:::note
+Application install overwrites the restic timeout that you set with the `kubectl patch deployment velero` command.
+:::


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/54091/document-workaround-for-patching-the-velero-deployment-to-edit-restic-timeout

See the Timeout Error section: https://deploy-preview-494--replicated-docs.netlify.app/enterprise/snapshots-troubleshooting-backup-restore#timeout-error-when-creating-a-snapshot

I also did some reformatting to use the Symptom/Cause/Solution format