### PR TITLE
Remove separate Tutorials section

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -7,12 +7,12 @@ Welcome! This topic describes how to get started with Replicated as a software v
 
 ## Get Started with Replicated
 
-The Getting Started section includes an overview of the Replicated product as well as tutorials that help vendors learn how to use Replicated by completing common tasks with sample applications.
+The Getting Started section includes an overview of the Replicated product, as well as tutorials that help vendors learn about Replicated by completing common tasks with sample applications.
 
-To get started, see [What is Replicated?](intro-replicated) and complete the following introductory tutorials designed to help you learn the product:
-* [Managing Releases with the CLI](tutorial-installing-with-cli)
+To get started, see [What is Replicated?](intro-replicated) and complete the following introductory tutorials:
 * [Packaging and Installing on an Existing Cluster](tutorial-installing-with-existing-cluster)
 * [Packaging and Installing on a Kubernetes Installer Cluster](tutorial-installing-without-existing-cluster)
+* [Managing Releases with the CLI](tutorial-installing-with-cli)
 
 ## About the Replicated Documentation
 
@@ -31,4 +31,4 @@ This Replicated product documentation site is divided into the following main se
 
    For more information, see [Overview of Installing an Application with App Manager](enterprise/installing-overview).
 
-* **Reference**: Reference documentation for Replicated custom resources, template functions, CLIs, and the Vendor API. Vendors use this reference material when packaging their applicaiton and when testing the installation process for their application.
+* **Reference**: The Reference section includes reference documentation for Replicated custom resources, template functions, CLIs, and the Vendor API.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -10,15 +10,17 @@ For information about the Replicated product, see [What is Replicated?](intro-re
 
 The Replicated product documentation is divided into the following main sections:
 
- * **Vendor**: The Vendor section includes information for software providers, or
- _vendors_. The topics in this section guide vendors through packaging,
- distributing, and managing their application with Replicated.
+ * **Getting Started**: The Getting Started section includes an overview of the Replicated product as well as tutorials that help vendors learn how to use Replicated by completing common tasks with sample applications. To get started, see [What is Replicated?](intro-replicated).
 
- To get started as a
- vendor, see [How to Distribute an Application](vendor/distributing-workflow).
+ * **Vendor**: The Vendor section guides vendors through packaging,
+ distributing, and updating their application with Replicated.
 
- * **Enterprise**: The Enterprise section includes information for the _enterprise users_
+ To begin packaging your application with Replicated, see [How to Package and Distribute a Production Application](vendor/distributing-workflow).
+
+ * **Enterprise**: The Enterprise section includes information for the enterprise users
  of applications delivered with Replicated. The topics in this section describe
- how enterprise users can install, update, manage, and monitor the application.
+ how enterprise users can install, update, manage, backup and restore, and monitor the application.
 
- To get started as an enterprise user, see [Overview of Installing an Application with App Manager](enterprise/installing-overview).
+   Vendors can reference the documentation in the Enterprise section to test the process of installing and managing their application with Replicated.
+
+   For more information, see [Overview of Installing an Application with App Manager](enterprise/installing-overview).

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -11,8 +11,8 @@ The Getting Started section includes an overview of the Replicated product as we
 
 To get started, see [What is Replicated?](intro-replicated) and complete the following introductory tutorials designed to help you learn the product:
 * [Managing Releases with the CLI](tutorial-installing-with-cli)
-* [Installing with an Existing Cluster](tutorial-installing-with-existing-cluster)
-* [Installing without an Existing Cluster](tutorial-installing-without-existing-cluster)
+* [Packaging and Installing on an Existing Cluster](tutorial-installing-with-existing-cluster)
+* [Packaging and Installing on a Kubernetes Installer Cluster](tutorial-installing-without-existing-cluster)
 
 ## About the Replicated Documentation
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,7 +1,7 @@
 ---
 slug: /
 ---
-# Welcome to Replicated Docs
+# Welcome
 
 Welcome! This topic describes how to get started with Replicated as a software vendor. It also includes information on how to navigate the Replicated product documentation site.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -3,14 +3,20 @@ slug: /
 ---
 # Welcome to Replicated Docs
 
-This topic describes how to navigate the Replicated product documentation site.
-For information about the Replicated product, see [What is Replicated?](intro-replicated).
+Welcome! This topic describes how to get started with Replicated as a software vendor. It also includes information on how to navigate the Replicated product documentation site.
+
+## Get Started with Replicated
+
+The Getting Started section includes an overview of the Replicated product as well as tutorials that help vendors learn how to use Replicated by completing common tasks with sample applications.
+
+To get started, see [What is Replicated?](intro-replicated) and complete the following introductory tutorials designed to help you learn the product:
+* [Managing Releases with the CLI](tutorial-installing-with-cli)
+* [Installing with an Existing Cluster](tutorial-installing-with-existing-cluster)
+* [Installing without an Existing Cluster](tutorial-installing-without-existing-cluster)
 
 ## About the Replicated Documentation
 
-The Replicated product documentation is divided into the following main sections:
-
- * **Getting Started**: The Getting Started section includes an overview of the Replicated product as well as tutorials that help vendors learn how to use Replicated by completing common tasks with sample applications. To get started, see [What is Replicated?](intro-replicated).
+This Replicated product documentation site is divided into the following main sections:
 
  * **Vendor**: The Vendor section guides vendors through packaging,
  distributing, and updating their application with Replicated.
@@ -21,6 +27,8 @@ The Replicated product documentation is divided into the following main sections
  of applications delivered with Replicated. The topics in this section describe
  how enterprise users can install, update, manage, backup and restore, and monitor the application.
 
-   Vendors can reference the documentation in the Enterprise section to test the process of installing and managing their application with Replicated.
+   Vendors reference the documentation in the Enterprise section to test the process of installing and managing their application with Replicated.
 
    For more information, see [Overview of Installing an Application with App Manager](enterprise/installing-overview).
+
+* **Reference**: Reference documentation for Replicated custom resources, template functions, CLIs, and the Vendor API. Vendors use this reference material when packaging their applicaiton and when testing the installation process for their application.

--- a/docs/vendor/config-screen-about.md
+++ b/docs/vendor/config-screen-about.md
@@ -10,7 +10,7 @@ This means that your users can provide configuration values through a user inter
 
 For example, you can use the configuration screen to provide database configuration options for your application. Your users could connect your application to an external database by providing required values in the configuration screen, such as the host, port, and a username and password for the database.
 
-Or, you can also use the configuration screen to provide a database option that runs in the cluster as part of your application. For a tutorial of this use case, see [Adding Database Configuration Options for your Application](tutorial-adding-db-config).
+Or, you can also use the configuration screen to provide a database option that runs in the cluster as part of your application. For a tutorial of this use case, see [Tutorial: Adding Database Configuration Options](tutorial-adding-db-config).
 
 ## Viewing the Configuration Screen
 

--- a/docs/vendor/config-screen-map-inputs.md
+++ b/docs/vendor/config-screen-map-inputs.md
@@ -12,7 +12,7 @@ For example, if you provide an embedded database with your application, you migh
 
 Similarly, you can include fields on the configuration screen where your users can enable a custom ingress controller for the cluster. You then map these user-supplied values to the Ingress custom resources in your application.
 
-For a tutorial of mapping database configuration options in a sample application, see [Adding Database Configuration Options for your Application](tutorial-adding-db-config).
+For a tutorial of mapping database configuration options in a sample application, see [Tutorial: Adding Database Configuration Options](tutorial-adding-db-config).
 
 For an example of adding custom Ingress resources based on user-supplied configuration, see [Configuring Cluster Ingress](packaging-ingress).
 

--- a/docs/vendor/database-config-adding-options.md
+++ b/docs/vendor/database-config-adding-options.md
@@ -1,8 +1,8 @@
-# Adding Database Configuration Options
+# About Adding Persistent Data Stores
 
 You can integrate persistent stores, such as databases, queues, and caches. There are options to give an end user, such as  embedding an instance alongside the application or connecting an application to an external instance that they will manage.
 
-For more information about integrating persistent datastores, see the the [persistent datastores tutorial](tutorial-adding-db-config).
+For more information about integrating persistent datastores, see [Tutorial: Adding Database Configuration Options](tutorial-adding-db-config).
 
 ## Managing Stateful Services
 

--- a/docs/vendor/distributing-workflow.md
+++ b/docs/vendor/distributing-workflow.md
@@ -93,8 +93,8 @@ To iterate on the release of your production application:
         <th width="70%">Description</th>
       </tr>
       <tr>
-        <td><a href="database-config-adding-options">Add Database Configuration Options</a></td>
-        <td>Enable database options and set stateful services.</td>
+        <td><a href="database-config-adding-options">Adding Persistent Data Stores</a></td>
+        <td><p>Integrate persistent stores, such as databases, queues, and caches. </p><p>Add options for your users to either embed a database instance with the application, or connect your application to an external database instance that they manage.</p></td>
       </tr>
       <tr>
         <td><a href="admin-console-customize-app-icon">Customizing the Admin Console and Download Portal</a></td>

--- a/docs/vendor/distributing-workflow.md
+++ b/docs/vendor/distributing-workflow.md
@@ -17,8 +17,8 @@ Complete the following items before you perform this task:
 - Create your account in the Replicated vendor portal. See [Creating a Vendor Account](vendor-portal-creating-account).
 - (Recommended) Complete a tutorial to package, distribute, and install a sample application:
   * [Managing Releases with the CLI](tutorial-installing-with-cli).
-  * [Installing with an Existing Cluster](tutorial-installing-with-existing-cluster).
-  * [Installing without an Existing Cluster](tutorial-installing-without-existing-cluster).
+  * [Packaging and Installing on an Existing Cluster](tutorial-installing-with-existing-cluster).
+  * [Packaging and Installing on a Kubernetes Installer Cluster](tutorial-installing-without-existing-cluster).
 - (Recommended) Send a questionnaire to your customers to gather information about their environments. See [Customer Application Deployment Questionnaire](planning-questionnaire).
 
 ## Creating and Testing Your Initial Release

--- a/docs/vendor/packaging-private-images.md
+++ b/docs/vendor/packaging-private-images.md
@@ -41,7 +41,7 @@ All applications in your vendor portal Team have access to the external registry
 that you add. This means that you can use the images in the external registry across
 multiple apps in the Team.
 
-To follow a tutorial connecting a sample app to an Amazon Elastic Container Registry (ECR), see [Using ECR for Private Images](tutorial-ecr-private-images).
+To follow a tutorial connecting a sample app to an Amazon Elastic Container Registry (ECR), see [Tutorial: Using ECR for Private Images](tutorial-ecr-private-images).
 
 To configure access to your private images in an external registry:
 
@@ -179,4 +179,4 @@ The app manager supports image digests only for online (Internet-connected) inst
 
 ## Related Topic
 
-[Using ECR for Private Images](tutorial-ecr-private-images)
+[Tutoiral: Using ECR for Private Images](tutorial-ecr-private-images)

--- a/docs/vendor/repository-workflow-and-tagging-releases.md
+++ b/docs/vendor/repository-workflow-and-tagging-releases.md
@@ -17,4 +17,4 @@ The recommended workflow is:
 
 ## Related Topic
 
-[Integrating with an Existing CI/CD Platform](tutorial-ci-cd-integration)
+[Tutorial: Integrating with an Existing CI/CD Platform](tutorial-ci-cd-integration)

--- a/docs/vendor/tutorial-adding-db-config.md
+++ b/docs/vendor/tutorial-adding-db-config.md
@@ -1,4 +1,4 @@
-# Adding Database Configuration Options for your Application
+# Tutorial: Adding Database Configuration Options
 
 In this tutorial, we'll explore ways to give your end user the option to either embed a database instance with the application, or connect your application to an external database instance that they will manage.
 We'll use a PostgreSQL database as an example, configuring an example app to connect.

--- a/docs/vendor/tutorial-adding-db-config.md
+++ b/docs/vendor/tutorial-adding-db-config.md
@@ -14,7 +14,12 @@ It is split into 5 sections:
 
 ### Prerequisites
 
-You should have completed one of the installation tutorials, such as [installing without an existing cluster](tutorial-installing-without-existing-cluster), as this guide assumes you have a running instance of `kotsadm` to iterate against in either an existing cluster or Replicated Kubernetes installer-created cluster, and a local git checkout of your application manifests.
+This guide assumes you have:
+
+* A running instance of the Replicated admin console (`kotsadm`) to iterate against in either an existing cluster or a Replicated Kubernetes installer-created cluster. If you do not have a running instance of the admin console on an existing or Kubernetes installer cluster, complete one of the following getting started tutorials to package and install a sample application:
+   * [Packaging and Installing on an Existing Cluster](tutorial-installing-with-existing-cluster)
+   * [Packaging and Installing on a Kubernetes Installer Cluster](tutorial-installing-without-existing-cluster)
+* A local git checkout of your application manifests.
 
 ### Accompanying Code Examples
 

--- a/docs/vendor/tutorial-ci-cd-integration.md
+++ b/docs/vendor/tutorial-ci-cd-integration.md
@@ -1,4 +1,4 @@
-# Integrating with an Existing CI/CD Platform
+# Tutorial: Integrating with an Existing CI/CD Platform
 
 This tutorial demonstrates how you can package and release an application with Replicated within your existing continuous integration and continuous deployment (CI/CD) platform.
 

--- a/docs/vendor/tutorial-ecr-private-images.md
+++ b/docs/vendor/tutorial-ecr-private-images.md
@@ -1,34 +1,24 @@
-# Using ECR for Private Images
+# Tutorial: Using ECR for Private Images
 
 The Replicated app manager supports working with private images stored in Amazon's Elastic Container Registry (ECR).
 
 ## Objective
 
-The purpose of this guide is to walk you through a hello-world example on how to configure Replicated to pull images from a private registry in Amazon's Elastic Container Registry (ECR).
+The purpose of this tutorial is to walk you through a hello-world example on how to configure Replicated to pull images from a private registry in Amazon's Elastic Container Registry (ECR). This tutorial demonstrates the differences between using public and private images in Replicated. 
 
-## Prerequisites & Assumptions
+## Prerequisites
 
-This power-user's guide assumes you have completed the Replicated product installation tutorials [without an existing cluster](tutorial-installing-without-existing-cluster) or the [using the CLI](tutorial-installing-with-cli), as this guide is a continuation of those tutorials.
+* To install the application in this tutorial, you must have a virtual machine (VM) that meets the following minimum requirements:
+   * Ubuntu 18.04
+   * At least 8 GB of RAM
+   * 4 CPU cores
+   * At least 40GB of disk space
 
-As with the previous tutorials, we will also need a virtual machine (VM) to install the application with the following minimum requirements:
-
-* Ubuntu 18.04
-* At least 8 GB of RAM
-* 4 CPU cores
-* At least 40GB of disk space
-
-We are going to focus on the difference between using a public image versus a private image in Replicated.
-To do this, we'll pull the public NGINX container and then push it to a private repository in ECR.
-
-This means we'll need:
-
-* An ECR Repository
-* An AWS Account to use with Docker to pull and push the public NGINX image to the ECR repository
-* Docker
-* The AWS CLI
-
-Later in the guide we will configure Replicated to pull from the ECR repository using a read-only account.
-To do this we'll need to make sure the above AWS account can also create this user.
+* To pull a public NGINX container and push it to a private repository in ECR as part of this tutorial, you must have the following:
+   * An ECR Repository
+   * An AWS account to use with Docker to pull and push the public NGINX image to the ECR repository. The AWS account must be able to create a read-only user.
+   * Docker
+   * The AWS CLI
 
 ## Overview
 

--- a/docs/vendor/tutorial-ecr-private-images.md
+++ b/docs/vendor/tutorial-ecr-private-images.md
@@ -4,7 +4,7 @@ The Replicated app manager supports working with private images stored in Amazon
 
 ## Objective
 
-The purpose of this tutorial is to walk you through a hello-world example on how to configure Replicated to pull images from a private registry in Amazon's Elastic Container Registry (ECR). This tutorial demonstrates the differences between using public and private images in Replicated. 
+The purpose of this tutorial is to walk you through how to configure Replicated to pull images from a private registry in Amazon's Elastic Container Registry (ECR). This tutorial demonstrates the differences between using public and private images in Replicated.
 
 ## Prerequisites
 
@@ -38,7 +38,12 @@ We are going to use the default NGINX deployment to create our application and t
 
 ### Create Sample Application and deploy the first release
 
-In this section, we cover at a high level the steps to create a new application and install it on a VM. As mentioned earlier, it is assumed that you have completed the Replicated product installation tutorials [without an existing cluster](tutorial-installing-without-existing-cluster) or the [using the CLI](tutorial-installing-with-cli), which cover these steps in detail.
+In this section, we cover at a high level the steps to create a new application and install it on a VM.
+
+For more detailed information about how to create and install an application, follow one of the following getting started tutorials:
+* [Packaging and Installing on an Existing Cluster](tutorial-installing-with-existing-cluster)
+* [Packaging and Installing on a Kubernetes Installer Cluster](tutorial-installing-without-existing-cluster)
+* [Managing Releases with the CLI](tutorial-installing-with-cli)
 
 To create our sample application follow these steps:
 

--- a/docs/vendor/tutorial-ha-cluster-deploying.md
+++ b/docs/vendor/tutorial-ha-cluster-deploying.md
@@ -1,10 +1,10 @@
 # Deploying a High Availability Cluster
 
-In this guide, we will walk through the steps needed to enable Kubernetes high availability capabilities with a cluster installed by the Replicated Kubernetes installer and managed by the Replicated app manager. This only applies to Kubernetes installer-created cluster (embedded cluster) installations. (The Kubernetes installer is our commercial distribution of the kURL open source project).
+In this guide, we will walk through the steps needed to enable Kubernetes high availability capabilities with a cluster installed by the Replicated Kubernetes installer and managed by the Replicated app manager. This only applies to Kubernetes installer-created cluster (embedded cluster) installations. The Kubernetes installer is our commercial distribution of the kURL open source project.
 
 ## Objective
 
-As with the rest of the guides, this is meant as a 'hello world' example to help get you familiarized with the process of standing up a highly available Kubernetes cluster using the Replicated toolset. The architecture we will follow is presented below:
+This is meant to help get you familiarized with the process of standing up a highly available Kubernetes cluster using the Replicated toolset. The architecture we will follow is presented below:
 
 ![Architecture](/images/guides/kots/ha-cluster-architecture.png)
 
@@ -26,7 +26,7 @@ There are a few things to keep in mind about this guide:
 
 - In the example commands and screenshots, we are using a sample application called `AppDirect`. For more information, see [Sample Application](#sample-application).
 
-- This is an advanced topic, and assumes that you have already completed one of the Replicated installation tutorials, such as [Installing without an existing cluster](tutorial-installing-without-existing-cluster), and have already a level of familiarity with Replicated.
+- This is an advanced topic that assumes you have a level of familiarity with Replicated. If you are not yet familiar with Replicated, first complete one of the getting started tutorials, such as [Packaging and Installing on a Kubernetes Installer Cluster](tutorial-installing-without-existing-cluster).
 
 
 ### Sample application

--- a/docs/vendor/tutorial-installing-air-gap-existing-cluster-gcp.md
+++ b/docs/vendor/tutorial-installing-air-gap-existing-cluster-gcp.md
@@ -14,7 +14,7 @@ If you are planning to deploy your application to air gapped Amazon EKS, Red Hat
 
 ## Prerequisites
 
-* Complete the [existing cluster quick start](tutorial-installing-with-existing-cluster) to set up a non-air gapped cluster.
+* Complete the [Packaging and Installing on an Existing Cluster](tutorial-installing-with-existing-cluster) tutorial to set up a non-air gapped cluster.
 
 ## End to End GCP Example
 

--- a/docs/vendor/tutorial-installing-air-gap.md
+++ b/docs/vendor/tutorial-installing-air-gap.md
@@ -2,9 +2,9 @@
 
 This tutorial shows how to install the Replicated app manager in an air gapped environment.
 
-The tutorial assumes that you have already completed one of the quick start tutorials and set up a non-air gapped cluster. See:
-* [Installing without an Existing Cluster](tutorial-installing-without-existing-cluster)
-* [Installing with an Existing Cluster](tutorial-installing-with-existing-cluster)
+The tutorial assumes that you have already completed one of the getting started tutorials and set up a non-air gapped cluster. See:
+* [Packaging and Installing on a Kubernetes Installer Cluster](tutorial-installing-without-existing-cluster)
+* [Packaging and Installing on an Existing Cluster](tutorial-installing-with-existing-cluster)
 * [Managing Releases with the CLI](tutorial-installing-with-cli)
 
 The air gap installation follows this process:

--- a/docs/vendor/tutorial-installing-with-cli.md
+++ b/docs/vendor/tutorial-installing-with-cli.md
@@ -2,7 +2,7 @@
 
 This tutorial helps you use Replicated app manager to quickly deploy, install, and iterate with a sample Kubernetes application using a CLI-based workflow.
 
-For a more conceptual overview before using the CLI tools, you can start with the tutorial for [installing a sample application without an existing cluster](tutorial-installing-without-existing-cluster).
+For a more conceptual overview before using the CLI tools, you can start with the [Packaging and Installing on a Kubernetes Cluster](tutorial-installing-without-existing-cluster) tutorial.
 
 To deploy the sample application, follow these steps:
 

--- a/docs/vendor/tutorial-installing-with-cli.md
+++ b/docs/vendor/tutorial-installing-with-cli.md
@@ -508,8 +508,8 @@ You can iterate further on your application. Continue making changes and using `
 
 To learn more about the app manager features, you can explore some of the tutorials and packaging options, such as:
 
-* [Integrating with an existing CI/CD platform](tutorial-ci-cd-integration)
-* [Integrating a Helm chart](helm-overview)
+* Integrating with a CI/CD platform. See [Tutorial: Integrating with an existing CI/CD platform](tutorial-ci-cd-integration).
+* Packaging an application from a Helm chart. See [About Packaging with Helm](helm-overview).
 
 If you already have a release published in the vendor portal that you want to use as a starting point, run the following command to access the help docs for `replicated release download`:
 

--- a/docs/vendor/tutorial-installing-with-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-with-existing-cluster.md
@@ -1,4 +1,4 @@
-# Installing with an Existing Cluster
+# Packaging and Installing on an Existing Cluster
 
 This tutorial demonstrates packaging and installing a sample NGINX application in Kubernetes on an existing cluster in GKE (or another cluster that you have available).
 

--- a/docs/vendor/tutorial-installing-without-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-without-existing-cluster.md
@@ -1,4 +1,4 @@
-# Installing without an Existing Cluster
+# Packaging and Installing on a Kubernetes Installer Cluster
 
 This tutorial demonstrates packaging and installing a sample NGINX application in Kubernetes using a single virtual machine (VM).
 
@@ -142,10 +142,10 @@ To create the test server and install the app manager:
   Kotsadm: http://[ip-address]:8800
   Login with password (will not be shown again): [password]
   ```
-  
+
   :::note
   The login password displayed in the CLI output of the installation command is not shown again. Copy this password so that you can log in to the admin console in a later step of the installation process.
-  ::: 
+  :::
 
 1. Reload your shell to access the cluster with `kubectl`:
 

--- a/docs/vendor/tutorial-installing-without-existing-cluster.md
+++ b/docs/vendor/tutorial-installing-without-existing-cluster.md
@@ -302,4 +302,4 @@ To check for updates manually:
 
 ## Next Step
 
-Now that you are familiar with the basics, we recommend that you run through the tutorial for [installing with the CLI](tutorial-installing-with-cli) to start [managing your release YAML in a git repo](repository-workflow-and-tagging-releases).
+Now that you are familiar with the basics, we recommend that you run through the tutorial for [managing releases with the CLI](tutorial-installing-with-cli) to start [managing your release YAML in a git repo](repository-workflow-and-tagging-releases).

--- a/docs/vendor/vendor-portal-creating-account.md
+++ b/docs/vendor/vendor-portal-creating-account.md
@@ -38,7 +38,7 @@ To create a vendor account:
 # Next steps
 * Invite team members to collaborate with you in vendor portal. See [Invite Members](team-management#invite-members).
 * Complete a tutorial to package, distribute, and install a sample application. See:
-   * [Installing a Sample Application with the CLI](tutorial-installing-with-cli).
-   * [Installing a Sample Application on an Existing Cluster](tutorial-installing-with-existing-cluster).
-   * [Installing a Sample Application Without an Existing Cluster](tutorial-installing-without-existing-cluster).
+   * [Managing Releases with the CLI](tutorial-installing-with-cli).
+   * [Packaging and Installing on an Existing Cluster](tutorial-installing-with-existing-cluster).
+   * [Packaging and Installing on a Kubernetes Installer Cluster](tutorial-installing-without-existing-cluster).
 * Learn about how to package, test, iterate, and distribute your production application. See [How to Distribute a Production Application](distributing-workflow).

--- a/docs/vendor/vendor-portal-creating-account.md
+++ b/docs/vendor/vendor-portal-creating-account.md
@@ -46,4 +46,4 @@ To create a vendor account:
    * [Managing Releases with the CLI](tutorial-installing-with-cli).
    * [Packaging and Installing on an Existing Cluster](tutorial-installing-with-existing-cluster).
    * [Packaging and Installing on a Kubernetes Installer Cluster](tutorial-installing-without-existing-cluster).
-* Learn about how to package, test, iterate, and distribute your production application. See [How to Distribute a Production Application](distributing-workflow).
+* Learn about how to package, test, iterate, and distribute your production application. See [How to Package and Distribute a Production Application](distributing-workflow).

--- a/sidebars.js
+++ b/sidebars.js
@@ -20,13 +20,12 @@ const sidebars = {
 
   tutorialSidebar: [
 
-
+    'intro',
+    'intro-replicated',
     {
       type: 'category',
-      label: 'Getting Started',
+      label: 'Getting Started Tutorials',
       items: [
-        'intro',
-        'intro-replicated',
         'vendor/tutorial-installing-without-existing-cluster',
         'vendor/tutorial-installing-with-existing-cluster',
         'vendor/tutorial-installing-with-cli',
@@ -54,7 +53,6 @@ const sidebars = {
             type: 'category',
             label: 'Creating and Managing Releases',
             items: [
-              'vendor/repository-workflow-and-tagging-releases',
               'vendor/releases-creating-releases',
               {
                 type: 'category',
@@ -169,7 +167,14 @@ const sidebars = {
               },
               'vendor/releases-promoting',
               'vendor/releases-updating',
-              'vendor/tutorial-ci-cd-integration',
+              {
+                type: 'category',
+                label: 'Integrating with CI/CD',
+                items: [
+                  'vendor/repository-workflow-and-tagging-releases',
+                  'vendor/tutorial-ci-cd-integration',
+                ],
+              },
               'vendor/packaging-air-gap-excluding-minio',
             ],
           },
@@ -215,7 +220,7 @@ const sidebars = {
         },
         {
           type: 'category',
-          label: 'Tutorials',
+          label: 'Advanced Tutorials',
           items: [
             'vendor/tutorial-installing-air-gap-existing-cluster-gcp',
             'vendor/tutorial-ha-cluster-deploying',

--- a/sidebars.js
+++ b/sidebars.js
@@ -127,6 +127,14 @@ const sidebars = {
                   },
                   {
                     type: 'category',
+                    label: 'Adding Persistent Data Stores',
+                    items: [
+                      'vendor/database-config-adding-options',
+                      'vendor/tutorial-adding-db-config',
+                    ]
+                  },
+                  {
+                    type: 'category',
                     label: 'Customizing the Admin Console and Download Portal',
                     items: [
                       'vendor/admin-console-customize-app-icon',
@@ -135,7 +143,7 @@ const sidebars = {
                       'vendor/admin-console-prometheus-monitoring',
                     ],
                   },
-                  'vendor/database-config-adding-options',
+
                   'vendor/packaging-ingress',
                   'vendor/packaging-custom-resources',
                   'vendor/packaging-kots-versions',
@@ -160,6 +168,7 @@ const sidebars = {
               },
               'vendor/releases-promoting',
               'vendor/releases-updating',
+              'vendor/tutorial-ci-cd-integration',
               'vendor/packaging-air-gap-excluding-minio',
             ],
           },
@@ -208,10 +217,7 @@ const sidebars = {
           label: 'Tutorials',
           items: [
             'vendor/tutorial-installing-air-gap-existing-cluster-gcp',
-
             'vendor/tutorial-ha-cluster-deploying',
-            'vendor/tutorial-ci-cd-integration',
-            'vendor/tutorial-adding-db-config',
           ],
         },
       ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -19,12 +19,13 @@ const sidebars = {
   // But you can create a sidebar manually
 
   tutorialSidebar: [
-    'intro',
+
 
     {
       type: 'category',
       label: 'Getting Started',
       items: [
+        'intro',
         'intro-replicated',
         'vendor/tutorial-installing-without-existing-cluster',
         'vendor/tutorial-installing-with-existing-cluster',

--- a/sidebars.js
+++ b/sidebars.js
@@ -20,8 +20,18 @@ const sidebars = {
 
   tutorialSidebar: [
     'intro',
-    'intro-replicated',
 
+    {
+      type: 'category',
+      label: 'Getting Started',
+      items: [
+        'intro-replicated',
+        'vendor/tutorial-installing-without-existing-cluster',
+        'vendor/tutorial-installing-with-existing-cluster',
+        'vendor/tutorial-installing-with-cli',
+        'vendor/tutorial-installing-air-gap',
+      ]
+    },
     {
       type: 'category',
       label: 'Vendor',
@@ -29,16 +39,6 @@ const sidebars = {
       items: [
         'vendor/distributing-workflow',
         'vendor/vendor-portal-creating-account',
-        {
-          type: 'category',
-          label: 'Quick Start Tutorials with Sample Applications',
-          items: [
-            'vendor/tutorial-installing-without-existing-cluster',
-            'vendor/tutorial-installing-with-existing-cluster',
-            'vendor/tutorial-installing-with-cli',
-            'vendor/tutorial-installing-air-gap',
-          ]
-        },
         'vendor/planning-questionnaire',
           {
             type: 'category',
@@ -113,6 +113,14 @@ const sidebars = {
                       'vendor/helm-airgap-builder',
                     ],
                   },
+                  {
+                    type: 'category',
+                    label: 'Adding Persistent Data Stores',
+                    items: [
+                      'vendor/database-config-adding-options',
+                      'vendor/tutorial-adding-db-config',
+                    ]
+                  },
                   'vendor/packaging-embedded-kubernetes',
                   'vendor/preflight-host-preflights',
                   'vendor/preflight-support-bundle-creating',
@@ -124,14 +132,6 @@ const sidebars = {
                         'vendor/snapshots-configuring-backups',
                         'vendor/snapshots-hooks',
                     ],
-                  },
-                  {
-                    type: 'category',
-                    label: 'Adding Persistent Data Stores',
-                    items: [
-                      'vendor/database-config-adding-options',
-                      'vendor/tutorial-adding-db-config',
-                    ]
                   },
                   {
                     type: 'category',

--- a/sidebars.js
+++ b/sidebars.js
@@ -66,6 +66,7 @@ const sidebars = {
                         'vendor/packaging-private-images',
                         'vendor/packaging-private-registry-cname',
                         'vendor/packaging-private-registry-security',
+                        'vendor/tutorial-ecr-private-images',
                     ],
                   },
                   {
@@ -207,7 +208,7 @@ const sidebars = {
           label: 'Tutorials',
           items: [
             'vendor/tutorial-installing-air-gap-existing-cluster-gcp',
-            'vendor/tutorial-ecr-private-images',
+
             'vendor/tutorial-ha-cluster-deploying',
             'vendor/tutorial-ci-cd-integration',
             'vendor/tutorial-adding-db-config',


### PR DESCRIPTION
Story: https://app.shortcut.com/replicated/story/57808/remove-separate-tutorials-section

Detailed description of all the changes made in this comment on the story: https://app.shortcut.com/replicated/story/57808/remove-separate-tutorials-section#activity-58194

Topics for review:
- Welcome topic updated to include Get Started with Replicated section: https://deploy-preview-619--replicated-docs.netlify.app/
- Getting started section renamed and moved to top, and tutorials re-titled: https://deploy-preview-619--replicated-docs.netlify.app/vendor/tutorial-installing-without-existing-cluster
- ECR tutorial moved: https://deploy-preview-619--replicated-docs.netlify.app/vendor/tutorial-ecr-private-images
- Adding db options tutorial moved to a new section in Packaging named Adding Persistent Data Stores: https://deploy-preview-619--replicated-docs.netlify.app/vendor/tutorial-adding-db-config
- CI/CD tutorial moved to a new section after Promoting Releases (not sure if the placement or naming of the section should be edited): https://deploy-preview-619--replicated-docs.netlify.app/vendor/tutorial-ci-cd-integration
- Tutorials renamed to Advanced Tutorials: https://deploy-preview-619--replicated-docs.netlify.app/vendor/tutorial-installing-air-gap-existing-cluster-gcp