### PR TITLE
Edit manual kots CLI install steps

### DIFF
--- a/docs/reference/kots-cli-getting-started.md
+++ b/docs/reference/kots-cli-getting-started.md
@@ -125,7 +125,7 @@ To manually download and install the `kots` CLI:
       ```bash
       tar xvf kots_linux_amd64.tar.gz
       ```
-   * **Linux (ARM)**: Download
+   * **Linux (ARM)**:
 
       ```bash
       tar xvf kots_linux_arm64.tar.gz

--- a/docs/reference/kots-cli-getting-started.md
+++ b/docs/reference/kots-cli-getting-started.md
@@ -89,28 +89,37 @@ Users in air gap environments can also follow this procedure to install the kots
 
 To manually download and install the `kots` CLI:
 
-1. Download the release for your operating system from https://github.com/replicatedhq/kots/releases/latest. Air gap customers can also download this file from the download portal provided by your vendor.
+1. Download the kots CLI release for your operating system from the [Releases](https://github.com/replicatedhq/kots/releases/latest) page in the KOTS GitHub repository:
 
-  Linux and MacOS are supported.
+   * **MacOS (AMD and ARM)**: Download `kots_darwin_all.tar.gz`
+   * **Linux (AMD)**: Download `kots_linux_amd64.tar.gz`
+   * **Linux (ARM)**: Download `kots_linux_arm64.tar.gz`
 
-  **Example:**
+  For air gap environments, download the kots CLI release from the download portal provided by your vendor.
 
-  ```bash
-  curl -L https://github.com/replicatedhq/kots/releases/latest/download/kots_linux_amd64.tar.gz
-  ```
-1. Unarchive the binary by running the following command:
-
-  ```bash
-  tar xvf kots_linux_amd64.tar.gz
-  ```
-
-1. Rename the `kots` executable to `kubectl-kots` and move the plugin to your path by running the following command:
+1. Unarchive the binary:
 
   ```bash
