### PR TITLE
change helmVersion default to v3

### DIFF
--- a/docs/reference/custom-resource-helmchart.md
+++ b/docs/reference/custom-resource-helmchart.md
@@ -27,8 +27,8 @@ spec:
 
   exclude: "repl{{ ConfigOptionEquals `include_chart` `include_chart_no`}}"
 
-  # helmVersion identifies the Helm Version used to render the chart. Default is v2.
-  helmVersion: v2
+  # helmVersion identifies the Helm Version used to render the chart. Default is v3.
+  helmVersion: v3
 
   # useHelmInstall identifies whether this Helm chart will use the
   # Replicated Helm installation (false) or native Helm installation (true). Default is false.
@@ -100,7 +100,7 @@ Must be a valid Helm release name that matches regex `^[a-z0-9]([-a-z0-9]*[a-z0-
 ## helmVersion
 
 Identifies the Helm Version used to render the chart.
-Acceptable values are `v2` or `v3`. `v2` is the default when no value is specified.
+Acceptable values are `v2` or `v3`. `v3` is the default when no value is specified.
 
 ## useHelmInstall
 


### PR DESCRIPTION
Changing the default value for `helmVersion` to `v3` to document the changes in: https://github.com/replicatedhq/kots/pull/3041.

Additionally, the example manifest has a `helmVersion: v2` along with `useHelmInstall: true`, but native helm installations are only available for `v3` charts, so I changed this so I modified the example to be a valid combination of the two.