### PR TITLE
Update KOTS install reference to include new env variable options

### DIFF
--- a/docs/reference/kots-cli-getting-started.md
+++ b/docs/reference/kots-cli-getting-started.md
@@ -13,22 +13,22 @@ If you are using an [embedded Kubernetes installer-created cluster](../enterpris
 
 ## Install
 
-To install the latest version of the kots CLI, run:
+To install the latest version of the kots CLI to `/usr/local/bin`, run:
 
 ```bash
 curl https://kots.io/install | bash
+```
+
+To install to a directory other than `/usr/local/bin`, run:
+
+```bash
+curl https://kots.io/install | REPL_INSTALL_PATH=/path/to/cli bash
 ```
 
 To install a specific version of the kots CLI, run:
 
 ```bash
 curl https://kots.io/install/<version> | bash
-```
-
-To install to a directory different than the default, `/usr/local/bin`, use the `REPL_INSTALL_PATH` environment variable.
-
-```bash
-curl https://kots.io/install | REPL_INSTALL_PATH=/usr/sbin bash
 ```
 
 To verify your installation, run:
@@ -39,27 +39,27 @@ kubectl kots --help
 
 ## Install without Root Access
 
-You can install the kots CLI on computers without root access or computers that cannot write to the `/usr/local/bin` directory. This procedure applies to online clusters and air gapped environments.
+You can install the kots CLI on computers without root access or computers that cannot write to the `/usr/local/bin` directory.
 
 ### Using the Install Script
 
-To install the `kots` CLI without root access, two environment variables are provided for altering the behavior of the install script, `REPL_INSTALL_PATH` and `REPL_USE_SUDO`. 
+To install the kots CLI without root access in an online environment, you can change the installation path to a directory that doesn't require elevated permissions, or you can have the installation script prompt you for your sudo password if needed.
 
-The `REPL_INSTALL_PATH` variable can be set to install to a different directory. The user home symbol `~` can be used and will be expanded to `$HOME`.
+The `REPL_INSTALL_PATH` environment variable can be used to install to a different directory. The user home symbol `~` can be used and will be expanded to `$HOME`.
 
 **Example:**
 ```bash
 curl -L https://kots.io/install | REPL_INSTALL_PATH=~/bin bash
 ```
 
-The `REPL_USE_SUDO` environment flag can be set to any value if the install can be done using sudo. This will use sudo to create and write to the installation directory as needed. The script will also prompt for the sudo password if it is required for the user executing the script.
+The `REPL_USE_SUDO` environment variable can be set to any value if the install can be done using sudo. The installation script will use sudo to create and write to the installation directory as needed. The script will prompt for the sudo password if it is required for the user executing the script.
 
 **Example:**
 ```bash
 curl -L https://kots.io/install | REPL_USE_SUDO=y bash
 ```
 
-The two environment variables can be combined to use a different install directory that also requires sudo for creation and writing.
+The two environment variables can be combined to use a different directory that also requires sudo.
 
 **Example:**
 ```bash

--- a/docs/reference/kots-cli-getting-started.md
+++ b/docs/reference/kots-cli-getting-started.md
@@ -49,7 +49,7 @@ To install the kots CLI without root access, you can do any of the following:
 
 ### Install to a Different Directory
 
-You can set the `REPL_INSTALL_PATH` environment variable to install the kots CLI to a directory other `/usr/local/bin` that does not require elevated permissions.
+You can set the `REPL_INSTALL_PATH` environment variable to install the kots CLI to a directory other than `/usr/local/bin` that does not require elevated permissions.
 
 **Example:**
 

--- a/docs/reference/kots-cli-getting-started.md
+++ b/docs/reference/kots-cli-getting-started.md
@@ -41,34 +41,55 @@ kubectl kots --help
 
 You can install the kots CLI on computers without root access or computers that cannot write to the `/usr/local/bin` directory.
 
-### Using the Install Script
+To install the kots CLI without root access, you can do any of the following:
 
-To install the kots CLI without root access in an online environment, you can change the installation path to a directory that doesn't require elevated permissions, or you can have the installation script prompt you for your sudo password if needed.
+* (Online Only) [Install to a Different Directory](#install-to-a-different-directory)
+* (Online Only) [Install Using Sudo](#install-using-sudo)
+* (Online or Air Gap) [Manually Download and Install](#manually-download-and-install)
 
-The `REPL_INSTALL_PATH` environment variable can be used to install to a different directory. The user home symbol `~` can be used and will be expanded to `$HOME`.
+### Install to a Different Directory
+
+You can set the `REPL_INSTALL_PATH` environment variable to install the kots CLI to a directory other `/usr/local/bin` that does not require elevated permissions.
 
 **Example:**
+
 ```bash
 curl -L https://kots.io/install | REPL_INSTALL_PATH=~/bin bash
 ```
 
-The `REPL_USE_SUDO` environment variable can be set to any value if the install can be done using sudo. The installation script will use sudo to create and write to the installation directory as needed. The script will prompt for the sudo password if it is required for the user executing the script.
+In the example above, the installation script installs the kots CLI to `~/bin` in the local directory.
+
+:::note
+You can use the user home symbol `~` in the `REPL_INSTALL_PATH` environment variable. The script expands `~` to `$HOME`.
+:::
+
+### Install Using Sudo
+
+If you have sudo access to the directory where you want to install the kots CLI, you can set the `REPL_USE_SUDO` environment variable so that the installation script prompts you for your sudo password.
+
+When you set the `REPL_USE_SUDO` environment variable to any value, the installation script uses sudo to create and write to the installation directory as needed. The script prompts for a sudo password if it is required for the user executing the script in the specified directory.
 
 **Example:**
+
 ```bash
 curl -L https://kots.io/install | REPL_USE_SUDO=y bash
 ```
-
-The two environment variables can be combined to use a different directory that also requires sudo.
+In the example above, the script uses sudo to install the kots CLI to the default `/usr/local/bin` directory.
 
 **Example:**
+
 ```bash
 curl -L https://kots.io/install | REPL_INSTALL_PATH=/replicated/bin REPL_USE_SUDO=y bash
 ```
+In the example above, the script uses sudo to install the kots CLI to the `/replicated/bin` directory.
 
-### Manual Install
+### Manually Download and Install
 
-To download the `kots` CLI without root access:
+You can manually download and install the kots CLI binary to install without root access, rather than using the installation script.
+
+Users in air gap environments can also follow this procedure to install the kots CLI.
+
+To manually download and install the `kots` CLI:
 
 1. Download the release for your operating system from https://github.com/replicatedhq/kots/releases/latest. Air gap customers can also download this file from the download portal provided by your vendor.
 

--- a/docs/reference/kots-cli-getting-started.md
+++ b/docs/reference/kots-cli-getting-started.md
@@ -53,15 +53,11 @@ You can set the `REPL_INSTALL_PATH` environment variable to install the kots CLI
 
 **Example:**
 
+In the following example, the installation script installs the kots CLI to `~/bin` in the local directory. You can use the user home symbol `~` in the `REPL_INSTALL_PATH` environment variable. The script expands `~` to `$HOME`.
+
 ```bash
 curl -L https://kots.io/install | REPL_INSTALL_PATH=~/bin bash
 ```
-
-In the example above, the installation script installs the kots CLI to `~/bin` in the local directory.
-
-:::note
-You can use the user home symbol `~` in the `REPL_INSTALL_PATH` environment variable. The script expands `~` to `$HOME`.
-:::
 
 ### Install Using Sudo
 
@@ -71,17 +67,19 @@ When you set the `REPL_USE_SUDO` environment variable to any value, the installa
 
 **Example:**
 
+In the following example, the script uses sudo to install the kots CLI to the default `/usr/local/bin` directory.
+
 ```bash
 curl -L https://kots.io/install | REPL_USE_SUDO=y bash
 ```
-In the example above, the script uses sudo to install the kots CLI to the default `/usr/local/bin` directory.
 
 **Example:**
+
+In the following example, the script uses sudo to install the kots CLI to the `/replicated/bin` directory.
 
 ```bash
 curl -L https://kots.io/install | REPL_INSTALL_PATH=/replicated/bin REPL_USE_SUDO=y bash
 ```
-In the example above, the script uses sudo to install the kots CLI to the `/replicated/bin` directory.
 
 ### Manually Download and Install
 

--- a/docs/reference/kots-cli-getting-started.md
+++ b/docs/reference/kots-cli-getting-started.md
@@ -25,6 +25,12 @@ To install a specific version of the kots CLI, run:
 curl https://kots.io/install/<version> | bash
 ```
 
+To install to a directory different than the default, `/usr/local/bin`, use the `REPL_INSTALL_PATH` environment variable.
+
+```bash
+curl https://kots.io/install | REPL_INSTALL_PATH=/usr/sbin bash
+```
+
 To verify your installation, run:
 
 ```bash
@@ -34,6 +40,33 @@ kubectl kots --help
 ## Install without Root Access
 
 You can install the kots CLI on computers without root access or computers that cannot write to the `/usr/local/bin` directory. This procedure applies to online clusters and air gapped environments.
+
+### Using the Install Script
+
+To install the `kots` CLI without root access, two environment variables are provided for altering the behavior of the install script, `REPL_INSTALL_PATH` and `REPL_USE_SUDO`. 
+
+The `REPL_INSTALL_PATH` variable can be set to install to a different directory. The user home symbol `~` can be used and will be expanded to `$HOME`.
+
+**Example:**
+```bash
+curl -L https://kots.io/install | REPL_INSTALL_PATH=~/bin bash
+```
+
+The `REPL_USE_SUDO` environment flag can be set to any value if the install can be done using sudo. This will use sudo to create and write to the installation directory as needed. The script will also prompt for the sudo password if it is required for the user executing the script.
+
+**Example:**
+```bash
+curl -L https://kots.io/install | REPL_USE_SUDO=y bash
+```
+
+The two environment variables can be combined to use a different install directory that also requires sudo for creation and writing.
+
+**Example:**
+```bash
+curl -L https://kots.io/install | REPL_INSTALL_PATH=/replicated/bin REPL_USE_SUDO=y bash
+```
+
+### Manual Install
 
 To download the `kots` CLI without root access:
 


### PR DESCRIPTION
Updates the KOTS reference install section to include instructions on how and when to use the new env variables the install script reads `REPL_INSTALL_PATH` and `REPL_USE_SUDO`