### PR TITLE
Added default values to kots CLI install reference info

### DIFF
--- a/docs/reference/kots-cli-install.md
+++ b/docs/reference/kots-cli-install.md
@@ -24,7 +24,7 @@ This command supports all [global flags](kots-cli-global-flags) and also:
 | `--config-values`           | string | Path to a manifest file containing configuration values. This manifest must be `apiVersion: kots.io/v1beta1` and `kind: ConfigValues`. For more information, see [Define Application Configuration Values](../enterprise/installing-existing-cluster-automation#define-application-configuration-values).|
 | `--copy-proxy-env`          | bool   | Copy proxy environment variables from current environment into all admin console components. **Default:** `false`|
 | `--disable-image-push`      | bool   | Set to `true` to disable images from being pushed to private registry. **Default:** `false`|
-| `--ensure-rbac`             | bool   | When set to `true`, KOTS skips RBAC configuration at installation time. **Default:** `false`. If a role specification is needed, use the [generate-manifests](kots-cli-admin-console-generate-manifests) command. |
+| `--ensure-rbac`             | bool   | When set to `true`, KOTS configures RBAC at installation time. **Default:** `true`. If a role specification is needed, use the [generate-manifests](kots-cli-admin-console-generate-manifests) command. |
 | `-h, --help`                |        | Help for install. |
 | `--http-proxy`              | string | Sets HTTP_PROXY environment variable in all admin console components.  |
 | `--https-proxy`             | string | Sets HTTPS_PROXY environment variable in all admin console components. |

--- a/docs/reference/kots-cli-install.md
+++ b/docs/reference/kots-cli-install.md
@@ -18,13 +18,13 @@ This command supports all [global flags](kots-cli-global-flags) and also:
 
 | Flag                        | Type   | Description                                                                                                                                                                                           |
 |:----------------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--airgap`                  | bool   | Set to true to run install in air gapped mode. Setting `--airgap-bundle` implies `--airgap=true`. For more information, see [Installing in an Air Gapped Environment](../enterprise/installing-existing-cluster#air-gap). |
+| `--airgap`                  | bool   | Set to `true` to run install in air gapped mode. Setting `--airgap-bundle` implies `--airgap=true`. **Default:** `false`. For more information, see [Installing in an Air Gapped Environment](../enterprise/installing-existing-cluster#air-gap). |
 | `--airgap-bundle`           | string | Path to the application air gap bundle where application metadata will be loaded from. Setting `--airgap-bundle` implies `--airgap=true`. For more information, see [Installing in an Air Gapped Environment](../enterprise/installing-existing-cluster#air-gap).|
 | `--app-version-label`       | string | The application version label to install. If not specified, the latest version is installed. |
 | `--config-values`           | string | Path to a manifest file containing configuration values. This manifest must be `apiVersion: kots.io/v1beta1` and `kind: ConfigValues`. For more information, see [Define Application Configuration Values](../enterprise/installing-existing-cluster-automation#define-application-configuration-values).|
-| `--copy-proxy-env`          | bool   | Copy proxy environment variables from current environment into all admin console components. |
-| `--disable-image-push`      | bool   | Set to true to disable images from being pushed to private registry. |
-| `--ensure-rbac`             | bool   | When set to true, KOTS skips RBAC configuration at installation time. **Default:** false. If a role specification is needed, use the [generate-manifests](kots-cli-admin-console-generate-manifests) command. |
+| `--copy-proxy-env`          | bool   | Copy proxy environment variables from current environment into all admin console components. **Default:** `false`|
+| `--disable-image-push`      | bool   | Set to `true` to disable images from being pushed to private registry. **Default:** `false`|
+| `--ensure-rbac`             | bool   | When set to `true`, KOTS skips RBAC configuration at installation time. **Default:** `false`. If a role specification is needed, use the [generate-manifests](kots-cli-admin-console-generate-manifests) command. |
 | `-h, --help`                |        | Help for install. |
 | `--http-proxy`              | string | Sets HTTP_PROXY environment variable in all admin console components.  |
 | `--https-proxy`             | string | Sets HTTPS_PROXY environment variable in all admin console components. |
@@ -33,22 +33,22 @@ This command supports all [global flags](kots-cli-global-flags) and also:
 | `--license-file`            | string | Path to a license file. Required when [`--upstream-uri`](kots-cli-upload#usage) points to a Replicated application. |
 | `--local-path`              | string | Specify a local-path to test the behavior of rendering a Replicated application locally. Only supported on Replicated application types.   |
 | `--name`                    | string | Name of the application to use in the admin console. |
-| `--no-port-forward`         | bool   | Set to true to disable automatic port forward. **Default:** false |
+| `--no-port-forward`         | bool   | Set to `true` to disable automatic port forward. **Default:** `false` |
 | `--no-proxy`                | string | Sets NO_PROXY environment variable in all admin console components. |
-| `--port`                    | string | Override the local port to access the admin console. Default: 8800 |
+| `--port`                    | string | Override the local port to access the admin console. **Default:** 8800 |
 | `--preflights-wait-duration`| string | Timeout to be used while waiting for preflights to complete. Must be in [Go duration](https://pkg.go.dev/time#ParseDuration) format. For example, 10s, 2m. **Default:** 15m |
 | `--registry-password`       | string | Password to use to authenticate with the application registry. Used for air gapped installations. For more information, see [Installing in an Air Gapped Environment](../enterprise/installing-existing-cluster#air-gap).|
 | `--registry-username`       | string | Username to use to authenticate with the application registry. Used for air gapped installations. For more information, see [Installing in an Air Gapped Environment](../enterprise/installing-existing-cluster#air-gap).|
-| `--repo`                    | string | Repo URI to use when installing a Helm chart |
-| `--set`                     | strings| Values to pass to Helm when running `helm template` |
+| `--repo`                    | string | Repo URI to use when installing a Helm chart. |
+| `--set`                     | strings| Values to pass to Helm when running `helm template`. |
 | `--shared-password`         | string | Shared password to use when deploying the admin console.  |
-| `--skip-compatibility-check`| bool   | Set to true to skip compatibility checks between the current KOTS version and the application |
-| `--skip-preflights`         | bool   | Set to true to skip preflight checks. If any strict preflight checks are configured, the `--skip-preflights` flag is not honored because strict preflight checks must run and contain no failures before the application is deployed. For more information, see [About Preflight Checks and Support Bundles](../vendor/preflight-support-bundle-creating#about-preflight-checks-and-support-bundles).|
-| `--skip-rbac-check`         | bool   | Set to true to bypass RBAC check |
-| `--strict-security-context` | bool   | Set to true to explicitly enable explicit security contexts for all KOTS pods and containers. **Note**: Might not work for some storage providers. |
-| `--use-minimal-rbac`        | bool   | When set to true, KOTS is namespace-scoped if the application supports namespace scoped installations |
+| `--skip-compatibility-check`| bool   | Set to `true` to skip compatibility checks between the current KOTS version and the application. **Default:** `false` |
+| `--skip-preflights`         | bool   | Set to `true` to skip preflight checks. **Default:** `false`. If any strict preflight checks are configured, the `--skip-preflights` flag is not honored because strict preflight checks must run and contain no failures before the application is deployed. For more information, see [About Preflight Checks and Support Bundles](/vendor/preflight-support-bundle-creating#about-preflight-checks-and-support-bundles).|
+| `--skip-rbac-check`         | bool   | Set to `true` to bypass RBAC check. **Default:** `false`|
+| `--strict-security-context` | bool   | Set to `true` to explicitly enable explicit security contexts for all KOTS pods and containers. **Default:** `false`. **Note**: Might not work for some storage providers. |
+| `--use-minimal-rbac`        | bool   | When set to `true`, KOTS is namespace-scoped if the application supports namespace scoped installations. **Default:** `false` |
 | `--wait-duration`           | string | Timeout to be used while waiting for individual components to be ready. Must be in [Go duration](https://pkg.go.dev/time#ParseDuration) format. For example, 10s, 2m. **Default:** 2m |
-| `--with-minio`              | bool   | When set to true, KOTS deploys a local MinIO instance for storage and uses MinIO for host path and NFS snapshot storage. **Default:** true |
+| `--with-minio`              | bool   | When set to `true`, KOTS deploys a local MinIO instance for storage and uses MinIO for host path and NFS snapshot storage. **Default:** `true` |
 
 ### Examples
 


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/56888/all-flags-in-the-cli-reference-should-include-information-on-the-default

Preview: https://deploy-preview-599--replicated-docs.netlify.app/reference/kots-cli-install#usage