### PR TITLE
57300: Hostname field required for Identity Service

### DIFF
--- a/docs/enterprise/auth-identity-provider.md
+++ b/docs/enterprise/auth-identity-provider.md
@@ -13,9 +13,9 @@ The identity service has the following limitations:
 * Only available for installations onto a cluster created by the Kubernetes installer.
 * Only available through the admin console.
 
-## Prerequisites
+## Prerequisite
 
-Configure the hostname used to access the admin console. This is done during installation of the admin console, when you are setting up TLS certificates on the HTTPS page. Hostname is required whether you are using identity service with either a self-signed certificate or a custom certificate. For more information about configuring the hostname field, see [Completing Application Setup and Deploying](installing-app-setup).
+When you are installing the admin console and setting up TLS certificates on the HTTPS page, you must configure the hostname to use to access the admin console. The hostname is required whether you are using the identity service with either a self-signed certificate or a custom certificate. For more information about configuring the hostname field, see [Completing Application Setup and Deploying](installing-app-setup).
 
 ## Configuration
 

--- a/docs/enterprise/auth-identity-provider.md
+++ b/docs/enterprise/auth-identity-provider.md
@@ -15,7 +15,7 @@ The identity service has the following limitations:
 
 ## Prerequisites
 
-Configure the hostname used to access the admin console. This is done during installation of the admin console, when you are setting up TLS certificates on the HTTPS page. Hostname is required whether you are using identity service with either a self-signed certificate or a custom certificate. Fo more information about configuring the hostname field, see [Completing Application Setup and Deploying](installing-app-setup).
+Configure the hostname used to access the admin console. This is done during installation of the admin console, when you are setting up TLS certificates on the HTTPS page. Hostname is required whether you are using identity service with either a self-signed certificate or a custom certificate. For more information about configuring the hostname field, see [Completing Application Setup and Deploying](installing-app-setup).
 
 ## Configuration
 

--- a/docs/enterprise/auth-identity-provider.md
+++ b/docs/enterprise/auth-identity-provider.md
@@ -15,7 +15,7 @@ The identity service has the following limitations:
 
 ## Prerequisites
 
-Configure the hostname used to access the admin console. This is done during installation of the admin console, when you are setting up TLS certificates on the HTTPS page. Hostname is required whether you are using identity service with either a self-signed certificate or a custom certificate. Fo more information about configuring the hostname field, see [Completing Application Setup and Deploying](installing-ap-setup).
+Configure the hostname used to access the admin console. This is done during installation of the admin console, when you are setting up TLS certificates on the HTTPS page. Hostname is required whether you are using identity service with either a self-signed certificate or a custom certificate. Fo more information about configuring the hostname field, see [Completing Application Setup and Deploying](installing-app-setup).
 
 ## Configuration
 

--- a/docs/enterprise/auth-identity-provider.md
+++ b/docs/enterprise/auth-identity-provider.md
@@ -13,6 +13,10 @@ The identity service has the following limitations:
 * Only available for installations onto a cluster created by the Kubernetes installer.
 * Only available through the admin console.
 
+## Prerequisites
+
+Configure the hostname used to access the admin console. This is done during installation of the admin console, when you are setting up TLS certificates on the HTTPS page. Hostname is required whether you are using identity service with either a self-signed certificate or a custom certificate. Fo more information about configuring the hostname field, see [Completing Application Setup and Deploying](installing-ap-setup).
+
 ## Configuration
 
 To begin, click the **Access** tab at the top of the admin console.

--- a/docs/enterprise/installing-app-setup.md
+++ b/docs/enterprise/installing-app-setup.md
@@ -26,12 +26,10 @@ To complete application setup and deploy from the admin console:
 
 1. (Kubernetes Installer Cluster Only) On the Bypass Browser TLS warning page, review the information about how to bypass the browser TLS warning, and then click **Continue to Setup**.
 
-1. (Kubernetes Installer Cluster Only) On the HTTPS page, do one of the following. Using identity service with either certificate type is optional.
+1. (Kubernetes Installer Cluster Only) On the HTTPS page, do one of the following:
 
