### PR TITLE
Remove kustomize CVE exceptions after upgrade to v4

### DIFF
--- a/docs/reference/custom-resource-application.md
+++ b/docs/reference/custom-resource-application.md
@@ -22,7 +22,7 @@ spec:
   releaseNotes: These are our release notes
   allowRollback: false
   kubectlVersion: latest
-  kustomizeVersion: latest
+  kustomizeVersion: ">= 4.0.0"
   targetKotsVersion: "1.60.0"
   minKotsVersion: "1.40.0"
   requireMinimalRBACPrivileges: false
@@ -88,17 +88,17 @@ For backwards compatibility, exact versions are also supported.
 When an exact version is specified, the app manager will choose the matching major and minor version.
 
 ## kustomizeVersion
-The app manager maintains up-to-date minor and patch versions of all supported Kustomize major versions.
-When unspecified, the app manager will use the newest version from the list of supported versions below.
+The app manager maintains up-to-date minor and patch versions of all Kustomize major versions that the app manager supports.
+When unspecified, the app manager uses the latest supported version. The following major versions are supported.
 
 - 4.x.x
 
-An optional SemVer range can be specified, as defined in [blang SemVer range](https://github.com/blang/semver#ranges) (like `4.x.x` or `>=4.0.0 <5.0.0`).
-The latest version within the provided range will be used.
-If the specified version or range does not match any supported versions, the latest version from the above list will be used.
+An optional semantic version range can be specified, as defined in [blang SemVer range](https://github.com/blang/semver#ranges) (like `4.x.x` or `>=4.0.0 <5.0.0`).
+The latest supported version within the provided range will be used.
+If the specified version or range does not match any supported versions, the latest version from the above list of supported versions will be used.
 
 For backwards compatibility, exact versions are also supported.
-When an exact version is specified, the app manager will choose the matching major and minor version.
+When an exact version is specified, the app manager will choose the matching version if it is supported, or it will choose the latest support minor and patch version for the specified major version.
 
 ## requireMinimalRBACPrivileges
 

--- a/docs/reference/custom-resource-application.md
+++ b/docs/reference/custom-resource-application.md
@@ -91,9 +91,9 @@ When an exact version is specified, the app manager will choose the matching maj
 The app manager maintains up-to-date minor and patch versions of all supported Kustomize major versions.
 When unspecified, the app manager will use the newest version from the list of supported versions below.
 
-- 3.x.x
+- 4.x.x
 
-An optional SemVer range can be specified, as defined in [blang SemVer range](https://github.com/blang/semver#ranges) (like `3.x.x` or `>=3.0.0 <4.0.0`).
+An optional SemVer range can be specified, as defined in [blang SemVer range](https://github.com/blang/semver#ranges) (like `4.x.x` or `>=4.0.0 <5.0.0`).
 The latest version within the provided range will be used.
 If the specified version or range does not match any supported versions, the latest version from the above list will be used.
 

--- a/docs/reference/custom-resource-application.md
+++ b/docs/reference/custom-resource-application.md
@@ -82,10 +82,10 @@ When unspecified, the app manager uses the newest version from the list of suppo
 
 An optional Semantic Versioning (SemVer) range can be specified, as defined in [blang SemVer range](https://github.com/blang/semver#ranges) (like `1.16.x` or `>=1.16.0 <1.17.0`).
 The latest version within the provided range will be used.
-If the specified version or range does not match any supported versions, the latest version from the above list will be used.
+If the specified version or range does not match any supported versions, the latest version from the above list is used.
 
 For backwards compatibility, exact versions are also supported.
-When an exact version is specified, the app manager will choose the matching major and minor version.
+When an exact version is specified, the app manager chooses the matching major and minor version.
 
 ## kustomizeVersion
 The app manager maintains up-to-date minor and patch versions of all Kustomize major versions that the app manager supports.
@@ -94,11 +94,11 @@ When unspecified, the app manager uses the latest supported version. The followi
 - 4.x.x
 
 An optional semantic version range can be specified, as defined in [blang SemVer range](https://github.com/blang/semver#ranges) (like `4.x.x` or `>=4.0.0 <5.0.0`).
-The latest supported version within the provided range will be used.
-If the specified version or range does not match any supported versions, the latest version from the above list of supported versions will be used.
+The latest supported version within the provided range is used.
+If the specified version or range does not match any supported versions, the latest version from the above list of supported versions is used.
 
 For backwards compatibility, exact versions are also supported.
-When an exact version is specified, the app manager will choose the matching version if it is supported. If the specific version is not supported, the app manager will choose the latest supported minor and patch version for the specified major version.
+When an exact version is specified, the app manager chooses the matching version if it is supported. If the specific version is not supported, the app manager chooses the latest supported minor and patch version for the specified major version.
 
 ## requireMinimalRBACPrivileges
 

--- a/docs/reference/custom-resource-application.md
+++ b/docs/reference/custom-resource-application.md
@@ -98,7 +98,7 @@ The latest supported version within the provided range will be used.
 If the specified version or range does not match any supported versions, the latest version from the above list of supported versions will be used.
 
 For backwards compatibility, exact versions are also supported.
-When an exact version is specified, the app manager will choose the matching version if it is supported, or it will choose the latest support minor and patch version for the specified major version.
+When an exact version is specified, the app manager will choose the matching version if it is supported. If the specific version is not supported, the app manager will choose the latest supported minor and patch version for the specified major version.
 
 ## requireMinimalRBACPrivileges
 

--- a/docs/vendor/policies-vulnerability-patch.md
+++ b/docs/vendor/policies-vulnerability-patch.md
@@ -26,7 +26,6 @@ When a larger base image is required, we will keep it updated to the latest vers
 | Minor version | Within 30 days |
 | Major version | Before the previous version is EOL |
 
-
 ## Upstream CVE Disclosure
 
 Replicated KOTS and kURL deliver many upstream Kubernetes and ecosystem components.
@@ -47,24 +46,3 @@ The following CVEs have yet to be resolved by the upstream maintainers and there
 | CVE ID | Explanation|
 |--------|------------|
 |CVE-2022-1292| The reported vulnerability affects an OpenSSL script in the container image, ```(c_rehash)```, but neither Velero nor Replicated use this script. As such, it is our opinion that CVE-2022-1292 is not remotely exploitable within Replicated.|
-
-## Known Disclosed Vulnerabilities in our On Premises Products
-
-KOTS uses an older version of Kustomize, v3.5.4, released in January 2020. We continue to include and use this version because newer versions, including v3.10.0 through v4.x, are 6 to 12 times slower. This imparts an unacceptable delay when saving application configuration or applying updates in KOTS. However, v3.5.4 also contains a number of high or critical vulnerabilities. We have assessed each of these vulnerabilities for both relevance to KOTS as well as risk.
-
-Based on this analysis, we feel these vulnerabilities do not meaningfully detract from KOTS overall security posture while still maintaining usability. We continue to performance test new versions of Kustomize to find a suitably performant and secure version. At this time, we are continuing to include v3.5.4 with the known vulnerabilities until a better solution is available.
-
-The following table lists the vulnerabilities in Kustomize v3.5.4, including a summary, rationale, and link for more information.
-
-| CVE | CVE Summary | Rationale | Additional Reading |
-|-----|-------------|-----------|--------------------|
-|CVE-2014-3499|Docker 1.0.0 uses world-readable and world-writable permissions on the management socket, which allows local users to gain privileges via unspecified vectors. |	If Docker is the CRI of choice, Docker 1.0.0 is unlikely to be in use. Alternatively, another CRI may be implemented as a compensating control.	| [CVE-2014-3499 Details](https://access.redhat.com/security/cve/CVE-2014-3499)
-CVE-2014-6407 |	Docker earlier than 1.3.2 allows remote attackers to write to arbitrary files and execute arbitrary code via a (1) symlink or (2) hard link attack in an image archive in a (a) pull or (b) load operation. |	Exploitation requires a malicious image. KOTS utilizes trusted images directly supplied by the software vendor. |	[CVE-2014-6407 Details](https://access.redhat.com/security/cve/CVE-2014-6407#cve-cvss-v2)
-CVE-2014-9356	| It was found that a malicious container image could overwrite arbitrary portions of the host file system by including absolute symlinks, potentially leading to privilege escalation. |	Exploitation requires a malicious image. KOTS utilizes trusted images directly supplied by the software vendor.	| [CVE-2014-9356 Details](https://access.redhat.com/security/cve/cve-2014-9356)
-CVE-2014-9357 |	A flaw was found in the way the Docker service unpacked images or builds after a "docker pull". An attacker could use this flaw to provide a malicious image or build that, when unpacked, would escalate their privileges on the system. |	Exploitation requires a malicious image. KOTS utilizes trusted images directly supplied by the software vendor. |	[CVE-2014-9357 Details](https://access.redhat.com/security/cve/cve-2014-9357)
-CVE-2015-3627 |	Libcontainer and Docker Engine earlier than 1.6.1 opens the file-descriptor passed to the pid-1 process before performing the chroot, which allows local users to gain privileges via a symlink attack in an image. |	Exploitation requires a malicious image. KOTS utilizes trusted images directly supplied by the software vendor. |	[CVE-2015-3627 Details](https://access.redhat.com/security/cve/cve-2015-3627)
-CVE-2022-27191 |	The golang.org/x/crypto/ssh package before 0.0.0-20220314234659-1baeb1ce4c0b for Go allows an attacker to crash a server in certain circumstances involving AddHostKey.	| KOTS does not utilize Go’s SSH package to create key pairs. |	[CVE-2022-27191 Details](https://access.redhat.com/security/cve/cve-2022-27191)
-CVE-2020-14040 | A denial of service vulnerability was found in the golang.org/x/text library. If an attacker supplies specific input there is the potential to cause an infinite loop to occur using more memory, resulting in a denial of service. |	KOTS does not accept generic user input, only Kubernetes manifests which are then passed to Kustomize. Additionally, there is never a direct interface to golang’s text library |	[CVE-2020-14040](https://access.redhat.com/security/cve/cve-2020-14040) |
-|CVE-2020-27847| A vulnerability exists in the SAML connector of the github.com/dexidp/dex library used to process SAML Signature Validation. This flaw allows an attacker to bypass SAML authentication. The highest threats from this vulnerability are to confidentiality, integrity, and system availability. This flaw affects dex versions before 2.27.0. | This is a false positive from Trivy. This vulnerability applies to Dex version 2.27.0 and earlier, whereas Replicated is using Dex version 2.32.0. Dex does not follow Go's semantic versioning convention, which may explain the erroneous result from Trivy. | https://github.com/replicatedhq/kots/pull/2934 https://github.com/aquasecurity/trivy/issues/2433 https://github.com/dexidp/dex/issues/1578#issuecomment |
-|CVE-2021-38561 | Due to improper index calculation, an incorrectly formatted language tag can cause Parse to panic, due to an out of bounds read. If Parse is used to process untrusted user inputs, this may be used as a vector for a denial of service attack. | KOTS does not accept generic user input, only Kubernetes manifests which are then passed to Kustomize. Additionally, there is never a direct interface to golang’s text library | https://www.mend.io/vulnerability-database/CVE-2021-38561 |
-|CVE-2021-3121 | A flaw in protobuf before 1.3.2 allows a remote attacker to send specific protobuf messages to cause a denial of service | Protobuf is included in the Kustomize binary but Kustomize never acts as a protobuf server so it is not possible for an attacker to send the specific protobuf messages required to exploit this vulnerability | https://access.redhat.com/security/cve/cve-2021-3121 | 

--- a/docs/vendor/policies-vulnerability-patch.md
+++ b/docs/vendor/policies-vulnerability-patch.md
@@ -67,4 +67,4 @@ As subsequent versions of the vulnerable software are released, Replicated conti
 
 ## Known Disclosed Vulnerabilities in our On Premises Products
 
-None at this time.
+There are no known disclosed vulnerabilities at this time.


### PR DESCRIPTION
In our next version of KOTS, we plan to upgrade to the latest version of kustomize, because the performance degradation from our current version seems to be acceptably small. This new version resolves all current CVEs, so we can remove this section from our docs that lists out the CVEs we exepted for kustomize.

FYI @tcalotta