### PR TITLE
Correct the api version for Preflight example

### DIFF
--- a/docs/vendor/licenses-referencing-fields.md
+++ b/docs/vendor/licenses-referencing-fields.md
@@ -40,7 +40,7 @@ You could define this limit by creating a `node_count` custom license field:
 To enforce the node count when a customer installs or updates your application,
 you can create a preflight check that references the `node_count` field:
 
-```
+```yaml
 apiVersion: troubleshoot.sh/v1beta2
 kind: Preflight
 metadata:

--- a/docs/vendor/licenses-referencing-fields.md
+++ b/docs/vendor/licenses-referencing-fields.md
@@ -41,7 +41,7 @@ To enforce the node count when a customer installs or updates your application,
 you can create a preflight check that references the `node_count` field:
 
 ```
-apiVersion: troubleshoot.replicated.com/v1beta1
+apiVersion: troubleshoot.sh/v1beta2
 kind: Preflight
 metadata:
   name: example-preflight-checks


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/58428/incorrect-api-version-on-preflight-example

Also noticed that the code sample did not specify `yaml`, so I updated that too.

Preview: https://deploy-preview-628--replicated-docs.netlify.app/vendor/licenses-referencing-fields#example-reference-a-custom-license-field-in-a-preflight-check
