### PR TITLE
update supported k8s versions for app manager

### DIFF
--- a/.github/workflows/app-manager-release-notes.yml
+++ b/.github/workflows/app-manager-release-notes.yml
@@ -22,7 +22,7 @@ jobs:
         owner-repo: replicatedhq/kots
         head: $KOTS_VERSION
         title: ${KOTS_VERSION#v}
-        description: 'Support for Kubernetes: 1.21, 1.22, 1.23, 1.24, and 1.25'
+        description: 'Support for Kubernetes: 1.23, 1.24, 1.25, and 1.26'
         include-pr-links: false
         github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
this PR updates the automated release notes action to reflect the currently supported k8s versions for the next kots release