### PR TITLE
add helm-chart-missing and helm-archive-missing lint rules

### DIFF
--- a/docs/partials/kots-lint-rules/_invalid-yaml.mdx
+++ b/docs/partials/kots-lint-rules/_invalid-yaml.mdx
@@ -1,0 +1,14 @@
+**Correct**:
+
+```yaml
+spec:
+  kubernetes:
+    version: 1.24.5
+```
+
+**Incorrect**:
+
+```yaml
+spec:
+  kubernetes: version 1.24.x
+```

--- a/docs/partials/kots-lint-rules/_invalid_type.mdx
+++ b/docs/partials/kots-lint-rules/_invalid_type.mdx
@@ -1,0 +1,15 @@
+**Correct**:
+
+```yaml
+ports:
+  - serviceName: "example"
+    servicePort: 80
+```
+
+**Incorrect**:
+
+```yaml
+ports:
+  - serviceName: "example"
+    servicePort: "80"
+```

--- a/docs/reference/kots-lint.mdx
+++ b/docs/reference/kots-lint.mdx
@@ -422,6 +422,49 @@ spec:
 </table>
 
 
+### helm-archive-missing
+
+<table>
+  <tr>
+    <th>Description</th>
+    <td>
+      <p>Requires that a <code>*.tar.gz</code> file is present that matches what is in the HelmChart custom resource manifest file.</p>
+    </td>
+  </tr>
+  <tr>
+    <th>Level</th>
+    <td>Error</td>
+  </tr>
+  <tr>
+    <th>Applies To</th>
+    <td>
+    Releases with a HelmChart custom resource manifest file containing <code>kind: HelmChart</code> and <code>apiVersion: kots.io/v1beta1</code>.
+    </td>
+  </tr>
+</table>
+
+### helm-chart-missing
+
+<table>
+  <tr>
+    <th>Description</th>
+    <td>
+      <p>Enforces that a HelmChart custom resource manifest file with <code>kind: HelmChart</code> is present if there is a <code>*.tar.gz</code> archive present.</p>
+    </td>
+  </tr>
+  <tr>
+    <th>Level</th>
+    <td>Error</td>
+  </tr>
+  <tr>
+    <th>Applies To</th>
+    <td>
+    Releases with a <code>*.tar.gz</code> archive file present.
+    </td>
+  </tr>
+</table>
+
+
 ### invalid-helm-release-name
 
 <table>

--- a/docs/reference/kots-lint.mdx
+++ b/docs/reference/kots-lint.mdx
@@ -32,7 +32,8 @@ import RepeatOptionMissingValuesByGroup from "../partials/kots-lint-rules/_repea
 import RepeatOptionMalformedYAMLPath from "../partials/kots-lint-rules/_repeat-option-malformed-yamlpath.mdx"
 import ConfigOptionPasswordType from "../partials/kots-lint-rules/_config-option-password-type.mdx"
 import ConfigOptionIsCircular from "../partials/kots-lint-rules/_config-option-is-circular.mdx"
-import InvalidType from "../partials/kots-lint-rules/_invalid-type.mdx"
+import InvalidType from "../partials/kots-lint-rules/_invalid_type.mdx"
+import InvalidYaml from "../partials/kots-lint-rules/_invalid-yaml.mdx"
 
 # KOTS Lint Rules
 
@@ -411,6 +412,10 @@ spec:
     <td>
       YAML files.
     </td>
+  </tr>
+  <tr>
+    <th>Example</th>
+    <td><InvalidYaml/></td>
   </tr>
 </table>
 

--- a/docs/reference/kots-lint.mdx
+++ b/docs/reference/kots-lint.mdx
@@ -384,7 +384,7 @@ spec:
   <tr>
     <th>Applies To</th>
     <td>
-      All files.
+      All files
     </td>
   </tr>
   <tr>
@@ -410,7 +410,7 @@ spec:
   <tr>
     <th>Applies To</th>
     <td>
-      YAML files.
+      YAML files
     </td>
   </tr>
   <tr>

--- a/docs/reference/kots-lint.mdx
+++ b/docs/reference/kots-lint.mdx
@@ -32,6 +32,7 @@ import RepeatOptionMissingValuesByGroup from "../partials/kots-lint-rules/_repea
 import RepeatOptionMalformedYAMLPath from "../partials/kots-lint-rules/_repeat-option-malformed-yamlpath.mdx"
 import ConfigOptionPasswordType from "../partials/kots-lint-rules/_config-option-password-type.mdx"
 import ConfigOptionIsCircular from "../partials/kots-lint-rules/_config-option-is-circular.mdx"
+import InvalidType from "../partials/kots-lint-rules/_invalid-type.mdx"
 
 # KOTS Lint Rules
 
@@ -362,6 +363,54 @@ spec:
   <tr>
     <th>Example</th>
     <td><InvalidKubernetesInstaller/></td>
+  </tr>
+</table>
+
+
+### invalid_type
+
+<table>
+  <tr>
+    <th>Description</th>
+    <td>
+      <p>Requires that the value of a property matches that property's expected type.</p>
+    </td>
+  </tr>
+  <tr>
+    <th>Level</th>
+    <td>Error</td>
+  </tr>
+  <tr>
+    <th>Applies To</th>
+    <td>
+      All files.
+    </td>
+  </tr>
+  <tr>
+    <th>Example</th>
+    <td><InvalidType/></td>
+  </tr>
+</table>
+
+
+### invalid-yaml
+
+<table>
+  <tr>
+    <th>Description</th>
+    <td>
+      <p>Enforces valid YAML.</p>
+    </td>
+  </tr>
+  <tr>
+    <th>Level</th>
+    <td>Error</td>
+  </tr>
+  <tr>
+    <th>Applies To</th>
+    <td>
+      YAML files.
+    </td>
   </tr>
 </table>
 


### PR DESCRIPTION
This PR adds these missing rules to the [KOTS lint docs page](https://docs.replicated.com/reference/kots-lint):
- helm-archive-missing
- helm-chart-missing
- invalid-yaml
- invalid_type

Related story: https://app.shortcut.com/replicated/story/61334/add-docs-for-missing-linter-rules