### PR TITLE
62925: Removed multifactor from two RBAC resources

### DIFF
--- a/docs/vendor/team-management-rbac-resource-names.md
+++ b/docs/vendor/team-management-rbac-resource-names.md
@@ -196,11 +196,11 @@ Grants the holder permission to create RBAC policies for the team.
 
 ### team/authentication/update
 
-Grants the holder permission to manage the following team authentication settings: multifactor authentication, Google authentication, Auto-join, and SAML authentication.
+Grants the holder permission to manage the following team authentication settings: Google authentication, Auto-join, and SAML authentication.
 
 ### team/authentication/read
 
-Grants the holder permission to read the following authentication settings: multifactor authentication, Google authentication, Auto-join, and SAML authentication.
+Grants the holder permission to read the following authentication settings: Google authentication, Auto-join, and SAML authentication.
 
 ### team/security/update
 


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/62925/remove-multifactor-from-the-team-authentication-read-and-team-authentication-update-docs

Previews:

- https://deploy-preview-805--replicated-docs.netlify.app/vendor/team-management-rbac-resource-names#teamauthenticationupdate
- https://deploy-preview-805--replicated-docs.netlify.app/vendor/team-management-rbac-resource-names#teamauthenticationread