-  mv kots /PATH/kubectl-kots
+  tar xvf KOTS_BINARY
   ```
+  Replace `KOTS_BINARY` with the kots CLI release binary that you downloaded in the previous step. For example, `kots_darwin_all.tar.gz`.
 
-  Replace PATH with the path to the directory where your system can access the binary.
+1. Rename the `kots` executable to `kubectl-kots` and use `sudo` to move it to a directory in your PATH so that your system can access the binary:
+
+  ```bash
+  sudo mv kots /PATH_TO_KOTS/kubectl-kots
+  ```
+  Replace `PATH_TO_KOTS` with the path to the directory. For example, `/usr/local/bin`.
+
+1. When prompted, enter your sudo password.
+
+  You see a message confirming that the binary was installed. For example, `Installed at /usr/local/bin/kubectl-kots`.
+
+1. Verify the installation:
+
+   ```
+   kubectl kots --help
+   ```
 
 ## Uninstall
 

--- a/docs/reference/kots-cli-getting-started.md
+++ b/docs/reference/kots-cli-getting-started.md
@@ -91,29 +91,61 @@ To manually download and install the `kots` CLI:
 
 1. Download the kots CLI release for your operating system from the [Releases](https://github.com/replicatedhq/kots/releases/latest) page in the KOTS GitHub repository:
 
-   * **MacOS (AMD and ARM)**: Download `kots_darwin_all.tar.gz`
-   * **Linux (AMD)**: Download `kots_linux_amd64.tar.gz`
-   * **Linux (ARM)**: Download `kots_linux_arm64.tar.gz`
+   * **MacOS (AMD and ARM)**:
 
-  For air gap environments, download the kots CLI release from the download portal provided by your vendor.
+      ```bash
+      curl -L https://github.com/replicatedhq/kots/releases/latest/download/kots_darwin_all.tar.gz
+      ```
 
-1. Unarchive the binary:
+   * **Linux (AMD)**:
 
-  ```bash
-  tar xvf KOTS_BINARY
-  ```
-  Replace `KOTS_BINARY` with the kots CLI release binary that you downloaded in the previous step. For example, `kots_darwin_all.tar.gz`.
+      ```bash
+      curl -L https://github.com/replicatedhq/kots/releases/latest/download/kots_linux_amd64.tar.gz
+      ```
 
-1. Rename the `kots` executable to `kubectl-kots` and use `sudo` to move it to a directory in your PATH so that your system can access the binary:
+   * **Linux (ARM)**:
 
-  ```bash
-  sudo mv kots /PATH_TO_KOTS/kubectl-kots
-  ```
-  Replace `PATH_TO_KOTS` with the path to the directory. For example, `/usr/local/bin`.
+      ```bash
+      curl -L https://github.com/replicatedhq/kots/releases/latest/download/kots_linux_arm64.tar.gz
+      ```
 
-1. When prompted, enter your sudo password.
+ :::note
+ For air gap environments, download the kots CLI release from the download portal provided by your vendor.
+ :::
 
-  You see a message confirming that the binary was installed. For example, `Installed at /usr/local/bin/kubectl-kots`.
+1. Unarchive the `.tar.gz` file that you downloaded:
+
+   * **MacOS (AMD and ARM)**:
+
+      ```bash
+      tar xvf kots_darwin_all.tar.gz
+      ```
+   * **Linux (AMD)**:
+
+      ```bash
+      tar xvf kots_linux_amd64.tar.gz
+      ```
+   * **Linux (ARM)**: Download
+
+      ```bash
+      tar xvf kots_linux_arm64.tar.gz
+      ```
+
+1. Rename the `kots` executable to `kubectl-kots` and move it to a directory that is on your PATH. Run one of the following commands, depending on if you have write access to the target directory:
+
+   * **You have write access to the directory**:
+
+     ```bash
+     mv kots /PATH_TO_KOTS/kubectl-kots
+     ```
+     Replace `PATH_TO_KOTS` with the path to the directory. For example, `/usr/local/bin`.
+
+   * **You do _not_ have write access to the directory**: 
+
+     ```bash
+     sudo mv kots /PATH_TO_KOTS/kubectl-kots
+     ```
+     Replace `PATH_TO_KOTS` with the path to the directory. For example, `/usr/local/bin`.
 
 1. Verify the installation:
 

--- a/docs/reference/kots-cli-getting-started.md
+++ b/docs/reference/kots-cli-getting-started.md
@@ -131,21 +131,27 @@ To manually download and install the `kots` CLI:
       tar xvf kots_linux_arm64.tar.gz
       ```
 
-1. Rename the `kots` executable to `kubectl-kots` and move it to a directory that is on your PATH. Run one of the following commands, depending on if you have write access to the target directory:
+1. Rename the `kots` executable to `kubectl-kots` and move it to one of the directories that is in your PATH environment variable. This ensures that the system can access the executable when you run kots CLI commands.
+
+   :::note
+   You can run `echo $PATH` to view the list of directories in your PATH.
+   :::
+
+   Run one of the following commands, depending on if you have write access to the target directory:
 
    * **You have write access to the directory**:
 
      ```bash
-     mv kots /PATH_TO_KOTS/kubectl-kots
+     mv kots /PATH_TO_TARGET_DIRECTORY/kubectl-kots
      ```
-     Replace `PATH_TO_KOTS` with the path to the directory. For example, `/usr/local/bin`.
+     Replace `PATH_TO_TARGET_DIRECTORY` with the path to a directory that is in your PATH environment variable. For example, `/usr/local/bin`.
 
    * **You do _not_ have write access to the directory**: 
 
      ```bash
-     sudo mv kots /PATH_TO_KOTS/kubectl-kots
+     sudo mv kots /PATH_TO_TARGET_DIRECTORY/kubectl-kots
      ```
-     Replace `PATH_TO_KOTS` with the path to the directory. For example, `/usr/local/bin`.
+     Replace `PATH_TO_TARGET_DIRECTORY` with the path to a directory that is in your PATH environment variable. For example, `/usr/local/bin`.
 
 1. Verify the installation:
 


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/67365/kots-cli-docs-are-unclear-for-mac

Preview: https://deploy-preview-929--replicated-docs.netlify.app/reference/kots-cli-getting-started#manually-download-and-install