### PR TITLE
Move Swarm, Ship, AKA to EOL in support table

### DIFF
--- a/docs/vendor/policies-support-lifecycle.md
+++ b/docs/vendor/policies-support-lifecycle.md
@@ -46,19 +46,19 @@ Replicated will provide support for products per our terms and services until th
   </tr>
   <tr>
     <td><a href="https://help.replicated.com/docs/kubernetes/getting-started/overview/">Replicated Classic (AKA SDK)</a></td>
-    <td>EOA</td>
+    <td>EOL</td>
     <td>2022-02-28</td>
     <td>2022-12-31</td>
   </tr>
   <tr>
     <td><a href="https://help.replicated.com/docs/ship/getting-started/overview/">Replicated Classic (Ship SDK)</a></td>
-    <td>EOA</td>
+    <td>EOL</td>
     <td>2022-02-28</td>
     <td>2022-12-31&#42;</td>
   </tr>
   <tr>
     <td><a href="https://help.replicated.com/docs/swarm/getting-started/overview/">Replicated Classic (Swarm SDK)</a></td>
-    <td>EOA</td>
+    <td>EOL</td>
     <td>2022-02-28</td>
     <td>2022-12-31&#42;</td>
   </tr>
@@ -68,4 +68,4 @@ Replicated will provide support for products per our terms and services until th
 
 The information contained herein is believed to be accurate as of the date of publication, but updates and revisions may be posted periodically and without notice.
 
-Last modified December 8, 2022.
+Last modified January 3, 2023.


### PR DESCRIPTION
Now that it's past 12/31/22, these products need to be updated from EOA to EOL