### PR TITLE
Remove Open Source Tools section from What Is Replicated

### DIFF
--- a/docs/intro-replicated.md
+++ b/docs/intro-replicated.md
@@ -22,40 +22,35 @@ define Kubernetes manifest files, including application manifests and custom res
 manifests, for their application. These files describe to the app manager how to
 package the application for distribution. Vendors can also use the vendor portal
 to manage other artifacts, such as customer license files, image registries, and
-release channels. For more information, see [Creating a Vendor Account](vendor/vendor-portal-creating-account).
+release channels. The vendor portal also includes an API, called the Vendor API v3,
+and a CLI, called the replicated CLI.
+For more information about getting started with the vendor portal, see
+[Creating a Vendor Account](vendor/vendor-portal-creating-account).
 * **App manager**: The Replicated app manager reads the Kubernetes manifest files that
 the vendor defines to package and install an application on a Kubernetes cluster
 in a customer environment. It also installs the admin console along with the application.
 The app manager is based on the open-source KOTS project, which is maintained by
 Replicated.
+
+   The app manager also uses functionality from the Troubleshoot
+   open source project, which is maintained by Replicated. For example, the app manager runs preflight checks in the customer environment before the customer deploys
+   For more information, see [Getting Started](https://troubleshoot.sh/docs/) in the
+   Troubleshoot documentation.
+* **Admin console**: The Replicated admin console is the user interface where enterprise
+application users can configure, update, manage, backup and restore, and troubleshoot
+the application that they installed. The admin console is deployed by the app manager
+when the customer installs the application.
 * **Kubernetes installer**: The Replicated Kubernetes installer provisions a Kubernetes
 cluster, called an _embedded cluster_, in the customer's environment if they do
 not have an existing cluster. The Kubernetes installer is based on the open-source
 kURL project, which is maintained by Replicated. For more information, see
 [Introduction to kURL](https://kurl.sh/docs/introduction/) in the kURL documentation.
-* **Admin console**: The Replicated admin console is the user interface where enterprise
-application users can configure, update, manage, backup and restore, and troubleshoot
-the application that they installed. The admin console is deployed by the app manager
-when the customer installs the application.
-
-## How Replicated Works with Open-source Tools
-
-In general, Replicated components are grouped into one of the following categories:
-
-* **Cluster Operator Tools**: A set of open source projects that vendors can invoke to provide cluster operators with the necessary tools to validate, install, configure, troubleshoot, and automate the management of applications.
-These tools are built with a strong focus on production grade day-2 operations.
-* **Software Vendor Tools**: Primarily hosted by the [Replicated vendor portal](https://vendor.replicated.com) that serves as a centralized collaboration platform to manage customers, licenses/entitlements, releases/release channels, and troubleshooting. The vendor tools are [integrated with the open source KOTS projects](https://blog.replicated.com/announcing-kots/) to provide processes and workflows to operationalize and scale the distribution of a modern on-prem application.
-
-The foundational open source projects that Replicated coordinates are the [kots CLI](../reference/kots-cli-getting-started/) and [KOTS](../enterprise/installing-overview) (installation and admin console), [Troubleshoot](https://troubleshoot.sh) (preflight checks and support bundles), [kURL](https://kurl.sh) (embedded K8s option) as well as several community driven open source software (OSS) projects like Kubernetes, Kustomize, Helm, and Kubeadm.
 
 ## Replicated APIs and CLIs
 
-Replicated also includes a Vendor API and CLIs that allow both vendors and enterprise
-users to complete tasks programmatically.
+Replicated includes a Vendor API and CLIs that allow both vendors and enterprise
+users to complete tasks programmatically:
 
-For information about the Vendor API v3, see [Using the Vendor API v3](reference/vendor-api-using).
-
-For information about the replicated CLI, see [Installing the replicated CLI](reference/replicated-cli-installing).
-
-For information about the kots CLI, see [Getting Started with KOTS](reference/kots-cli-getting-started)
-in the kots CLI documentation.
+* **Vendor API v3**: The API for the vendor portal. See [Using the Vendor API v3](reference/vendor-api-using).
+* **replicated CLI**: The CLI for the vendor portal. See [Installing the replicated CLI](reference/replicated-cli-installing).
+* **kots CLI**: The CLI for the KOTS open source project. Enterprise users can use both the kots CLI and the admin console UI to access app manager functionality. For example, the kots CLI allows users to automate headless application installations, rather than configuring and installing an application from the admin console. See [Installing the kots CLI](reference/kots-cli-getting-started).

--- a/docs/intro-replicated.md
+++ b/docs/intro-replicated.md
@@ -22,28 +22,28 @@ define Kubernetes manifest files, including application manifests and custom res
 manifests, for their application. These files describe to the app manager how to
 package the application for distribution. Vendors can also use the vendor portal
 to manage other artifacts, such as customer license files, image registries, and
-release channels. The vendor portal also includes an API, called the Vendor API v3,
-and a CLI, called the replicated CLI.
+release channels.
 For more information about getting started with the vendor portal, see
 [Creating a Vendor Account](vendor/vendor-portal-creating-account).
-* **App manager**: The Replicated app manager reads the Kubernetes manifest files that
+* **App manager**: The Replicated app manager is based on the open source KOTS project,
+which is maintained by Replicated. The app manager reads the Kubernetes manifest files that
 the vendor defines to package and install an application on a Kubernetes cluster
 in a customer environment. It also installs the admin console along with the application.
-The app manager is based on the open-source KOTS project, which is maintained by
-Replicated.
 
-   The app manager also uses functionality from the Troubleshoot
-   open source project, which is maintained by Replicated. For example, the app manager runs preflight checks in the customer environment before the customer deploys
+   The app manager also uses functionality from the Troubleshoot open source project,
+   which is maintained by Replicated. For example, the app manager runs preflight
+   checks before the customer deploys the application to ensure that the customer
+   environment meets any application requirements.
    For more information, see [Getting Started](https://troubleshoot.sh/docs/) in the
    Troubleshoot documentation.
 * **Admin console**: The Replicated admin console is the user interface where enterprise
 application users can configure, update, manage, backup and restore, and troubleshoot
 the application that they installed. The admin console is deployed by the app manager
 when the customer installs the application.
-* **Kubernetes installer**: The Replicated Kubernetes installer provisions a Kubernetes
+* **Kubernetes installer**: The Replicated Kubernetes installer is based on the open source
+kURL project, which is maintained by Replicated. The Kubernetes installer provisions a Kubernetes
 cluster, called an _embedded cluster_, in the customer's environment if they do
-not have an existing cluster. The Kubernetes installer is based on the open-source
-kURL project, which is maintained by Replicated. For more information, see
+not have an existing cluster. For more information, see
 [Introduction to kURL](https://kurl.sh/docs/introduction/) in the kURL documentation.
 
 ## Replicated APIs and CLIs
@@ -53,4 +53,4 @@ users to complete tasks programmatically:
 
 * **Vendor API v3**: The API for the vendor portal. See [Using the Vendor API v3](reference/vendor-api-using).
 * **replicated CLI**: The CLI for the vendor portal. See [Installing the replicated CLI](reference/replicated-cli-installing).
-* **kots CLI**: The CLI for the KOTS open source project. Enterprise users can use both the kots CLI and the admin console UI to access app manager functionality. For example, the kots CLI allows users to automate headless application installations, rather than configuring and installing an application from the admin console. See [Installing the kots CLI](reference/kots-cli-getting-started).
+* **kots CLI**: The CLI for the KOTS open source project. The kots CLI allows users to interact with the app manager on the command line, rather than through the admin console. See [Installing the kots CLI](reference/kots-cli-getting-started).

--- a/docs/intro-replicated.md
+++ b/docs/intro-replicated.md
@@ -28,14 +28,14 @@ For more information about getting started with the vendor portal, see
 * **App manager**: The Replicated app manager is based on the open source KOTS project,
 which is maintained by Replicated. The app manager reads the Kubernetes manifest files that
 the vendor defines to package and install an application on a Kubernetes cluster
-in a customer environment. It also installs the admin console along with the application.
+in a customer environment. It installs the admin console along with the application.
 
    The app manager also uses functionality from the Troubleshoot open source project,
    which is maintained by Replicated. For example, the app manager runs preflight
    checks before the customer deploys the application to ensure that the customer
    environment meets any application requirements.
-   For more information, see [Getting Started](https://troubleshoot.sh/docs/) in the
-   Troubleshoot documentation.
+   For more information about using the features from the Troubleshoot project
+   in your application, see [Configuring Preflight Checks and Support Bundles](/vendor/preflight-support-bundle-creating).
 * **Admin console**: The Replicated admin console is the user interface where enterprise
 application users can configure, update, manage, backup and restore, and troubleshoot
 the application that they installed. The admin console is deployed by the app manager
@@ -43,8 +43,12 @@ when the customer installs the application.
 * **Kubernetes installer**: The Replicated Kubernetes installer is based on the open source
 kURL project, which is maintained by Replicated. The Kubernetes installer provisions a Kubernetes
 cluster, called an _embedded cluster_, in the customer's environment if they do
-not have an existing cluster. For more information, see
-[Introduction to kURL](https://kurl.sh/docs/introduction/) in the kURL documentation.
+not have an existing cluster.
+
+  For more information about configuring a Kubernetes
+  installer cluster, see [Creating a Kubernetes Installer](/vendor/packaging-embedded-kubernetes).
+  For more information about how enterprise users install with the Kubernetes installer,
+  see [Installing with the Kubernetes Installer](/enterprise/installing-embedded-cluster).
 
 ## Replicated APIs and CLIs
 


### PR DESCRIPTION
Story: https://app.shortcut.com/replicated/stories/space/37255/documentation-team-view

Preview: https://deploy-preview-719--replicated-docs.netlify.app/intro-replicated

Removes the confusing open source section and redistributes the relevant info from that section accordingly. (Additional edits to the Replicated Features section to be done as part of a different story)