### PR TITLE
firefox known issue

### DIFF
--- a/docs/release-notes/rn-app-manager.md
+++ b/docs/release-notes/rn-app-manager.md
@@ -37,13 +37,13 @@ Support for Kubernetes: 1.21, 1.22, 1.23, and 1.24
 
 ### Known Issue {#known-issues-1-86-0}
 
-There is a known issue in the app manager v1.86.0 that causes the application icon in the Replicated admin console to display incorrectly in Firefox browsers. The icon displays in a very large size, preventing users from accessing the fields on many of the admin console screens.
+There is a known issue in the app manager v1.86.0 that causes certain icons in the Replicated admin console to display incorrectly in Firefox browsers. The icons display in a very large size, making it difficult for users to access the fields on several of the admin console screens.
 
-To use the admin console on v1.86.0, users must open the admin console in a supported browser other than Firefox, such as Google Chrome. For more information about supported browsers, see [Supported Browsers](/enterprise/installing-general-requirements#supported-browsers) in _Installation Requirements_.
+To use the admin console on v1.86.0, users should open the admin console in a supported browser other than Firefox, such as Google Chrome. For more information about supported browsers, see [Supported Browsers](/enterprise/installing-general-requirements#supported-browsers) in _Installation Requirements_.
 
 If users are unable to use a browser other than Firefox to access the admin console, Replicated recommends that they do not upgrade to the app manager v1.86.0.
 
-To prevent users from upgrading to v1.86.0, define a `targetKotsVersion` of `"1.85.0"` in your Application custom resource manifest file. For more information about adding a target version for KOTS, see [Using Target KOTS Versions](/vendor/packaging-kots-versions#using-target-kots-versions) in _Setting Minimum and Target Versions for KOTS_.
+Until a new version of the app manager is available, Replicated recommends defining a `targetKotsVersion` of `"1.85.0"` in your Application custom resource manifest file if you have customers using Firefox. For more information about adding a target version for KOTS, see [Using Target KOTS Versions](/vendor/packaging-kots-versions#using-target-kots-versions) in _Setting Minimum and Target Versions for KOTS_.
 
 ## 1.85.0
 

--- a/docs/release-notes/rn-app-manager.md
+++ b/docs/release-notes/rn-app-manager.md
@@ -41,9 +41,9 @@ There is a known issue in the app manager v1.86.0 that causes the application ic
 
 To use the admin console on v1.86.0, users must open the admin console in a supported browser other than Firefox, such as Google Chrome. For more information about supported browsers, see [Supported Browsers](/enterprise/installing-general-requirements#supported-browsers) in _Installation Requirements_.
 
-If users are unable to use a browser other than Firefox to access the admin console, Replicated recommends that they do not upgrade to the app manager v1.8.6.
+If users are unable to use a browser other than Firefox to access the admin console, Replicated recommends that they do not upgrade to the app manager v1.86.0.
 
-To prevent users from upgrading to v1.8.6, define a `targetKotsVersion` of `"1.85.0"` in your Application custom resource manifest file. For more information about adding a target version for KOTS, see [Using Target KOTS Versions](/vendor/packaging-kots-versions#using-target-kots-versions) in _Setting Minimum and Target Versions for KOTS_.
+To prevent users from upgrading to v1.86.0, define a `targetKotsVersion` of `"1.85.0"` in your Application custom resource manifest file. For more information about adding a target version for KOTS, see [Using Target KOTS Versions](/vendor/packaging-kots-versions#using-target-kots-versions) in _Setting Minimum and Target Versions for KOTS_.
 
 ## 1.85.0
 

--- a/docs/release-notes/rn-app-manager.md
+++ b/docs/release-notes/rn-app-manager.md
@@ -7,7 +7,7 @@ toc_max_heading_level: 2
 ## 1.86.0
 
 :::important
-The app manager v1.86.0 contains a known issue that prevents the use of
+The app manager v1.86.0 contains a known issue that affects the use of
 the Replicated admin console in Firefox browsers.
 See [Known Issue](#known-issues-1-86-0) below.
 :::
@@ -43,7 +43,7 @@ To use the admin console on v1.86.0, users should open the admin console in a su
 
 If users are unable to use a browser other than Firefox to access the admin console, Replicated recommends that they do not upgrade to the app manager v1.86.0.
 
-Until a new version of the app manager is available, Replicated recommends defining a `targetKotsVersion` of `"1.85.0"` in your Application custom resource manifest file if you have customers using Firefox. For more information about adding a target version for KOTS, see [Using Target KOTS Versions](/vendor/packaging-kots-versions#using-target-kots-versions) in _Setting Minimum and Target Versions for KOTS_.
+Replicated recommends defining a `targetKotsVersion` of `"1.85.0"` in your Application custom resource manifest file if you have customers using Firefox. For more information about adding a target version for KOTS, see [Using Target KOTS Versions](/vendor/packaging-kots-versions#using-target-kots-versions) in _Setting Minimum and Target Versions for KOTS_.
 
 ## 1.85.0
 

--- a/docs/release-notes/rn-app-manager.md
+++ b/docs/release-notes/rn-app-manager.md
@@ -6,6 +6,12 @@ toc_max_heading_level: 2
 
 ## 1.86.0
 
+:::important
+The app manager v1.86.0 contains a known issue that prevents the use of
+the Replicated admin console in Firefox browsers.
+See [Known Issue](#known-issues-1-86-0) below.
+:::
+
 Released on September 27, 2022
 
 Support for Kubernetes: 1.21, 1.22, 1.23, and 1.24
@@ -28,6 +34,16 @@ Support for Kubernetes: 1.21, 1.22, 1.23, and 1.24
 * Fixes a bug in Helm-managed mode (Alpha) that required you to visit the config screen to deploy a new version with required config items, even if all of the config values had been set in a previously deployed version.
 * Fixes a bug that caused the currently deployed version to temporarily appear as a newly available version when an update check ran in Helm-managed mode (Alpha).
 * Fixes styling on `<pre>` elements in the Helm install modals (Alpha) so that their heights match the content.
+
+### Known Issue {#known-issues-1-86-0}
+
+There is a known issue in the app manager v1.86.0 that causes the application icon in the Replicated admin console to display incorrectly in Firefox browsers. The icon displays in a very large size, preventing users from accessing the fields on many of the admin console screens.
+
+To use the admin console on v1.86.0, users must open the admin console in a supported browser other than Firefox, such as Google Chrome. For more information about supported browsers, see [Supported Browsers](/enterprise/installing-general-requirements#supported-browsers) in _Installation Requirements_.
+
+If users are unable to use a browser other than Firefox to access the admin console, Replicated recommends that they do not upgrade to the app manager v1.8.6.
+
+To prevent users from upgrading to v1.8.6, define a `targetKotsVersion` of `"1.85.0"` in your Application custom resource manifest file. For more information about adding a target version for KOTS, see [Using Target KOTS Versions](/vendor/packaging-kots-versions#using-target-kots-versions) in _Setting Minimum and Target Versions for KOTS_.
 
 ## 1.85.0
 


### PR DESCRIPTION
Document this known issue in the release notes, including workarounds: https://app.shortcut.com/replicated/story/59762/kots-icons-are-huge-on-firefox-browser

Docs story: https://app.shortcut.com/replicated/story/59849/known-issue-for-firefox-bug

Preview: Warning note at the top of the 1.86.0 release and a new Known Issue section https://deploy-preview-673--replicated-docs.netlify.app/release-notes/rn-app-manager#1860