### PR TITLE
Fix inaccuracy in headless install

### DIFF
--- a/docs/enterprise/installing-existing-cluster-automation.md
+++ b/docs/enterprise/installing-existing-cluster-automation.md
@@ -90,7 +90,7 @@ kubectl kots install app-name \
   --no-port-forward
 ```
 
-After this completes, you can optionally run the following command to start the admin console:
+After this completes, you can optionally run the following command to access the admin console at http://localhost:8800:
 
 ```
 kubectl kots admin-console --namespace NAMESPACE

--- a/docs/enterprise/installing-existing-cluster-automation.md
+++ b/docs/enterprise/installing-existing-cluster-automation.md
@@ -90,7 +90,12 @@ kubectl kots install app-name \
   --no-port-forward
 ```
 
-After this has completed, you can go to http://localhost:8800 will show the configured application dashboard, assuming all required config items were set and any included preflight checks passed.
+After this completes, you can optionally run the following command to start the admin console:
+
+```
+kubectl kots admin-console --namespace NAMESPACE
+```
+Replace `NAMESPACE` with the namespace you specified in the `kots install` command.
 
 ## Air Gap Installation
 


### PR DESCRIPTION
Story: https://app.shortcut.com/replicated/story/46286/confusing-directions-in-headless-installation

Fixing inaccurate statement that says you can access the admin console at port 8800 after running with --no-port-forward. Instead, you can run `kubectl kots admin-console --namespace NAMESPACE` to start the admin console if you want

Preview: https://deploy-preview-779--replicated-docs.netlify.app/enterprise/installing-existing-cluster-automation#disable-admin-console-port-forwarding