### PR TITLE
57161: Added a list of supported `kots velero` commands

### DIFF
--- a/docs/reference/kots-cli-velero-index.md
+++ b/docs/reference/kots-cli-velero-index.md
@@ -10,9 +10,7 @@ kubectl kots velero [command] [global flags]
 
 This command supports all [global flags](kots-cli-global-flags).
 
-#### Available Commands
-
-The following `kots velero` commands are supported. For more information about these commands, see the listing for a specific command:
+The following `kots velero` commands are supported:
 
 - [`configure-aws-s3`](kots-cli-velero-configure-aws-s3): Configures an AWS S3 bucket as the storage destination.
 - [`configure-azure`](kots-cli-velero-configure-azure): Configures an Azure Blob Storage Container as the storage destination.

--- a/docs/reference/kots-cli-velero-index.md
+++ b/docs/reference/kots-cli-velero-index.md
@@ -1,11 +1,25 @@
 # velero
 
-KOTS Velero interface
+The KOTS Velero interface, which configures storage destinations for backups (snapshots), permissions, and print instructions fo set up.
 
 ### Usage
 
 ```bash
-kubectl kots velero [command]
+kubectl kots velero [command] [global flags]
 ```
 
 This command supports all [global flags](kots-cli-global-flags).
+
+#### Available Commands
+
+The following `kots velero` commands are supported. For more information about these commands, see the listing for a specific command:
+
+- [`configure-aws-s3`](kots-cli-velero-configure-aws-s3): Configures an AWS S3 bucket as the storage destination.
+- [`configure-azure`](kots-cli-velero-configure-azure): Configures an Azure Blob Storage Container as the storage destination.
+- [`configure-gcp`](kots-cli-velero-configure-gcp): Configures a Google Cloud Platform Object Storage Bucket as The storage destination.
+- [`configure-internal`](kots-cli-velero-configure-internal): (Kubernetes installer clusters only) Configures the internal object store in the cluster as the storage destination.
+- [`configure-other-s3`](kots-cli-velero-configure-other-s3): Configures an S3-compatible storage provider as the storage destination.
+- [`configure-nfs`](kots-cli-velero-configure-nfs): Configures NFS as the storage destination.
+- [`configure-hostpath`](kots-cli-velero-configure-hostpath): Configures a host path as the storage destination.
+- [`ensure-permissions`](kots-cli-velero-ensure-permissions): Allows the Replicated admin console to access Velero.
+- [`print-fs-instructions`](kots-cli-velero-print-fs-instructions): Prints instructions for setting up Velero with the current file system configuration.

--- a/sidebars.js
+++ b/sidebars.js
@@ -420,8 +420,8 @@ const sidebars = {
                   'reference/kots-cli-velero-configure-other-s3',
                   'reference/kots-cli-velero-configure-nfs',
                   'reference/kots-cli-velero-configure-hostpath',
-                  'reference/kots-cli-velero-print-fs-instructions',
                   'reference/kots-cli-velero-ensure-permissions',
+                  'reference/kots-cli-velero-print-fs-instructions',
               ],
             },
             {


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/57161/add-list-of-kots-cli-configure-commands-to-the-main-velero-section

Preview: https://deploy-preview-594--replicated-docs.netlify.app/reference/kots-cli-velero-index