### PR TITLE
update install instructions for embedded tutorial

### DIFF
--- a/docs/vendor/tutorial-installing-without-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-without-existing-cluster.md
@@ -114,12 +114,16 @@ The app manager can be installed either into an existing Kubernetes cluster or a
 
 To create the test server and install the app manager:
 
-1. Create a server using any cloud provider (GCP, AWS, etc.) or a local virtual machine. Ensure the following criteria:
+1. Create a server using any cloud provider (such as GCP or AWS). Or, use a local virtual machine. The server must meet the following criteria:
 
     * Ubuntu 18.04
     * At least 8 GB of RAM
     * 4 CPU cores
     * At least 50GB of disk space
+
+    :::note
+    If you use a virtual machine that is behind a firewall, make sure that port 8800 (and any other ports you attempt to access through the internet) are allowed to accept traffic. GCP and AWS typically require firewall rule creation to expose ports.
+    :::
 
 1. Use SSH to access the server you just created.
 1. Run the installation script:
@@ -173,7 +177,7 @@ To install the application:
 1. In a browser, enter the URL from the `Kotsadm:` field in the CLI output of the installation script. For more information about the installation script, see [Create a Test Server and Install the App Manager](#create-a-test-server-and-install-the-app-manager) above. Notice that the [Kubernetes installer](https://kurl.sh) cluster has provisioned a self-signed certificate.
 
   :::note
-  If your virtual machine is behind a firewall, make sure port 8800 (and any other ports you attempt to access through the internet) are allowed to accept traffic. GCP and AWS typically require firewall rule creation to expose ports.
+  If your virtual machine is behind a firewall, make sure that port 8800 (and any other ports you attempt to access through the internet) are allowed to accept traffic. GCP and AWS typically require firewall rule creation to expose ports.
   :::
 
 1. Bypass the insecure certificate warning. You have the option of uploading a trusted certificate and key.

--- a/docs/vendor/tutorial-installing-without-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-without-existing-cluster.md
@@ -114,16 +114,12 @@ The app manager can be installed either into an existing Kubernetes cluster or a
 
 To create the test server and install the app manager:
 
-1. Create a server using Google Cloud and the following criteria:
+1. Create a server using any cloud provider (GCP, AWS, etc.) or a local virtual machine. Ensure the following criteria:
 
     * Ubuntu 18.04
     * At least 8 GB of RAM
     * 4 CPU cores
     * At least 50GB of disk space
-
-  :::note
-  You can also use any cloud provider or local virtual machine.
-  :::
 
 1. Use SSH to access the server you just created.
 1. Run the installation script:
@@ -139,7 +135,6 @@ To create the test server and install the app manager:
   After the installation script completes the initial installation, the output displays the connection URL and password that you must use in a later step of the installation process:
 
   ```text
-
   Kotsadm: http://[ip-address]:8800
   Login with password (will not be shown again): [password]
   ```
@@ -151,36 +146,22 @@ To create the test server and install the app manager:
 1. Reload your shell to access the cluster with `kubectl`:
 
   ```
-    bash -l
+  bash -l
   ```
 
-    The UIs of Prometheus, Grafana and Alertmanager have been exposed on NodePorts 30900, 30902 and 30903 respectively.
-
-1. Use the generated user:password of admin:[password] to access Grafana.
-
-1. Run the following script on your other nodes to add worker nodes to this installation:
-
-  ```
-    curl -sSL https://kurl.sh/starter-kots-demo-unstable/join.sh | sudo bash -s kubernetes-master-address=[ip-address]:6443 kubeadm-token=[token] kubeadm-token-ca-hash=sha256:[sha] kubernetes-version=1.16.4 docker-registry-ip=[ip-address]
-
-    ```
-
-1. Reload the shell, following the instructions on the screen, to make `kubectl` now work:
+1. Run a `kubectl` command to test:
 
   ```bash
-  user@kots-guide:~$ kubectl get pods
+  kubectl get pods
   ```
 
   **Example output:**
 
   ```
-  NAME                                  READY   STATUS      RESTARTS   AGE
-  kotsadm-585579b884-v4s8m              1/1     Running     0          4m47s
-  kotsadm-migrations                    0/1     Completed   2          4m47s
-  kotsadm-operator-fd9d5d5d7-8rrqg      1/1     Running     0          4m47s
-  kotsadm-postgres-0                    1/1     Running     0          4m47s
-  kurl-proxy-kotsadm-77c59cddc5-qs5bm   1/1     Running     0          4m46s
-  user@kots-guide:~$
+  NAME                                  READY   STATUS    RESTARTS   AGE
+  kotsadm-79dcb4dc7d-2xh85              1/1     Running   0          60m
+  kotsadm-postgres-0                    1/1     Running   0          60m
+  kurl-proxy-kotsadm-5f7fb75f47-b7jbz   1/1     Running   0          60m
   ```
 
 ### Install the Application
@@ -190,6 +171,10 @@ At this point, Kubernetes and the Replicated admin console are running, but the 
 To install the application:
 
 1. In a browser, enter the URL from the `Kotsadm:` field in the CLI output of the installation script. For more information about the installation script, see [Create a Test Server and Install the App Manager](#create-a-test-server-and-install-the-app-manager) above. Notice that the [Kubernetes installer](https://kurl.sh) cluster has provisioned a self-signed certificate.
+
+  :::note
+  If your virtual machine is behind a firewall, make sure port 8800 (and any other ports you attempt to access through the internet) are allowed to accept traffic. GCP and AWS typically require firewall rule creation to expose ports.
+  :::
 
 1. Bypass the insecure certificate warning. You have the option of uploading a trusted certificate and key.
   For production installations, we recommend using a trusted certificate. For this tutorial, use the self-signed certificate.

--- a/docs/vendor/tutorial-installing-without-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-without-existing-cluster.md
@@ -153,7 +153,7 @@ To create the test server and install the app manager:
   bash -l
   ```
 
-1. Run a `kubectl` command to test:
+1. Run a `kubectl` command to test that `kubectl` is working:
 
   ```bash
   kubectl get pods


### PR DESCRIPTION
Provided updates to clear up some confusing bits in the embedded tutorial, specifically around the getting started steps. These are recommendations, won't be surprised if some or all or rejected! Hope it's helpful.

- Condense instruction about using GCP and note about using other providers to a single instruction, avoids recommending GCP above others and helps clarify that all methods work equally
- Remove extra steps from install instructions. The output from kurl install is translated into steps in the tutorial, but this is a hand holding walkthrough and some steps are out of scope, and are also printed verbatim in the kurl install output for users that want them:
  - instructions to access Grafana
  - instructions to add worker nodes
- Remove prompt from `kubectl get pods` command block - this block has a copy/paste button, but it copies the prompt too, so the pasted command doesn't work
- Update example successful `kubectl get pods` output to be match what a user following this particular tutorial will see (operator and migration pods won't be there, for example)
- Added a note calling out the need to add firewall rules for many cloud providers - I ran into this a while back and we weren't sure why I couldn't successfully follow this tutorial, but it was due to the default GCP firewall and AWS has a similar default setup
  