### PR TITLE
62155: Removed redundant statements from tutorial intros

### DIFF
--- a/docs/partials/getting-started/_tutorial-intro.mdx
+++ b/docs/partials/getting-started/_tutorial-intro.mdx
@@ -1,5 +1,5 @@
 This tutorial introduces you to the Replicated features for software vendors and their enterprise users. It is designed to familiarize you with the key concepts and processes that you use as a software vendor when you package and distribute your application with Replicated.
 
-In this tutorial, you use a set of sample application manifest files for a basic Kubernetes application to learn how to:
+In this tutorial, you use a set of sample manifest files for a basic NGINX application to learn how to:
 * Create and promote releases for an application as a software vendor
-* Install and update an application as an enterprise user
+* Install and update an application on a Kubernetes cluster as an enterprise user

--- a/docs/vendor/tutorial-cli-setup.mdx
+++ b/docs/vendor/tutorial-cli-setup.mdx
@@ -8,7 +8,7 @@ import VMRequirements from "../partials/getting-started/_vm-requirements.mdx"
 
 <TutorialIntro/>
 
-The steps in this CLI-based tutorial show you how to use the replicated CLI to create and promote releases for your application. The replicated CLI is the CLI for the Replicated vendor portal. You can use the replicated CLI as a software vendor to programmatically create, configure, and manage your application artifacts, including application releases, release channels, customer entitlements, private image registries, and more.
+The steps in this CLI-based tutorial show you how to use the replicated CLI to perform these tasks. The replicated CLI is the CLI for the Replicated vendor portal. You can use the replicated CLI as a software vendor to programmatically create, configure, and manage your application artifacts, including application releases, release channels, customer entitlements, private image registries, and more.
 
 For a tutorial that demonstrates how to use the Replicated vendor portal to create and promote releases for your application, see [UI Tutorial](tutorial-ui-setup).
 

--- a/docs/vendor/tutorial-ui-setup.mdx
+++ b/docs/vendor/tutorial-ui-setup.mdx
@@ -8,7 +8,7 @@ import VMRequirements from "../partials/getting-started/_vm-requirements.mdx"
 
 <TutorialIntro/>
 
-The steps in this UI-based tutorial show you how to use the Replicated vendor portal to create and promote releases for a sample NGINX application. The vendor portal is the user interface that you use as a software vendor to create, configure, and manage your application artifacts, including application releases, release channels, customer entitlements, private image registries, and more.
+The steps in this UI-based tutorial show you how to use the Replicated vendor portal to perform these tasks. The vendor portal is the user interface that you use as a software vendor to create, configure, and manage your application artifacts, including application releases, release channels, customer entitlements, private image registries, and more.
 
 For a tutorial that demonstrates how to use the replicated CLI to create and promote releases for your application, see [CLI Tutorial](tutorial-cli-setup).
 
@@ -16,7 +16,7 @@ For a tutorial that demonstrates how to use the replicated CLI to create and pro
 
 ## Set Up the Environment
 
-As part of this tutorial, you install a sample application onto an existing Kubernetes cluster, or onto a cluster provisioned by the Replicated Kubernetes installer. The Kubernetes installer creates the cluster on an existing VM.
+As part of this tutorial, you install a sample application onto an existing Kubernetes cluster, or onto a cluster provisioned by the Replicated Kubernetes installer. The Kubernetes installer creates the cluster on an existing virtual machine (VM).
 
 Before you begin this tutorial, ensure that you have one of the following environments set up:
 


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/62155/update-tutorial-intro-to-remove-redundancies

Previews:

- https://deploy-preview-784--replicated-docs.netlify.app/vendor/tutorial-ui-setup
- https://deploy-preview-784--replicated-docs.netlify.app/vendor/tutorial-cli-setup