### PR TITLE
Edit section title to remove verb

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -68,7 +68,7 @@ const sidebars = {
         'vendor/planning-questionnaire',
         {
             type: 'category',
-            label: 'Using Private Registries',
+            label: 'Private Registries',
             items: [
               'vendor/packaging-private-images',
               'vendor/helm-image-registry',


### PR DESCRIPTION
Aligns with our new strategy of limiting words. (Feedback from JQ that I forgot to incorporate on previous PR: https://app.shortcut.com/replicated/story/64385/change-using-private-registries-to-private-registries)