### PR TITLE
Update helm-native-helm-install-order.md remove quotes from weight setting in docs

### DIFF
--- a/docs/vendor/helm-native-helm-install-order.md
+++ b/docs/vendor/helm-native-helm-install-order.md
@@ -48,7 +48,7 @@ To add a `weight` to native Helm charts:
      helmVersion: v3
 
      useHelmInstall: true
-     weight: "1"
+     weight: 1
 
      values:
        ...


### PR DESCRIPTION
Think that the weight number gives an error if it's in quotes