### PR TITLE
Corrects a typo in the embedded cluster steps

### DIFF
--- a/docs/vendor/tutorial-ui-install-app-manager.md
+++ b/docs/vendor/tutorial-ui-install-app-manager.md
@@ -70,7 +70,7 @@ To install the app manager on a VM using the Kubernetes installer:
   **Example:**
 
   ```bash
-  glcloud compute ssh NAME
+  gcloud compute ssh NAME
   ```
 
   Replace NAME with the name of the cluster.


### PR DESCRIPTION
Fixes a typo in the `gcloud` command where it was shown as `glcloud`.