### PR TITLE
HOLD FOR RELEASE update support for image tags and digests

### DIFF
--- a/docs/vendor/packaging-private-images.md
+++ b/docs/vendor/packaging-private-images.md
@@ -175,7 +175,7 @@ For more information about the `additionalNamespaces` attribute, see [Defining A
 
 The app manager supports image tags for applications in all use cases.
 
-The app manager supports image digests only for online (Internet-connected) installations where the app manager can pull all images from the Replicated private registry, a public external registry, or from a private external registry through proxy access. Image tags and digests can also be used together in these use-cases. Image digests are not supported for airgap installations or for online installations that are configured, via the **Registry Settings** tab, to push images to a private registry.
+The app manager supports image digests only for online (Internet-connected) installations where the app manager can pull all images from the Replicated private registry, a public external registry, or from a private external registry through proxy access. Image tags and digests can be used together for these installations too. Image digests are not supported for airgap installations or for online installations that are configured to push images to a private registry.
 
 ## Related Topic
 

--- a/docs/vendor/packaging-private-images.md
+++ b/docs/vendor/packaging-private-images.md
@@ -175,9 +175,7 @@ For more information about the `additionalNamespaces` attribute, see [Defining A
 
 The app manager supports image tags for applications in all use cases.
 
-The app manager supports image digests only for online (Internet-connected) installations where the app manager can pull all images from the Replicated private registry, a public external registry, or from a private external registry through proxy access.
-
-However, image tags and digests cannot be used together due to upstream limitations. For more information, see [Why do i see the error 'Docker references with both a tag and digest are currently not supported'?](https://community.replicated.com/t/why-do-i-see-the-error-docker-references-with-both-a-tag-and-digest-are-currently-not-supported/825) on the Replicated Community website.
+The app manager supports image digests only for online (Internet-connected) installations where the app manager can pull all images from the Replicated private registry, a public external registry, or from a private external registry through proxy access.  Image tags and digests can also be used together for online installations.
 
 ## Related Topic
 

--- a/docs/vendor/packaging-private-images.md
+++ b/docs/vendor/packaging-private-images.md
@@ -175,7 +175,7 @@ For more information about the `additionalNamespaces` attribute, see [Defining A
 
 The app manager supports image tags for applications in all use cases.
 
-The app manager supports image digests only for online (Internet-connected) installations where the app manager can pull all images from the Replicated private registry, a public external registry, or from a private external registry through proxy access.  Image tags and digests can also be used together for online installations, excluding those configured to use an internal private registry.
+The app manager supports image digests only for online (Internet-connected) installations where the app manager can pull all images from the Replicated private registry, a public external registry, or from a private external registry through proxy access. Image tags and digests can also be used together in these use-cases. Image digests are not supported for airgap installations or for online installations that are configured, via the **Registry Settings** tab, to push images to a private registry.
 
 ## Related Topic
 

--- a/docs/vendor/packaging-private-images.md
+++ b/docs/vendor/packaging-private-images.md
@@ -175,7 +175,7 @@ For more information about the `additionalNamespaces` attribute, see [Defining A
 
 The app manager supports image tags for applications in all use cases.
 
-The app manager supports image digests only for online (Internet-connected) installations where the app manager can pull all images from the Replicated private registry, a public external registry, or from a private external registry through proxy access.  Image tags and digests can also be used together for online installations.
+The app manager supports image digests only for online (Internet-connected) installations where the app manager can pull all images from the Replicated private registry, a public external registry, or from a private external registry through proxy access.  Image tags and digests can also be used together for online installations, excluding those configured to use an internal private registry.
 
 ## Related Topic
 


### PR DESCRIPTION
Removed the section that states that images and digests cannot be used together.  Also added an additional sentence after the online digest support piece to indicate that both can be used together for online installations (except for those configured to use an internal private registry).