### PR TITLE
59979: Added renewal clarification

### DIFF
--- a/docs/vendor/packaging-using-tls-certs.md
+++ b/docs/vendor/packaging-using-tls-certs.md
@@ -1,6 +1,6 @@
 # Using TLS Certificates
 
-The Replicated app manager provides default self-signed certificates that renew automatically. For Kubernetes installer clusters, the self-signed certificate renews 30 days before expiration when you enable the ECKO add-on version 0.7.0 and later.
+The Replicated app manager provides default self-signed certificates that renew automatically. For Kubernetes installer clusters, the self-signed certificate renews 30 days before expiration when you enable the EKCO add-on version 0.7.0 and later.
 
 Custom TLS options are supported:
 

--- a/docs/vendor/packaging-using-tls-certs.md
+++ b/docs/vendor/packaging-using-tls-certs.md
@@ -1,10 +1,12 @@
 # Using TLS Certificates
 
-The Replicated app manager provides default self-signed certificates. The use of custom TLS options are supported.
+The Replicated app manager provides default self-signed certificates that renew automatically. For Kubernetes installer clusters, the self-signed certificate renews 30 days before expiration when you enable the ECKO add-on version 0.7.0 and later.
 
-For existing clusters, the expectation is for the end customer to bring their own Ingress Controller such as Contour or Istio and upload their own `kubernetes.io/tls` secret. For an example, see [Ingress with TLS](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) in the Kubernetes documentation.
+Custom TLS options are supported:
 
-For Kubernetes installer clusters, end customers can upload a custom TLS certificate. The Kubernetes installer creates a TLS secret that can reused by other Kubernetes resources, such as Deployment or Ingress, which can be easier than providing and maintaining multiple certificates. As a vendor, you can enable the use of custom TLS certificates with these additional resources.
+- **Existing clusters:** The expectation is for the end customer to bring their own Ingress Controller such as Contour or Istio and upload their own `kubernetes.io/tls` secret. For an example, see [Ingress with TLS](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) in the Kubernetes documentation.
+
+- **Kubernetes installer clusters:** End customers can upload a custom TLS certificate. The Kubernetes installer creates a TLS secret that can reused by other Kubernetes resources, such as Deployment or Ingress, which can be easier than providing and maintaining multiple certificates. As a vendor, you can enable the use of custom TLS certificates with these additional resources.
 
 For example, if your application does TLS termination, your deployment would need the TLS secret. Or if the application is connecting to another deployment that is also secured using the same SSL certificate (which may not be a trusted certificate), the custom TLS certificate can be used to do validation without relying on the trust chain.
 


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/59979/remove-the-kots-specific-tls-certs-content-from-kurl-sh

This is just part one of this SC card - just adding the ECKO add-on info for the self-signed cert renewal. The removal of the kURL content will happen in another PR in the kURL repo.

Preview: https://deploy-preview-716--replicated-docs.netlify.app/vendor/packaging-using-tls-certs