-    - To use the self-signed TLS certificate only, click **Skip & continue**.
-    - To use a custom certificate only, upload a private key and SSL certificate to secure communication between your browser and the admin console. Then, click **Upload & continue**.
-    - To use identity service with the self-signed certificate, enter the hostname and click **Skip & continue**.
-    -  To use identity service with a custom certificate, enter the hostname. Then, upload a private key and SSL certificate, and click **Upload & continue**.
+    - To use the self-signed TLS certificate only, enter the hostname (required) if you are using identity service. If you are not using identity service, hostname is optional. Click **Skip & continue**.
+    - To use a custom certificate only, enter the hostname (required) if you are using identity service. If you are not using identity service, hostname is optional. Then upload a private key and SSL certificate to secure communication between your browser and the admin console. Click **Upload & continue**.
 
 1. Log in to the admin console:
    * **Existing cluster**: Log in with the password that you created during installation.

--- a/docs/enterprise/installing-app-setup.md
+++ b/docs/enterprise/installing-app-setup.md
@@ -28,8 +28,8 @@ To complete application setup and deploy from the admin console:
 
 1. (Kubernetes Installer Cluster Only) On the HTTPS page, do one of the following:
 
-    - To use the self-signed TLS certificate only, enter the hostname (required) if you are using identity service. If you are not using identity service, the hostname is optional. Click **Skip & continue**.
-    - To use a custom certificate only, enter the hostname (required) if you are using identity service. If you are not using identity service, the hostname is optional. Then upload a private key and SSL certificate to secure communication between your browser and the admin console. Click **Upload & continue**.
+    - To use the self-signed TLS certificate only, enter the hostname (required) if you are using the identity service. If you are not using the identity service, the hostname is optional. Click **Skip & continue**.
+    - To use a custom certificate only, enter the hostname (required) if you are using the identity service. If you are not using the identity service, the hostname is optional. Then upload a private key and SSL certificate to secure communication between your browser and the admin console. Click **Upload & continue**.
 
 1. Log in to the admin console:
    * **Existing cluster**: Log in with the password that you created during installation.

--- a/docs/enterprise/installing-app-setup.md
+++ b/docs/enterprise/installing-app-setup.md
@@ -26,7 +26,12 @@ To complete application setup and deploy from the admin console:
 
 1. (Kubernetes Installer Cluster Only) On the Bypass Browser TLS warning page, review the information about how to bypass the browser TLS warning, and then click **Continue to Setup**.
 
-1. (Kubernetes Installer Cluster Only) On the HTTPS page, upload a private key and SSL certificate to secure communication between your browser and the admin console. Then, click **Upload & continue**. Alternatively, click **Skip & continue** to use the self-signed TLS certificate.
+1. (Kubernetes Installer Cluster Only) On the HTTPS page, do one of the following. Using identity service with either certificate type is optional.
+
+    - To use the self-signed TLS certificate only, click **Skip & continue**.
+    - To use a custom certificate only, upload a private key and SSL certificate to secure communication between your browser and the admin console. Then, click **Upload & continue**.
+    - To use identity service with the self-signed certificate, enter the hostname and click **Skip & continue**.
+    -  To use identity service with a custom certificate, enter the hostname. Then, upload a private key and SSL certificate, and click **Upload & continue**.
 
 1. Log in to the admin console:
    * **Existing cluster**: Log in with the password that you created during installation.

--- a/docs/enterprise/installing-app-setup.md
+++ b/docs/enterprise/installing-app-setup.md
@@ -28,8 +28,8 @@ To complete application setup and deploy from the admin console:
 
 1. (Kubernetes Installer Cluster Only) On the HTTPS page, do one of the following:
 
-    - To use the self-signed TLS certificate only, enter the hostname (required) if you are using identity service. If you are not using identity service, hostname is optional. Click **Skip & continue**.
-    - To use a custom certificate only, enter the hostname (required) if you are using identity service. If you are not using identity service, hostname is optional. Then upload a private key and SSL certificate to secure communication between your browser and the admin console. Click **Upload & continue**.
+    - To use the self-signed TLS certificate only, enter the hostname (required) if you are using identity service. If you are not using identity service, the hostname is optional. Click **Skip & continue**.
+    - To use a custom certificate only, enter the hostname (required) if you are using identity service. If you are not using identity service, the hostname is optional. Then upload a private key and SSL certificate to secure communication between your browser and the admin console. Click **Upload & continue**.
 
 1. Log in to the admin console:
    * **Existing cluster**: Log in with the password that you created during installation.


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/57300/enterprise-identity-service-docs-should-mention-how-to-configure-the-hostname-for-the-admin-console

Previews:

- https://deploy-preview-612--replicated-docs.netlify.app/enterprise/auth-identity-provider#prerequisites
- https://deploy-preview-612--replicated-docs.netlify.app/enterprise/installing-app-setup#access-the-admin-console-and-deploy-the-application