### PR TITLE
doc: Clarifies the recommendations to not lead users to make bad design choices by looking the docs examples

### DIFF
--- a/docs/vendor/packaging-ingress.md
+++ b/docs/vendor/packaging-ingress.md
@@ -116,3 +116,5 @@ You should think carefully about the options added to be installed via your solu
 
 Assuming that your solution requires Prometheus and you are looking for a design that would be possible to consume it in a pre-existing cluster. Ideally, a cluster should have only one Prometheus installed and configured, which will serve all solutions running on it. Therefore, unless your solution's primary purpose would be installing and managing Prometheus, it does not fit in the application domain. Otherwise, it might become problematic when more than one solution deployed on the cluster tries to install Prometheus in this example. 
 
+For needs like the above example, a recommended approach would be to let the application users know that they can quickly get it running with the embedded cluster(`kURL`) or ensure that your solution's pre-requirements are correctly available on the pre-existent cluster. A typical option is to address this requirement via guidance and docs.
+ 

--- a/docs/vendor/packaging-ingress.md
+++ b/docs/vendor/packaging-ingress.md
@@ -107,3 +107,12 @@ spec:
               serviceName: nginx
               servicePort: 80
 ```
+
+## It is NOT recommended to use this option to address needs outside of the solution domain
+
+You should think carefully about the options added to be installed via your solution. Suppose you are looking to develop a design where your application would be capable of installing what is installed by the embedded cluster ([kURL](https://kurl.sh/)). Than note that it is **not** recommended design. Keep in mind that the kURL will install solutions that are valid for the whole cluster and which does not fit well in the application domain. 
+
+**To better clarifies the above recommendation, let's think in the example following example scenario.**
+
+Assuming that your solution requires Prometheus and you are looking for a design that would be possible to consume it in a pre-existing cluster. Ideally, a cluster should have only one Prometheus installed and configured, which will serve all solutions running on it. Therefore, unless your solution's primary purpose would be installing and managing Prometheus, it does not fit in the application domain. Otherwise, it might become problematic when more than one solution deployed on the cluster tries to install Prometheus in this example. 
+

--- a/docs/vendor/packaging-ingress.md
+++ b/docs/vendor/packaging-ingress.md
@@ -108,9 +108,9 @@ spec:
               servicePort: 80
 ```
 
-## It is NOT recommended to use this option to address needs outside of the solution domain
+## Common Pitfalls and Best Practices
 
-You should think carefully about the options added to be installed via your solution. Suppose you are looking to develop a design where your application would be capable of installing what is installed by the embedded cluster ([kURL](https://kurl.sh/)). Than note that it is **not** recommended design. Keep in mind that the kURL will install solutions that are valid for the whole cluster and which does not fit well in the application domain. 
+It is NOT recommended to use the option described above to address needs outside of the solution domain. You should think carefully about the options added to be installed via your solution. Suppose you are looking to develop a design where your application would be capable of installing what is installed by the embedded cluster ([kURL](https://kurl.sh/)). Than note that it is **not** recommended design. Keep in mind that the kURL will install solutions that are valid for the whole cluster and which does not fit well in the application domain. 
 
 **To better clarifies the above recommendation, let's think in the example following example scenario.**
 


### PR DESCRIPTION
## Description 

The example to use `kots.io/exclude` might lead users to think that is recommended they try to install what is installed by KURL when it should not be done and would be considered a bad practice. 

So, the goal of this PR is added the info to let the users be able to carefully think about how they will use this feature.