### PR TITLE
Removes advanced tutorials from TOC

### DIFF
--- a/docs/vendor/tutorial-ha-cluster-deploying.md
+++ b/docs/vendor/tutorial-ha-cluster-deploying.md
@@ -1,3 +1,5 @@
+<!-- This topic is removed from the table of contents because it has not been updated. -->
+
 # Deploying a High Availability Cluster
 
 In this guide, we will walk through the steps needed to enable Kubernetes high availability capabilities with a cluster installed by the Replicated Kubernetes installer and managed by the Replicated app manager. This only applies to Kubernetes installer-created cluster (embedded cluster) installations. The Kubernetes installer is our commercial distribution of the kURL open source project.

--- a/docs/vendor/tutorial-installing-air-gap-existing-cluster-gcp.md
+++ b/docs/vendor/tutorial-installing-air-gap-existing-cluster-gcp.md
@@ -1,3 +1,5 @@
+<!-- This topic is removed from the table of contents because it has not been updated. -->
+
 # Installing in an Air Gapped Existing Cluster using GCP
 
 This tutorial shows how to install the Replicated app manager in an existing cluster in an _air gapped_ environment, where the workstation and the cluster have no outbound internet connectivity.

--- a/sidebars.js
+++ b/sidebars.js
@@ -217,14 +217,6 @@ const sidebars = {
             'vendor/offsite-backup'
           ],
         },
-        {
-          type: 'category',
-          label: 'Advanced Tutorials',
-          items: [
-            'vendor/tutorial-installing-air-gap-existing-cluster-gcp',
-            'vendor/tutorial-ha-cluster-deploying',
-          ],
-        },
       ],
     },
     {


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/58652/remove-advanced-tutorials-from-the-vendor-docs