### PR TITLE
Add daemonset status informer info

### DIFF
--- a/docs/enterprise/status-viewing-details.md
+++ b/docs/enterprise/status-viewing-details.md
@@ -27,6 +27,7 @@ The following resource types are supported for displaying application status:
 * Service
 * Ingress
 * PersistentVolumeClaims (PVC)
+* DaemonSet
 
 Applications can specify one or more of the supported Kubernetes workloads listed above. The app manager watches all specified workloads for state changes.
 

--- a/docs/partials/status-informers/_statusesTable.mdx
+++ b/docs/partials/status-informers/_statusesTable.mdx
@@ -1,11 +1,12 @@
 <table>
  <tr>
     <th width="10%"></th>
-    <th width="18%">Deployment</th>
-    <th width="18%">StatefulSet</th>
-    <th width="18%">Service</th>
-    <th width="18%">Ingress</th>
-    <th width="18%">PVC</th>
+    <th width="15%">Deployment</th>
+    <th width="15%">StatefulSet</th>
+    <th width="15%">Service</th>
+    <th width="15%">Ingress</th>
+    <th width="15%">PVC</th>
+    <th width="15%">DaemonSet</th>
   </tr>
     <tr>
   <th>Ready</th>
@@ -14,6 +15,7 @@
     <td>All desired endpoints are ready, any load balancers have been assigned</td>
     <td>All desired backend service endpoints are ready, any load balancers have been assigned</td>
     <td>Claim is bound</td>
+    <td>Ready daemons equals desired scheduled daemons</td>
   </tr>
   <tr>
   <th>Updating</th>
@@ -22,6 +24,7 @@
     <td>N/A</td>
     <td>N/A</td>
     <td>N/A</td>
+    <td>The deployed daemons are from a different revision</td>
   </tr>
   <tr>
     <th>Degraded</th>
@@ -30,6 +33,7 @@
     <td>At least one endpoint is ready, but more are desired</td>
     <td>At least one backend service endpoint is ready, but more are desired</td>
     <td>N/A</td>
+    <td>At least one daemon is ready, but more are desired</td>
   </tr>
   <tr>
     <th>Unavailable</th>
@@ -38,9 +42,10 @@
     <td>No endpoints are ready, no load balancer has been assigned</td>
     <td>No backend service endpoints are ready, no load balancer has been assigned</td>
     <td>Claim is pending or lost</td>
+    <td>No daemons are ready</td>
   </tr>
   <tr>
     <th>Missing</th>
-    <td colspan="5">Missing is an initial deployment status indicating that informers have not reported their status because the application has just been deployed and the underlying resource has not been created yet. After the resource is created, the status changes. However, if a resource changes from another status to Missing, then the resource was either deleted or the informers failed to report a status.</td>
+    <td colspan="6">Missing is an initial deployment status indicating that informers have not reported their status because the application has just been deployed and the underlying resource has not been created yet. After the resource is created, the status changes. However, if a resource changes from another status to Missing, then the resource was either deleted or the informers failed to report a status.</td>
   </tr>
 </table>

--- a/docs/partials/status-informers/_statusesTable.mdx
+++ b/docs/partials/status-informers/_statusesTable.mdx
@@ -15,7 +15,7 @@
     <td>All desired endpoints are ready, any load balancers have been assigned</td>
     <td>All desired backend service endpoints are ready, any load balancers have been assigned</td>
     <td>Claim is bound</td>
-    <td>Ready daemons equals desired scheduled daemons</td>
+    <td>Ready daemon pods equals desired scheduled daemon pods</td>
   </tr>
   <tr>
   <th>Updating</th>
@@ -24,7 +24,7 @@
     <td>N/A</td>
     <td>N/A</td>
     <td>N/A</td>
-    <td>The deployed daemons are from a different revision</td>
+    <td>The deployed daemon pods are from a different revision</td>
   </tr>
   <tr>
     <th>Degraded</th>
@@ -33,7 +33,7 @@
     <td>At least one endpoint is ready, but more are desired</td>
     <td>At least one backend service endpoint is ready, but more are desired</td>
     <td>N/A</td>
-    <td>At least one daemon is ready, but more are desired</td>
+    <td>At least one daemon pod is ready, but more are desired</td>
   </tr>
   <tr>
     <th>Unavailable</th>
@@ -42,7 +42,7 @@
     <td>No endpoints are ready, no load balancer has been assigned</td>
     <td>No backend service endpoints are ready, no load balancer has been assigned</td>
     <td>Claim is pending or lost</td>
-    <td>No daemons are ready</td>
+    <td>No daemon pods are ready</td>
   </tr>
   <tr>
     <th>Missing</th>

--- a/docs/vendor/admin-console-display-app-status.md
+++ b/docs/vendor/admin-console-display-app-status.md
@@ -24,6 +24,7 @@ The following resource types are supported for displaying application status:
 * Service
 * Ingress
 * PersistentVolumeClaims (PVC)
+* DaemonSet
 
 You can target resources of the supported types that are deployed in any of the following ways:
 


### PR DESCRIPTION
Add information about the new daemonset status informer to the vendor and enterprise "Displaying Application Status" pages.

This is needed due to [this KOTS PR](https://github.com/replicatedhq/kots/pull/3636)

Things I'm not sure about:
* Are the column widths in the status table distributed in a visually appealing way? Maybe the leftmost column should shrink so everything else can be wider.
* Calling the pods in the daemonset daemons. They're really pods that run on each node, but they're also not replicas in the deployment or statefulset sense.