### PR TITLE
add information about lint-config to kots lint rules page

### DIFF
--- a/docs/reference/kots-lint.mdx
+++ b/docs/reference/kots-lint.mdx
@@ -66,7 +66,7 @@ The supported levels are:
       </tr>
       <tr>
         <td>off</td>
-        <tdThe rule is disabled.td>
+        <td>The rule is disabled.td>
       </tr>
     </table>
 

--- a/docs/reference/kots-lint.mdx
+++ b/docs/reference/kots-lint.mdx
@@ -42,15 +42,15 @@ The KOTS lint service runs automatically against releases that you create in the
 To use the KOTS lint service to lint your application manifest files, you can run the replicated CLI `replicated release lint` command against the root directory of your application manifest files. You can also use the `--lint` flag when you create a release with the `replicated release create` command. For more information, see [release lint](/reference/replicated-cli-release-lint) and [release create](/reference/replicated-cli-release-create) in the _replicated CLI_ section.
 
 ## Configuring lint rules
-Linting rules can be configured to use levels by including a lint-config.yaml file as part of the release. In the lint-config.yaml you can specify the rule name and level you want the rule to have. The levels supported are:
+Linting rules can be configured to use levels by including a kots-lint-config.yaml file as part of the release. In the kots-lint-config.yaml you can specify the rule name and level you want the rule to have. The levels supported are:
 - "error" - the rule is enabled and shown as an error
 - "warn" - the rule is enabled and shown as a warning
 - "info" - the rule is enabled and shown as an info message
 - "off" - the rule is disabled
 
-Rules that are not included in the lint-config.yaml will keep their default level. Linting rules and their default level are listed below.
+Rules that are not included in the kots-lint-config.yaml will keep their default level. Linting rules and their default level are listed below.
 
-Here is an example of what the `lint-config.yaml` should look like:
+Here is an example of what the `kots-lint-config.yaml` should look like:
 ```yaml
 apiVersion: kots.io/v1beta1
 kind: LintConfig

--- a/docs/reference/kots-lint.mdx
+++ b/docs/reference/kots-lint.mdx
@@ -66,7 +66,7 @@ The supported levels are:
       </tr>
       <tr>
         <td>off</td>
-        <td>The rule is disabled.td>
+        <td>The rule is disabled.</td>
       </tr>
     </table>
 

--- a/docs/reference/kots-lint.mdx
+++ b/docs/reference/kots-lint.mdx
@@ -41,6 +41,31 @@ The KOTS lint service runs automatically against releases that you create in the
 
 To use the KOTS lint service to lint your application manifest files, you can run the replicated CLI `replicated release lint` command against the root directory of your application manifest files. You can also use the `--lint` flag when you create a release with the `replicated release create` command. For more information, see [release lint](/reference/replicated-cli-release-lint) and [release create](/reference/replicated-cli-release-create) in the _replicated CLI_ section.
 
+## Configuring lint rules
+Linting rules can be configured to use levels by including a lint-config.yaml file as part of the release. In the lint-config.yaml you can specify the rule name and level you want the rule to have. The levels supported are:
+- "error" - the rule is enabled and shown as an error
+- "warn" - the rule is enabled and shown as a warning
+- "info" - the rule is enabled and shown as an info message
+- "off" - the rule is disabled
+
+Rules that are not included in the lint-config.yaml will keep their default level. Linting rules and their default level are listed below.
+
+Here is an example of what the `lint-config.yaml` should look like:
+```yaml
+apiVersion: kots.io/v1beta1
+kind: LintConfig
+metadata:
+  name: default-lint-config
+spec:
+  rules:
+  - name: application-icon
+    level: "off"
+  - name: application-statusInformers
+    level: "error"
+```
+In this example we are overwriting the level for the application-icon to `off` to disable the rule. We are also changing the level for the application-statusInformers rule to `error`, this way instead of seeing a warning we will see it as an error if we are missing status informers for our application .
+
+## Lint rules:
 ### missing-kind-field
 
 <table>

--- a/docs/reference/kots-lint.mdx
+++ b/docs/reference/kots-lint.mdx
@@ -41,16 +41,37 @@ The KOTS lint service runs automatically against releases that you create in the
 
 To use the KOTS lint service to lint your application manifest files, you can run the replicated CLI `replicated release lint` command against the root directory of your application manifest files. You can also use the `--lint` flag when you create a release with the `replicated release create` command. For more information, see [release lint](/reference/replicated-cli-release-lint) and [release create](/reference/replicated-cli-release-create) in the _replicated CLI_ section.
 
-## Configuring lint rules
-Linting rules can be configured to use levels by including a kots-lint-config.yaml file as part of the release. In the kots-lint-config.yaml you can specify the rule name and level you want the rule to have. The levels supported are:
-- "error" - the rule is enabled and shown as an error
-- "warn" - the rule is enabled and shown as a warning
-- "info" - the rule is enabled and shown as an info message
-- "off" - the rule is disabled
+## Customize Lint Rule Levels
 
-Rules that are not included in the kots-lint-config.yaml will keep their default level. Linting rules and their default level are listed below.
+Lint rules have default levels that can be overwritten. You configure custom levels by adding a LintConfig manifest file (`kind: LintConfig`) to the release. Specify the rule name and level you want the rule to have. Rules that are not included in the LintConfig manifest file keep their default level. For information about linting rules and their default levels, see [Lint Rules](#lint-rules).
 
-Here is an example of what the `kots-lint-config.yaml` should look like:
+The supported levels are:
+
+<table>
+      <tr>
+        <th width="20%">Level</th>
+        <th width="80%">Description</th>
+      </tr>
+      <tr>
+        <td>error</td>
+        <td>The rule is enabled and shows as an error.</td>
+      </tr>
+      <tr>
+        <td>warn</td>
+        <td>The rule is enabled and shows as a warning.</td>
+      </tr>
+      <tr>
+        <td>info</td>
+        <td>The rule is enabled and shows an informational message.</td>
+      </tr>
+      <tr>
+        <td>off</td>
+        <tdThe rule is disabled.td>
+      </tr>
+    </table>
+
+The following example manifest file overwrites the level for the application-icon to `off` to disable the rule. Additionally, the level for the application-statusInformers rule is changed to `error`, so instead of a warning, it displays an error if the application is missing status informers.
+
 ```yaml
 apiVersion: kots.io/v1beta1
 kind: LintConfig
@@ -63,7 +84,6 @@ spec:
   - name: application-statusInformers
     level: "error"
 ```
-In this example we are overwriting the level for the application-icon to `off` to disable the rule. We are also changing the level for the application-statusInformers rule to `error`, this way instead of seeing a warning we will see it as an error if we are missing status informers for our application .
 
 ## Lint rules:
 ### missing-kind-field


### PR DESCRIPTION
This PR adds information to the kots lint rules page on how to configure lint rules levels. 

Part of [SC-59102](https://app.shortcut.com/replicated/story/59102/kots-lintconfig).