### PR TITLE
Add Replicated `helm template` limitation

### DIFF
--- a/docs/partials/helm/_helm-cli-limitations.mdx
+++ b/docs/partials/helm/_helm-cli-limitations.mdx
@@ -1,6 +1,6 @@
-* No support for "last mile" changes with Kustomize. All configuration and customization must be done using Helm.
-* No support for `strict` preflights that block application installation. This is because Helm does not automatically run preflight checks. Preflight checks are supported with `helm install`, but your users must run the preflight checks manually before installing your application.
-* No support for air gap installations.
+* "Last mile" changes with Kustomize are not supported. All configuration and customization must be done using Helm.
+* Strict preflights that block application installation are not supported. This is because Helm does not automatically run preflight checks. Preflight checks are supported with `helm install`, but your users must run the preflight checks manually before installing your application.
+* Air gap installations are not supported.
 * Customer adoption is not reported to the vendor portal.
 * This feature supports multiple charts and Replicated does not wrap or provide any special tooling to manage multiple charts. Replicated recommends that you provide installation instructions with sequenced steps for users to follow to install each chart in the required order.
-* The Replicated admin console is not included by default when your users install using the helm CLI. For more information, see [Delivering the Admin Console with your Application](/vendor/helm-install#deliver-admin-console).
+* The Replicated admin console is not included by default when your users install using the helm CLI. For more information about how to include the admin console with your application for helm CLI installations, see [Delivering the Admin Console with your Application](/vendor/helm-install#deliver-admin-console).

--- a/docs/partials/helm/_helm-cli-limitations.mdx
+++ b/docs/partials/helm/_helm-cli-limitations.mdx
@@ -1,0 +1,6 @@
+* No support for "last mile" changes with Kustomize. All configuration and customization must be done using Helm.
+* No support for `strict` preflights that block application installation. This is because Helm does not automatically run preflight checks. Preflight checks are supported with `helm install`, but your users must run the preflight checks manually before installing your application.
+* No support for air gap installations.
+* Customer adoption is not reported to the vendor portal.
+* This feature supports multiple charts and Replicated does not wrap or provide any special tooling to manage multiple charts. Replicated recommends that you provide installation instructions with sequenced steps for users to follow to install each chart in the required order.
+* The Replicated admin console is not included by default when your users install using the helm CLI. For more information, see [Delivering the Admin Console with your Application](/vendor/helm-install#deliver-admin-console).

--- a/docs/partials/helm/_helm-template-limitation.mdx
+++ b/docs/partials/helm/_helm-template-limitation.mdx
@@ -1,0 +1,3 @@
+* Helm Kubernetes functions such as `lookup` and some `Capabilities` values are not supported with the Native Helm and Replicated KOTS deployment methods.
+
+   This is because the app manager uses the `helm template` command to render chart templates locally. During rendering, Helm does not have access to the cluster where the chart will be installed. For more information, see [Kubernetes and Chart Functions](https://helm.sh/docs/chart_template_guide/function_list/#kubernetes-and-chart-functions) in the Helm documentation.

--- a/docs/partials/helm/_native-helm-limitations.mdx
+++ b/docs/partials/helm/_native-helm-limitations.mdx
@@ -1,0 +1,8 @@
+* Only available for Helm V3.
+* Only supported for new installations.
+* Not supported on existing charts deployed on existing applications.
+* Migrating existing applications to the Native Helm deployment method is not supported. To deliver applications using the Native Helm deployment method, promote releases to a new channel for new customer installations.
+* The test hook is not supported.
+* Hook weights below -9999 are not supported. All hook weights must be set to a value above -9999 to ensure the Replicated image pull secret is deployed before any resources are pulled.
+* Not supported with GitOps workflows. For more information, see [Pushing Updates to a GitOps Workflow](/enterprise/gitops-workflow) in the _Enterprise_ documentation.
+* The name specified in the HelmChart custom resource must be an exact match to the actual Helm chart name that is provided to Replicated. If the Helm chart names do not match, then the installation can error or fail. See [HelmChart](/reference/custom-resource-helmchart) in _Custom Resources_.

--- a/docs/vendor/helm-install.md
+++ b/docs/vendor/helm-install.md
@@ -1,3 +1,5 @@
+import HelmCLILimitations from "../partials/helm/_helm-cli-limitations.mdx"
+
 # Supporting helm CLI Installations (Beta)
 
 :::note
@@ -60,12 +62,7 @@ The chart version must also comply with the Semantic Versioning (SemVer) specifi
 
 The `helm install` method is Beta and has the following limitations:
 
-* No support for "last mile" changes with Kustomize. All configuration and customization must be done using Helm.
-* No support for `strict` preflights that block application installation. This is because Helm does not automatically run preflight checks. Preflight checks are supported with `helm install`, but your users must run the preflight checks manually before installing your application.
-* No support for air gap installations.
-* Customer adoption is not reported to the vendor portal.
-* This feature supports multiple charts and Replicated does not wrap or provide any special tooling to manage multiple charts. Replicated recommends that you provide installation instructions with sequenced steps for users to follow to install each chart in the required order.
-* The Replicated admin console is not included by default when your users install using the helm CLI. For more information, see [Delivering the Admin Console with your Application](#deliver-admin-console) below.
+<HelmCLILimitations/>
 
 ## Delivering the Admin Console with your Application {#deliver-admin-console}
 

--- a/docs/vendor/helm-installing-native-helm.md
+++ b/docs/vendor/helm-installing-native-helm.md
@@ -1,3 +1,6 @@
+import NativeHelmLimitations from "../partials/helm/_native-helm-limitations.mdx"
+import TemplateLimitation from "../partials/helm/_helm-template-limitation.mdx"
+
 # Installing with Native Helm
 
 With the native Helm installation, you can exercise more control over chart deployment using Helm hooks and weights. In the native Helm installation workflow, the app manager deploys the app's v3 Helm charts with a `helm install` command. This means that Helm owns the installation and lifecycle management of the chart resources. For new applications, native Helm is the preferred method because it supports more Helm features, such as hook and weights.
@@ -8,14 +11,8 @@ Migrating existing installations to the native Helm workflow is not supported. H
 
 ## Native Helm Limitations
 The native Helm chart support has the following limitations:
-* Only available for Helm V3.
-* Only supported for new installations.
-* Not supported on existing charts deployed on existing applications.
-* Migrating existing applications to the native Helm implementation is not supported. To deliver applications using the native Helm workflow, promote releases to a new channel for new customer installations.
-* The test hook is not supported.
-* Hook weights below -9999. All hook weights must be set to a value above -9999 to ensure the Replicated image pull secret is deployed before any resources are pulled.
-* Not supported with the [GitOps workflows](../enterprise/gitops-workflow).
-* The name specified in the [HelmChart custom resource](/reference/custom-resource-helmchart) must be an exact match to the actual Helm Chart name that is provided to Replicated; failure to do this will result in errored installations.
+<TemplateLimitation/>
+<NativeHelmLimitations/>
 
 ### Helm Hooks and Weights
 

--- a/docs/vendor/helm-overview.md
+++ b/docs/vendor/helm-overview.md
@@ -1,3 +1,7 @@
+import NativeHelmLimitations from "../partials/helm/_native-helm-limitations.mdx"
+import TemplateLimitation from "../partials/helm/_helm-template-limitation.mdx"
+import HelmCLILimitations from "../partials/helm/_helm-cli-limitations.mdx"
+
 # About Packaging with Helm
 
 Helm is a popular package manager for Kubernetes applications. If your application is already packaged using Helm, you can use Replicated to more easily distribute and manage your application. Using Replicated to distribute applications packaged with Helm provides additional functionality not available through Helm, such as preflight checks, support bundles, a user interface for collecting user configuration values, support for using private images, and more.
@@ -20,12 +24,13 @@ The following describes the Native Helm and Replicated KOTS deployment methods:
 
 * **Native Helm (Recommended)**: The app manager uses the Helm binary to install and manage the lifecycle of the chart resources that are part of the application. This is the preferred method because it supports more features of Helm, such as hooks and weights.
 
-   For more information, see [Native Helm](helm-processing#native-helm) in _How the App Manager Processes Helm Charts_. See also [Enabling and Using Native Helm Charts](helm-installing-native-helm#enabling-and-using-native-helm-charts) in _Installing with Native Helm_.
+For more information, see [Native Helm](helm-processing#native-helm) in _How the App Manager Processes Helm Charts_. See also [Enabling and Using Native Helm Charts](helm-installing-native-helm#enabling-and-using-native-helm-charts) in _Installing with Native Helm_.
 
 * **Replicated KOTS**: The app manager renders the Helm templates and deploys them as standard Kubernetes manifests using `kubectl apply`. The app manager manages the lifecycle of the resources.
 
    For more information, see [Replicated KOTS](helm-processing#replicated-kots) in _How the App Manager Processes Helm Charts_.
 
+For limitations of the Native Helm and Replicated KOTS deployment methods, see [Native Helm and Replicated KOTS Limitations](#replicated-helm-limitations) below.  
 ### Using the helm CLI (Beta)
 
 Users can install an application packaged with a Helm chart into an existing cluster using the helm CLI. When users install with the helm CLI directly, Helm, rather than the app manager, manages the lifecycle of the application.
@@ -35,3 +40,28 @@ Deploying an application with the helm CLI differs from the "Native Helm" deploy
 Users do not have access to certain Replicated features when they install and manage the application with the helm CLI directly. This is because the app manager does not manage the lifecycle of the application. For example, users must update the application using the `helm upgrade` command, rather than using the admin console UI or the kots CLI.
 
 For more information about how to package an application so that users can install using the helm CLI, see [Supporting helm CLI Installations (Beta)](helm-install).
+
+## Limitations
+
+This section lists the limitations for packaging an application with Helm charts.
+
+There are different limitations depending on if your customers install and manage the application with the app manager, or if they use the helm CLI directly:
+
+* [Replicated KOTS and Native Helm Limitations](#replicated-helm-limitations)
+* [helm CLI Install Limitations](#helm-cli-limitations)
+
+### Native Helm and Replicated KOTS Limitations {#replicated-helm-limitations}
+
+The following limitations apply when using the app manager to install and manage Helm charts:
+
+<TemplateLimitation/>
+
+* The following limitations apply to the Native Helm deployment method:
+
+  <NativeHelmLimitations/>
+
+### helm CLI Install Limitations {#helm-cli-limitations}
+
+The helm CLI installation method is Beta and has the following limitations:
+
+<HelmCLILimitations/>


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/60145/document-that-helm-functions-that-require-access-to-cluster-are-not-supported

Creates a new Limitations section that applies to both the Replicated helm deployment methods ("Replicated KOTS" and "Native Helm") & adds a new limitation about how Helm cannot access the cluster during rendering with the `helm template` command.

Previews (used a snippet so that this shows up in a couple places):
* Adds the new limitation to the existing list of Native Helm limitations: https://deploy-preview-877--replicated-docs.netlify.app/vendor/helm-installing-native-helm#native-helm-limitations
* Adds a new Limitations section in `helm-overview.md` that lists all limitations for all Helm install methods: https://deploy-preview-877--replicated-docs.netlify.app/vendor/helm-overview#limitations 