### PR TITLE
remove references to deprecated 'kots pull helm' command

### DIFF
--- a/docs/reference/kots-cli-pull.md
+++ b/docs/reference/kots-cli-pull.md
@@ -18,16 +18,13 @@ This command supports all [global flags](kots-cli-global-flags) and also:
 | `--exclude-admin-console` | bool | set to true to exclude the admin console _(only valid when `[upstream-uri]` points to a replicated app)_ |
 | `--exclude-kots-kinds` | bool | set to true to exclude rendering KOTS custom objects to the base directory _(default `true`)_ |
 | `-h, --help` | | help for pull |
-| `--helm-version` | string | the Helm version with which to render the Helm Chart _(default `"v2"`)_. This is a beta feature |
 | `--image-namespace` | string | the namespace/org in the docker registry to push images to _(required when `--rewrite-images` is set)_ |
 | `--license-file` | string | path to a license file _(required when `[upstream-uri]` points to a replicated app)_ |
 | `--local-path` | string | specify a local-path to pull a locally available replicated app _(only valid when `[upstream-uri]` points to a replicated app)_ |
 | `-n, --namespace` | string | namespace to render the upstream to in the base _(default `"default"`)_ |
 | `--registry-endpoint` | string | the endpoint of the local docker registry to use when pushing images _(required when `--rewrite-images` is set)_ |
-| `--repo` | string | repo uri to use when downloading a helm chart |
 | `--rewrite-images` | bool | set to true to force all container images to be rewritten and pushed to a local registry |
 | `--rootdir` | string | root directory that will be used to write the yaml to _(default `${HOME}` or `%USERPROFILE%`)_ |
-| `--set` | strings | values to pass to helm when running helm template |
 | `--shared-password` | string | shared password to use when deploying the admin console |
 | `--http-proxy` | string | sets HTTP_PROXY environment variable in all KOTS Admin Console components |
 | `--https-proxy` | string | sets HTTPS_PROXY environment variable in all KOTS Admin Console components |
@@ -39,5 +36,4 @@ This command supports all [global flags](kots-cli-global-flags) and also:
 ### Examples
 ```bash
 kubectl kots pull sentry/unstable --license-file ~/license.yaml
-kubectl kots pull helm://elastic/elasticsearch --helm-version v3
 ```


### PR DESCRIPTION
Remove references to deprecated `kots pull helm` command. 
Internal ticket: [sc-47336](https://app.shortcut.com/replicated/story/47336/remove-code-for-install-helm-chart-from-kots-alpha-experiment)