### PR TITLE
56781: Updated Kubernetes Version Compatibility Table

### DIFF
--- a/docs/enterprise/installing-general-requirements.md
+++ b/docs/enterprise/installing-general-requirements.md
@@ -23,7 +23,9 @@ The following table lists the browser requirements for the latest Replicated adm
 
 Each release of the open source KOTS project maintains compatibility with the current Kubernetes version, and the two most recent versions at the time of its release. This includes support against all patch releases of the corresponding Kubernetes version.
 
-Kubernetes versions 1.21 and earlier are end-of-life (EOL), however Replicated still maintains KOTS support for the EOL Kubernetes versions listed in the following table. For more information about Kubernetes versions, see [Release History](https://kubernetes.io/releases/) in the Kubernetes documentation.
+Kubernetes versions 1.21 and earlier are end-of-life (EOL). For more information about Kubernetes versions, see [Release History](https://kubernetes.io/releases/) in the Kubernetes documentation.
+
+It is recommended to upgrade to a KOTS version that is compatible with Kubernetes 1.22 and higher. 
 
 :::note
 The app manager is based on the open source KOTS project. The app manager version is the same as the KOTS version. For example, KOTS v1.48 is the same as the app manager v1.48.

--- a/docs/enterprise/installing-general-requirements.md
+++ b/docs/enterprise/installing-general-requirements.md
@@ -21,9 +21,9 @@ The following table lists the browser requirements for the latest Replicated adm
 
 ## Kubernetes Version Compatibility
 
-Each release of the open source KOTS project maintains compatibility with the current Kubernetes version, and the two most recent versions at the time of its release.
+Each release of the open source KOTS project maintains compatibility with the current Kubernetes version, and the two most recent versions at the time of its release. This includes support against all patch releases of the corresponding Kubernetes version.
 
-This includes support against all patch releases of the corresponding Kubernetes version.
+Kubernetes versions 1.21 and earlier are end-of-life (EOL), however Replicated still maintains KOTS support for the EOL Kubernetes versions listed in the following table. For more information about Kubernetes versions, see [Release History](https://kubernetes.io/releases/) in the Kubernetes documentation.
 
 :::note
 The app manager is based on the open source KOTS project. The app manager version is the same as the KOTS version. For example, KOTS v1.48 is the same as the app manager v1.48.
@@ -40,10 +40,6 @@ The app manager is based on the open source KOTS project. The app manager versio
 | v1.20 to v1.35  | v1.19, v1.18, and v1.17 |
 | v1.15 to v1.19  | v1.18, v1.17, and v1.16 |
 | v1.11 to v1.14  | v1.17, v1.16, and v1.15 |
-
-:::note
-Kubernetes versions 1.21 and earlier are end-of-life, however Replicated still maintains KOTS support for these Kubernetes versions. For more information about Kubernetes versions, see [Release History](https://kubernetes.io/releases/) in the Kubernetes documentation.
-:::
 
 ## Minimum System Requirements
 

--- a/docs/enterprise/installing-general-requirements.md
+++ b/docs/enterprise/installing-general-requirements.md
@@ -31,17 +31,19 @@ The app manager is based on the open source KOTS project. The app manager versio
 
 | KOTS Versions   | Kubernetes Compatibility |
 |-----------------|---------------------------|
-| v1.71 and later | v1.24, v1.23, v1.22, and v1.21*|
-| v1.66 to v1.70 | v1.23, v1.22, and v1.21*   |
-| v1.61 to v1.65 | v1.23, v1.22, v1.21*, and v1.20*|
-| v1.59.3 to v1.60 | v1.22, v1.21*, and v1.20* |
-| v1.48 to v1.59.2 | v1.21*, v1.20*, and v1.19*|
-| v1.36 to v1.47  | v1.20*, v1.19*, and v1.18* |
-| v1.20 to v1.35  | v1.19*, v1.18*, and v1.17* |
-| v1.15 to v1.19  | v1.18*, v1.17*, and v1.16* |
-| v1.11 to v1.14  | v1.17*, v1.16*, and v1.15* |
+| v1.71 and later | v1.24, v1.23, v1.22, and v1.21|
+| v1.66 to v1.70 | v1.23, v1.22, and v1.21   |
+| v1.61 to v1.65 | v1.23, v1.22, v1.21, and v1.20|
+| v1.59.3 to v1.60 | v1.22, v1.21, and v1.20 |
+| v1.48 to v1.59.2 | v1.21, v1.20, and v1.19|
+| v1.36 to v1.47  | v1.20, v1.19, and v1.18 |
+| v1.20 to v1.35  | v1.19, v1.18, and v1.17 |
+| v1.15 to v1.19  | v1.18, v1.17, and v1.16 |
+| v1.11 to v1.14  | v1.17, v1.16, and v1.15 |
 
-`*`  Indicates Kubernetes versions that are end-of-life information, however Replicated still maintains KOTS support for these Kubernetes versions.
+:::note
+Kubernetes versions 1.21 and earlier are end-of-life, however Replicated still maintains KOTS support for these Kubernetes versions. For more information about Kubernetes versions, see [Release History](https://kubernetes.io/releases/) in the Kubernetes documentation.
+:::
 
 ## Minimum System Requirements
 

--- a/docs/enterprise/installing-general-requirements.md
+++ b/docs/enterprise/installing-general-requirements.md
@@ -25,7 +25,7 @@ Each release of the open source KOTS project maintains compatibility with the cu
 
 Kubernetes versions 1.21 and earlier are end-of-life (EOL). For more information about Kubernetes versions, see [Release History](https://kubernetes.io/releases/) in the Kubernetes documentation.
 
-It is recommended to upgrade to a KOTS version that is compatible with Kubernetes 1.22 and higher. 
+Replicated recommends upgrading to a KOTS version that is compatible with Kubernetes 1.22 and higher. 
 
 :::note
 The app manager is based on the open source KOTS project. The app manager version is the same as the KOTS version. For example, KOTS v1.48 is the same as the app manager v1.48.

--- a/docs/enterprise/installing-general-requirements.md
+++ b/docs/enterprise/installing-general-requirements.md
@@ -29,17 +29,19 @@ This includes support against all patch releases of the corresponding Kubernetes
 The app manager is based on the open source KOTS project. The app manager version is the same as the KOTS version. For example, KOTS v1.48 is the same as the app manager v1.48.
 :::
 
-| KOTS versions   | Kubernetes compatibility |
+| KOTS Versions   | Kubernetes Compatibility |
 |-----------------|---------------------------|
-| v1.11 to v1.14  | v1.17, v1.16, and v1.15   |
-| v1.15 to v1.19  | v1.18, v1.17, and v1.16   |
-| v1.20 to v1.35  | v1.19, v1.18, and v1.17   |
-| v1.36 to v1.47  | v1.20, v1.19, and v1.18   |
-| v1.48 to v1.59.2 | v1.21, v1.20, and v1.19   |
-| v1.59.3 to v1.60 | v1.22, v1.21, and v1.20   |
-| v1.61 to v1.65 | v1.23, v1.22, v1.21, and v1.20|
-| v1.66 to v1.70 | v1.23, v1.22, and v1.21   |
-| v1.71 and later | v1.24, v1.23, v1.22, and v1.21   |
+| v1.71 and later | v1.24, v1.23, v1.22**, and v1.21*|
+| v1.66 to v1.70 | v1.23, v1.22, and v1.21*   |
+| v1.61 to v1.65 | v1.23, v1.22, v1.21*, and v1.20*|
+| v1.59.3 to v1.60 | v1.22, v1.21*, and v1.20* |
+| v1.48 to v1.59.2 | v1.21*, v1.20*, and v1.19*|
+| v1.36 to v1.47  | v1.20*, v1.19*, and v1.18* |
+| v1.20 to v1.35  | v1.19*, v1.18*, and v1.17* |
+| v1.15 to v1.19  | v1.18*, v1.17*, and v1.16* |
+| v1.11 to v1.14  | v1.17*, v1.16*, and v1.15* |
+
+`*`  Indicates Kubernetes versions that are no longer supported or maintained. For Kubernetes end-of-life information, see [Release History](https://kubernetes.io/releases) in the Kubernetes documentation.
 
 ## Minimum System Requirements
 

--- a/docs/enterprise/installing-general-requirements.md
+++ b/docs/enterprise/installing-general-requirements.md
@@ -31,7 +31,7 @@ The app manager is based on the open source KOTS project. The app manager versio
 
 | KOTS Versions   | Kubernetes Compatibility |
 |-----------------|---------------------------|
-| v1.71 and later | v1.24, v1.23, v1.22**, and v1.21*|
+| v1.71 and later | v1.24, v1.23, v1.22, and v1.21*|
 | v1.66 to v1.70 | v1.23, v1.22, and v1.21*   |
 | v1.61 to v1.65 | v1.23, v1.22, v1.21*, and v1.20*|
 | v1.59.3 to v1.60 | v1.22, v1.21*, and v1.20* |
@@ -41,7 +41,7 @@ The app manager is based on the open source KOTS project. The app manager versio
 | v1.15 to v1.19  | v1.18*, v1.17*, and v1.16* |
 | v1.11 to v1.14  | v1.17*, v1.16*, and v1.15* |
 
-`*`  Indicates Kubernetes versions that are no longer supported or maintained. For Kubernetes end-of-life information, see [Release History](https://kubernetes.io/releases) in the Kubernetes documentation.
+`*`  Indicates Kubernetes versions that are end-of-life information, however Replicated still maintains KOTS support for these Kubernetes versions.
 
 ## Minimum System Requirements
 


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/56781/kubernetes-version-compatibility-table-should-not-include-unsupported-k8s-version

Preview: https://deploy-preview-597--replicated-docs.netlify.app/enterprise/installing-general-requirements#kubernetes-version-compatibility