### PR TITLE
61504: Update links to tutorials

### DIFF
--- a/docs/vendor/distributing-workflow.md
+++ b/docs/vendor/distributing-workflow.md
@@ -43,7 +43,7 @@ Complete the following procedures to import your files, create, and test your fi
       </tr>
       <tr>
         <td>Standard manifest files</td>
-        <td>We recommend using standard manifest YAML files unless you are already using Helm or Kubernetes Operators. <br></br><br></br>To import using the Replicated vendor portal, see <a href="releases-creating-releases">Create a Release</a>. To import using the replicated CLI, see <a href="tutorial-installing-with-cli">Managing Releases with the CLI</a>.</td>
+        <td>We recommend using standard manifest YAML files unless you are already using Helm or Kubernetes Operators. <br></br><br></br>To import using the Replicated vendor portal, see <a href="releases-creating-releases">Create a Release</a>.</td>
       </tr>
       <tr>
         <td>Helm charts</td>

--- a/docs/vendor/tutorial-adding-db-config.md
+++ b/docs/vendor/tutorial-adding-db-config.md
@@ -88,7 +88,7 @@ For now we'll hard code the DB variable values, in the next sections we'll wire 
 
 ### Deploying the example application
 
- Once you've added this deployment to you application's `manifests` directory, create a release by pushing a commit to your [starter repo copy](tutorial-installing-with-cli#2-setting-a-service-account-token) or by running `replicated release create --auto` locally.
+ Once you've added this deployment to you application's `manifests` directory, create a release by running `replicated release create --auto` locally.
  Then head to the admin console instance and click **Check for Updates** on the Version History tab to pull the new release:
 
 ![View Update](/images/guides/kots/view-update.png)

--- a/docs/vendor/tutorial-adding-db-config.md
+++ b/docs/vendor/tutorial-adding-db-config.md
@@ -17,8 +17,8 @@ It is split into 5 sections:
 This guide assumes you have:
 
 * A running instance of the Replicated admin console (`kotsadm`) to iterate against in either an existing cluster or a Replicated Kubernetes installer-created cluster. If you do not have a running instance of the admin console on an existing or Kubernetes installer cluster, complete one of the following getting started tutorials to package and install a sample application:
-   * [Packaging and Installing on an Existing Cluster](tutorial-installing-with-existing-cluster)
-   * [Packaging and Installing on a Kubernetes Installer Cluster](tutorial-installing-without-existing-cluster)
+   * [UI Tutorial](tutorial-ui-setup)
+   * [CLI Tutorial](tutorial-cli-setup)
 * A local git checkout of your application manifests.
 
 ### Accompanying Code Examples

--- a/docs/vendor/tutorial-ci-cd-integration.md
+++ b/docs/vendor/tutorial-ci-cd-integration.md
@@ -8,7 +8,7 @@ For a similar workflow that uses GitHub Actions, see [Replicated Kubernetes Star
 
 ## Environment Variables
 
-This section will assume you already have the App slug and API token from the [installing with the CLI](tutorial-installing-with-cli#2-setting-a-service-account-token) tutorial.
+This section will assume you already have the App slug and API token from the [CLI Tutorial](tutorial-cli-setup).
 
 - Configure the following 2 environment variables in your CI/CD configuration.
 

--- a/docs/vendor/tutorial-ecr-private-images.md
+++ b/docs/vendor/tutorial-ecr-private-images.md
@@ -41,9 +41,8 @@ We are going to use the default NGINX deployment to create our application and t
 In this section, we cover at a high level the steps to create a new application and install it on a VM.
 
 For more detailed information about how to create and install an application, follow one of the following getting started tutorials:
-* [Packaging and Installing on an Existing Cluster](tutorial-installing-with-existing-cluster)
-* [Packaging and Installing on a Kubernetes Installer Cluster](tutorial-installing-without-existing-cluster)
-* [Managing Releases with the CLI](tutorial-installing-with-cli)
+* [UI Tutorial](tutorial-ui-setup)
+* [CLI Tutorial](tutorial-cli-setup)
 
 To create our sample application follow these steps:
 

--- a/docs/vendor/tutorial-ha-cluster-deploying.md
+++ b/docs/vendor/tutorial-ha-cluster-deploying.md
@@ -28,7 +28,7 @@ There are a few things to keep in mind about this guide:
 
 - In the example commands and screenshots, we are using a sample application called `AppDirect`. For more information, see [Sample Application](#sample-application).
 
-- This is an advanced topic that assumes you have a level of familiarity with Replicated. If you are not yet familiar with Replicated, first complete one of the getting started tutorials, such as [Packaging and Installing on a Kubernetes Installer Cluster](tutorial-installing-without-existing-cluster).
+- This is an advanced topic that assumes you have a level of familiarity with Replicated. If you are not yet familiar with Replicated, first complete one of the getting started tutorials, such as [UI Tutorial](tutorial-ui-setup).
 
 
 ### Sample application

--- a/docs/vendor/tutorial-installing-air-gap-existing-cluster-gcp.md
+++ b/docs/vendor/tutorial-installing-air-gap-existing-cluster-gcp.md
@@ -16,7 +16,7 @@ If you are planning to deploy your application to air gapped Amazon EKS, Red Hat
 
 ## Prerequisites
 
-* Complete the [Packaging and Installing on an Existing Cluster](tutorial-installing-with-existing-cluster) tutorial to set up a non-air gapped cluster.
+* Complete the [UI Tutorial](tutorial-ui-setup) to set up a non-air gapped cluster.
 
 ## End to End GCP Example
 

--- a/docs/vendor/tutorial-ui-create-new-version.md
+++ b/docs/vendor/tutorial-ui-create-new-version.md
@@ -23,10 +23,6 @@ Now that you have an application running, a common task is to deliver updates. Y
 
 1. Change the number to `2` or more.
 
-  :::note
-  If you have worked ahead and completed the [CLI setup guide](tutorial-installing-with-cli), you can make this `replicas` change in your locally checked-out git repository, publish it with `replicated release create --auto`, and then skip to [Update the Test Server](#update-the-test-server).
-  :::
-
 1. Click **Save Release**.
 
 1. Following the same process you before, promote the release to a channel:

--- a/docs/vendor/tutorial-ui-update-app.md
+++ b/docs/vendor/tutorial-ui-update-app.md
@@ -15,6 +15,6 @@ To check for updates manually:
 
 ## Next Steps
 
-Now that you are familiar with the basics, we recommend that you run through the [CLI Quickstart Tutorial](tutorial-installing-with-cli) to start managing your release YAML in a git repository.
+Now that you are familiar with the basics, we recommend that you run through the [CLI Tutorial](tutorial-cli-setup) to start managing your release YAML in a git repository.
 
 You can also head over to [How to Package and Distribute a Production Application](distributing-workflow) to learn how to integrate your application with other app manager features.

--- a/docs/vendor/vendor-portal-creating-account.md
+++ b/docs/vendor/vendor-portal-creating-account.md
@@ -45,9 +45,4 @@ To create a vendor account:
 
 # Next steps
 * Invite team members to collaborate with you in vendor portal. See [Invite Members](team-management#invite-members).
-* Complete a tutorial to package, distribute, and install a sample application. See:
-
-   * [Managing Releases with the CLI](tutorial-installing-with-cli).
-   * [Packaging and Installing on an Existing Cluster](tutorial-installing-with-existing-cluster).
-   * [Packaging and Installing on a Kubernetes Installer Cluster](tutorial-installing-without-existing-cluster).
 * Learn about how to package, test, iterate, and distribute your production application. See [How to Package and Distribute a Production Application](distributing-workflow).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -94,8 +94,8 @@ const config = {
                 to: 'release-notes/rn-whats-new',
               },
               {
-                label: 'Quick Start Tutorials',
-                to: 'vendor/tutorial-installing-without-existing-cluster',
+                label: 'Getting Started Tutorials',
+                to: 'vendor/tutorial-ui-setup',
               },
             ],
           },
@@ -138,4 +138,3 @@ const config = {
 };
 
 module.exports = config;
-


### PR DESCRIPTION
Did an `ag` to find all the places where we still use the old tutorial links. Updated these links to use the new xrefs instead so that they are not relying on redirects.

https://app.shortcut.com/replicated/story/61504/replace-all-links-to-the-old-tutorial-topics