### PR TITLE
Fixes copy/paste error

### DIFF
--- a/docs/reference/replicated-cli-release-create.md
+++ b/docs/reference/replicated-cli-release-create.md
@@ -38,7 +38,7 @@ replicated release create --yaml-dir YAML_DIR [flags]
   <tr>
     <td><code>--release-notes</code></td>
     <td>string</td>
-    <td>When used with <code>--promote channel</code>, sets the version label for the release in this channel.</td>
+    <td>When used with <code>--promote channel</code>, creates the release notes in markdown.</td>
   </tr>
   <tr>
     <td><code>--version</code></td>


### PR DESCRIPTION
https://github.com/replicatedhq/replicated-docs/issues/834 caught a copy/paste error on the description of release notes and version flags for the replicated CLI release create command.