### PR TITLE
Change sidebar to add an SBOM subcategory in prep for more upcoming SBOM docs

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -466,9 +466,18 @@ const sidebars = {
             },
           ],
         },
+        {
+          type: 'category',
+          label: 'SBOM',
+          items: [
+            {
+              type: 'doc',
+              id: 'reference/kots-validating-sbom'
+            },
+          ]
+        },
         'reference/cron-expressions',
         'reference/linter',
-        'reference/kots-validating-sbom',
       ],
     },
     {


### PR DESCRIPTION
Change sidebar to add an SBOM subcategory in prep for more upcoming SBOM related documentation. 

Moved the existing KOTS SBOM reference doc under this new SBOM subcategory