### PR TITLE
Update notes on Redactors

### DIFF
--- a/docs/reference/custom-resource-redactor.md
+++ b/docs/reference/custom-resource-redactor.md
@@ -1,6 +1,6 @@
 # Redactor
 
-Preflight checks and support bundles include built-in redactors that hide sensitive customer data before it is analyzed. These default redactors hide passwords, tokens, AWS secrets, IP addresses, database connection strings, and URLs that contain usernames and passwords.
+Preflight checks and support bundles include built-in redactors that hide sensitive customer data before it is analyzed. These default redactors hide passwords, tokens, AWS secrets, database connection strings, and URLs that contain usernames and passwords.
 
 The default redactors cannot be disabled, but you can add custom redactors to support bundles using the Redactor custom resource manifest file. For example, you can redact API keys or account numbers, depending on your customer needs. For more information about redactors, see [Redacting Data](https://troubleshoot.sh/docs/redact/) in the Troubleshoot documentation.
 

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -39,7 +39,7 @@ Collectors identify what data to collect for analysis for preflight checks and s
 ### Redactors
 Redactors censor sensitive customer information from the data gathered by the collectors, before the preflight checks and support bundles analyze the data. By default, the following information is redacted:
 
-- Passwords 
+- Passwords
 - API token environment variables in JSON
 - AWS credentials
 - Database connection strings
@@ -47,7 +47,7 @@ Redactors censor sensitive customer information from the data gathered by the co
 
 This functionality cannot be disabled in the Replicated app manager. You can add custom redactors to support bundles only.
 
-To verify that the default redactors meet your requirements, see the [Redact](https://troubleshoot.sh/docs/redact/) section in the Troubleshoot documentation for detail on what information the redactors detect.
+For more detail on what information the default redactors detect, see the [Redact](https://troubleshoot.sh/docs/redact/) section in the Troubleshoot documentation.
 
 ### Analyzers
 Analyzers use the non-redacted data from the collectors to identify issues. The outcomes that you specify are displayed to customers.

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -39,14 +39,15 @@ Collectors identify what data to collect for analysis for preflight checks and s
 ### Redactors
 Redactors censor sensitive customer information from the data gathered by the collectors, before the preflight checks and support bundles analyze the data. By default, the following information is redacted:
 
-- Passwords
-- Tokens
-- AWS secrets
-- IP addresses
+- Passwords 
+- API token environment variables in JSON
+- AWS credentials
 - Database connection strings
 - URLs that include usernames and passwords
 
 This functionality cannot be disabled in the Replicated app manager. You can add custom redactors to support bundles only.
+
+Please review the [Troubleshoot](https://troubleshoot.sh/) documentation for the specific information on what these redactors detect, as they might not cover your specific requirements.
 
 ### Analyzers
 Analyzers use the non-redacted data from the collectors to identify issues. The outcomes that you specify are displayed to customers.

--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -47,7 +47,7 @@ Redactors censor sensitive customer information from the data gathered by the co
 
 This functionality cannot be disabled in the Replicated app manager. You can add custom redactors to support bundles only.
 
-Please review the [Troubleshoot](https://troubleshoot.sh/) documentation for the specific information on what these redactors detect, as they might not cover your specific requirements.
+To verify that the default redactors meet your requirements, see the [Redact](https://troubleshoot.sh/docs/redact/) section in the Troubleshoot documentation for detail on what information the redactors detect.
 
 ### Analyzers
 Analyzers use the non-redacted data from the collectors to identify issues. The outcomes that you specify are displayed to customers.


### PR DESCRIPTION
Change https://github.com/replicatedhq/troubleshoot/pull/734 removes IPv4 address redaction by default.  This change removes that promise from the document, plus adds a little more disclaimer type info on the remaining redactors since the promise in the doc is more broad than the actual redactors can cover.