### PR TITLE
add clarity around license expiration date

### DIFF
--- a/docs/vendor/licenses-about.md
+++ b/docs/vendor/licenses-about.md
@@ -57,7 +57,7 @@ and [Referencing Custom License Fields](licenses-referencing-fields).
 
 ## License Expiration Handling
 
-The built-in `expires_at` license field defines the expiration date for a customer license. When setting an expiration date in the Vendor Portal, the `expires_at` field will be set to midnight UTC on the date selected.
+The built-in `expires_at` license field defines the expiration date for a customer license. When you set an expiration date in the vendor portal, the `expires_at` field is set to midnight UTC on the date selected.
 
 By default, an application with an expired license continues to run, but is prevented from receiving updates. To change the behavior of your application when a license expires, you can can add custom logic based on the values for the `expires_at` field.
 

--- a/docs/vendor/licenses-about.md
+++ b/docs/vendor/licenses-about.md
@@ -57,7 +57,7 @@ and [Referencing Custom License Fields](licenses-referencing-fields).
 
 ## License Expiration Handling
 
-The built-in `expires_at` license field defines the expiration date for a customer license.
+The built-in `expires_at` license field defines the expiration date for a customer license. When setting an expiration date in the Vendor Portal, the `expires_at` field will be set to midnight UTC on the date selected.
 
 By default, an application with an expired license continues to run, but is prevented from receiving updates. To change the behavior of your application when a license expires, you can can add custom logic based on the values for the `expires_at` field.
 


### PR DESCRIPTION
This PR adds a sentence to explain that a license will expire at midnight UTC on the date selected in the vendor portal.  This supports https://github.com/replicatedhq/kots/pull/3380 for [SC-59063](https://app.shortcut.com/replicated/story/59063/can-t-check-for-updates-because-license-is-expired-but-neither-the-admin-console-nor-vendor-portal-says-it-is-expired-yet).

*No need to wait until release to merge this, as this is how the vendor portal behaves today.*