### PR TITLE
fix: ingress syntax

### DIFF
--- a/docs/vendor/packaging-ingress.md
+++ b/docs/vendor/packaging-ingress.md
@@ -78,6 +78,7 @@ spec:
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: nginx
@@ -105,6 +106,7 @@ spec:
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: nginx

--- a/docs/vendor/packaging-ingress.md
+++ b/docs/vendor/packaging-ingress.md
@@ -79,8 +79,10 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: nginx
-              servicePort: 80
+              service:
+                name: nginx
+                port:
+                  number: 80
 ```
 
 ```yaml
@@ -104,6 +106,8 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: nginx
-              servicePort: 80
+              service:
+                name: nginx
+                port:
+                  number: 80
 ```


### PR DESCRIPTION
Update ingress syntax to the [stable ingress API](https://kubernetes.io/docs/concepts/services-networking/ingress/)

The old syntax will cause: 
- "unknown field" errors for `serviceName` and `servicePort` fields
- "pathType is required" error for the missing `pathType` field