### PR TITLE
HOLD FOR RELEASE - fix custom graph example

### DIFF
--- a/docs/reference/custom-resource-application.md
+++ b/docs/reference/custom-resource-application.md
@@ -147,6 +147,7 @@ statusInformers:
 
 ## graphs
 Custom graphs to include on your admin console application dashboard.
+Entries support template functions.
 
 ### title
 The graph title.

--- a/docs/vendor/admin-console-prometheus-monitoring.md
+++ b/docs/vendor/admin-console-prometheus-monitoring.md
@@ -81,10 +81,10 @@ To customize graphs on the admin console dashboard:
              legend: 'Available: {{ instance }}'
          yAxisFormat: bytes
        - title: CPU Usage
-         query: 'fmt.Sprintf(`sum(rate(container_cpu_usage_seconds_total{namespace="%s",container!="POD",pod!=""}[5m])) by (pod)`, util.PodNamespace)'
+         query: 'sum(rate(container_cpu_usage_seconds_total{namespace="{{repl Namespace}}",container!="POD",pod!=""}[5m])) by (pod)'
          legend: '{{ pod }}'
        - title: Memory Usage
-         query: 'fmt.Sprintf(`sum(container_memory_usage_bytes{namespace="%s",container!="POD",pod!=""}) by (pod)`, util.PodNamespace)'
+         query: 'sum(container_memory_usage_bytes{namespace="{{repl Namespace}}",container!="POD",pod!=""}) by (pod)'
          legend: '{{ pod }}'
          yAxisFormat: bytes
       ```   


### PR DESCRIPTION
Updated example to include a working version of our default graphs using template functions.  This depends on the changes in [this PR](https://github.com/replicatedhq/kots/pull/3284), so we should hold off merging until the next KOTS release.

[SC-59379](https://app.shortcut.com/replicated/story/59379/fmt-sprintf-usage-broken-for-custom-graph-queries)