### PR TITLE
59193: Adding link to default spec

### DIFF
--- a/docs/vendor/preflight-support-bundle-creating.md
+++ b/docs/vendor/preflight-support-bundle-creating.md
@@ -139,7 +139,7 @@ Customizing a support bundle is unique to your application. Replicated app manag
 
 By default, support bundles contain a large number of commonly used, best practice collectors. The default `clusterInfo` and `clusterResources` collectors gather a large amount of data that is useful when remotely installing or debugging a Kubernetes application. You can supplement, edit, or exclude the default collectors and analyzers. You can also add redactors to the default redactors.
 
-This procedure provides a basic understanding and some key considerations to help guide you. For more information about configuring support bundles, see [Collecting Data](https://troubleshoot.sh/docs/collect/), [Redacting Data](https://troubleshoot.sh/docs/redact/), and [Analyzing Data](https://troubleshoot.sh/docs/analyze/) in the Troubleshoot documentation.
+This procedure provides a basic understanding and some key considerations to help guide you. For more information about configuring support bundles, see [Collecting Data](https://troubleshoot.sh/docs/collect/), [Redacting Data](https://troubleshoot.sh/docs/redact/), and [Analyzing Data](https://troubleshoot.sh/docs/analyze/) in the Troubleshoot documentation. You can also see the entire default specification at [spec.yaml](https://github.com/replicatedhq/kots/blob/main/pkg/supportbundle/defaultspec/spec.yaml) in the kots repository.
 
 To customize a support bundle:
 


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/59193/add-analyzer-example-to-support-bundle-content

Changed the scope of the SC ticket. Decided to simplify the complex request and docs by adding a link to the default kots support bundle spec.

Preview: https://deploy-preview-875--replicated-docs.netlify.app/vendor/preflight-support-bundle-creating#customize-a-support-bundle