### PR TITLE
71228: Pod Volume Backups

### DIFF
--- a/docs/enterprise/snapshots-creating.md
+++ b/docs/enterprise/snapshots-creating.md
@@ -38,7 +38,8 @@ For more information, see [backup](/reference/kots-cli-backup-index) in _kots CL
 
 To create a full backup in the admin console:
 
-1. To check if backups are supported for an application, go to the **View files** page, open the `upstream` folder, and confirm that the application includes a manifest file with `kind: Backup` and `apiVersion: velero.io/v1`. 
+1. To check if backups are supported for an application, go to the **View files** page, open the `upstream` folder, and confirm that the application includes a manifest file with `kind: Backup` and `apiVersion: velero.io/v1`. This manifest also shows which pod volumes are being backed up.
+
 1. Go to **Snapshots > Full Snapshots (Instance)**.
 1. Click **Start a snapshot**.
    

--- a/docs/vendor/snapshots-configuring-backups.md
+++ b/docs/vendor/snapshots-configuring-backups.md
@@ -2,7 +2,9 @@
 
 The snapshots feature is a backup and restore option that lets you define a manifest for creating snapshots and restoring previous snapshots. The backups include all of the annotated volumes in the archive. For more information, see [About Backup and Restore](snapshots-overview/).
 
-**Note:** If you are using multiple applications, repeat this procedure for each application. Every application must have its own Backup resource to be included in a full backup.
+:::note
+If you are using multiple applications, repeat this procedure for each application. Every application must have its own Backup resource to be included in a full backup.
+:::
 
 To configure backups:
 

--- a/docs/vendor/snapshots-configuring-backups.md
+++ b/docs/vendor/snapshots-configuring-backups.md
@@ -1,12 +1,16 @@
 # Configuring Backups
 
-The snapshots feature is a backup and restore option that lets you define a manifest for executing snapshots and restoring previous snapshots.
+The snapshots feature is a backup and restore option that lets you define a manifest for creating snapshots and restoring previous snapshots. The backups include all of the annotated volumes in the archive. For more information, see [About Backup and Restore](snapshots-overview/).
 
-1. To enable snapshots:
+**Note:** If you are using multiple applications, repeat this procedure for each application. Every application must have its own Backup resource to be included in a full backup.
 
-    1. Add a backup resource to the application using the Velero manifest. The following minimal YAML example enables snapshots in the application. When a snapshot is executed in the admin console or by a schedule, snapshots will include all annotated volumes in the archive (see the additional information on annotating volumes later in this task).
+To configure backups:
 
-        Example:
+1. Enable snapshots:
+
+    1. Add a Backup resource (`kind: Backup`) using `apiVersion: velero.io/v1` to the application manifest files. The following minimal YAML example enables snapshots in the application. For more information about Backup resource options, see [backup resource](/reference/custom-resource-backup) in _Reference_.
+
+        **Example:**
 
         ```yaml
         apiVersion: velero.io/v1
@@ -16,16 +20,13 @@ The snapshots feature is a backup and restore option that lets you define a mani
         spec: {}
 
         ```
+    1. (Optional) Configure the resources annotation in the manifest so that it can be dynamically enabled based on a license field or a config option. For more information, see [Including Optional and Conditional Resources](packaging-include-resources/).
 
-    1. Optional: Configure the optional resources annotation in the manifest so that it can be dynamically enabled based on a license field or a config option. For more information, see [optional resources](packaging-include-resources/).
-
-        **Note:** if you are using multiple applications, each application should have a [backup resource](../reference/custom-resource-backup) in each application's manifest so that each application can be included in the [Full snapshot](../enterprise/snapshots-understanding) backup.
-
-1. Configure a backup for any volumes that require backup. By default, no volumes are included in the backup. If any pods mount a volume that should be backed up, you must configure the backup with an annotation listing the specific volumes to include in the snapshot.
+1. Configure backups for each volume that requires a backup. By default, no volumes are included in the backup. If any pods mount a volume that should be backed up, you must configure the backup with an annotation listing the specific volumes to include in the snapshot.
 
     The annotation name is `backup.velero.io/backup-volumes` and the value is a comma separated list of volumes to include in the backup.
 
-    For example, in the following deployment, `pvc-volume` is the only volume that is backed up. The `scratch` volume is not included in the backup because it is not listed in annotation on the pod spec.
+    For example, in the following deployment, `pvc-volume` is the only volume that is backed up. The `scratch` volume is not included in the backup because it is not listed in annotation on the pod specification.
 
     ```yaml
     apiVersion: apps/v1
@@ -79,12 +80,8 @@ To exclude any manifest, add a `velero.io/exclude-from-backup` label to the mani
       uri: Secret To Not Include
 
     ```
-1. (Optional) If you are distributing your application with the Kubernetes installer, we recommend that you include the Velero add-on so that customers do not have to manually install Velero on their cluster. For more information about the Kubernetes installer, see [Creating a Kubernetes Installer Specification](packaging-embedded-kubernetes).
+1. (Optional) If you are distributing your application with the Kubernetes installer, Replicated recommends that you include the Velero add-on so that customers do not have to manually install Velero on their cluster. For more information about the Kubernetes installer, see [Creating a Kubernetes Installer Specification](packaging-embedded-kubernetes).
 
+## Next Step
 
 Next, you can configure backup and restore hooks. See [Configuring Backup and Restore Hooks](snapshots-hooks).
-
-## Related Topics
-  * [Snapshots Overview](snapshots-overview/)
-  * [Including and Excluding Resources](packaging-include-resources/)
-  * [Backup](../reference/custom-resource-backup)

--- a/docs/vendor/snapshots-configuring-backups.md
+++ b/docs/vendor/snapshots-configuring-backups.md
@@ -65,9 +65,14 @@ To configure backups:
     ```
 
 1. (Optional) Configure manifest exclusions. By default, Velero also includes snapshots of all of the Kubernetes objects in the namespace.
-To exclude any manifest, add a `velero.io/exclude-from-backup` label to the manifest to be excluded.
 
-    Example:
+  :::note
+  If you are using a Velero-compatible plug-in, such as the VMware Tanzu `velero-plugin-for-gcp`, add a label to exclude volumes that you do not want to backup. Otherwise, Velero backups up all volumes even if you only annotated a few volumes for inclusion, which can cause incomplete restores. For more information about plug-ins, see [Pod Volume Data](snapshots-overview/#pod-volume-data) in _About Backup and Restore_.
+  :::
+
+  To exclude any manifest, add a `velero.io/exclude-from-backup` label to the manifest to be excluded.
+
+    **Example:**
 
     ```yaml
     apiVersion: apps/v1

--- a/docs/vendor/snapshots-configuring-backups.md
+++ b/docs/vendor/snapshots-configuring-backups.md
@@ -66,10 +66,6 @@ To configure backups:
 
 1. (Optional) Configure manifest exclusions. By default, Velero also includes snapshots of all of the Kubernetes objects in the namespace.
 
-  :::note
-  If you are using a Velero-compatible plug-in, such as the VMware Tanzu `velero-plugin-for-gcp`, add a label to exclude volumes that you do not want to backup. Otherwise, Velero backups up all volumes even if you only annotated a few volumes for inclusion, which can cause incomplete restores. For more information about plug-ins, see [Pod Volume Data](snapshots-overview/#pod-volume-data) in _About Backup and Restore_.
-  :::
-
   To exclude any manifest, add a `velero.io/exclude-from-backup` label to the manifest to be excluded.
 
     **Example:**

--- a/docs/vendor/snapshots-overview.md
+++ b/docs/vendor/snapshots-overview.md
@@ -26,12 +26,9 @@ For limitations and considerations, see [Limitations and Considerations](/enterp
 
 ### Pod Volume Data
 
-By default, you must opt-in to have pod volumes backed up using restic (restic is referred to as File System Backup or FSB in the Velero documentation). In the Backup resource that you configure to enable snapshots, you must annotate each specific volume that you want to back up.
+Replicated snapshots supports the restic backup program only.
 
-You can use a Velero-compatible plug-in, such as the VMware Tanzu `velero-plugin-for-gcp`, instead of restic. In this case, Velero backs up everything, not just the annotated volumes that you want to include. Backing up everything can, in turn, cause incomplete restores. As a best practice when using plug-ins, after you opt-in the volumes that you want to include, add a label to exclude the volumes that you do not want to back up.
-
-For more information about including and excluding pod volumes, see [Configuring Backups](snapshots-configuring-backups). For more information about Velero File System Backup, see [File System Backup](https://velero.io/docs/v1.10/file-system-backup/) in the Velero documentation.
-
+By default, Velero requires that you opt-in to have pod volumes backed up. In the Backup resource that you configure to enable snapshots, you must annotate each specific volume that you want to back up. For more information about including and excluding pod volumes, see [Configuring Backups](snapshots-configuring-backups). 
 
 ### Object-Stored Data
 

--- a/docs/vendor/snapshots-overview.md
+++ b/docs/vendor/snapshots-overview.md
@@ -20,19 +20,17 @@ There are two types of snapshots available that back up different types of data:
 
 * **Full snapshots (Recommended)**: Backs up the admin console and all application data, including KOTS-specific object-stored data. For embedded clusters, this also backs up the Docker registry, which is required for air gapped installations.
 
+    If other types of object-stored data (not KOTS-specific) is being used that does not use a persistentVolumeClaim (PVC), then you must write custom backup and restore hooks for your users to be able to back up object-stored data. For example, Rook and Ceph do not use PVCs and require custom backup and restore hooks. For more information, see [Configuring Backup and Restore Hooks](snapshots-hooks).
+
 * **Partial snapshots**: Backs up the application volumes and manifests only. This is a legacy feature and does not support disaster recovery because it only backs up the application.
 
 For limitations and considerations, see [Limitations and Considerations](/enterprise/snapshots-understanding#limitations-and-considerations).
 
-### Pod Volume Data
+## Pod Volume Data
 
 Replicated snapshots supports the restic backup program only.
 
 By default, Velero requires that you opt-in to have pod volumes backed up. In the Backup resource that you configure to enable snapshots, you must annotate each specific volume that you want to back up. For more information about including and excluding pod volumes, see [Configuring Backups](snapshots-configuring-backups). 
-
-### Object-Stored Data
-
-If other types of object-stored data (not KOTS-specific) is being used that does not use a persistentVolumeClaim (PVC), then you must write custom backup and restore hooks for your users to be able to back up object-stored data. For example, Rook and Ceph do not use PVCs and require custom backup and restore hooks. For more information, see [Configuring Backup and Restore Hooks](snapshots-hooks).
 
 ## How to Enable Backup and Restore
 

--- a/docs/vendor/snapshots-overview.md
+++ b/docs/vendor/snapshots-overview.md
@@ -28,7 +28,7 @@ For limitations and considerations, see [Limitations and Considerations](/enterp
 
 By default, you must opt-in to have pod volumes backed up using restic (restic is referred to as File System Backup or FSB in the Velero documentation). In the Backup resource that you configure to enable snapshots, you must annotate each specific volume that you want to back up.
 
-If you are also using using a Velero-compatible plug-in, such as the VMware Tanzu `velero-plugin-for-gcp`, you must add a label to exclude volume backups from being created for the plug-in to prevent the issue of incomplete restores.
+You can use a Velero-compatible plug-in, such as the VMware Tanzu `velero-plugin-for-gcp`, instead of restic. In this case, Velero backs up everything, not just the annotated volumes that you want to include. Backing up everything can, in turn, cause incomplete restores. As a best practice when using plug-ins, after you opt-in the volumes that you want to include, add a label to exclude the volumes that you do not want to back up.
 
 For more information about including and excluding pod volumes, see [Configuring Backups](snapshots-configuring-backups). For more information about Velero File System Backup, see [File System Backup](https://velero.io/docs/v1.10/file-system-backup/) in the Velero documentation.
 

--- a/docs/vendor/snapshots-overview.md
+++ b/docs/vendor/snapshots-overview.md
@@ -18,21 +18,31 @@ The app manager also exposes hooks that can be used to inject scripts to execute
 
 There are two types of snapshots available that back up different types of data:
 
-* **Full snapshots (Recommended)**: Backs up the admin console and all application data, including kots-specific object-stored data. For embedded clusters, this also backs up the Docker registry, which is required for air gapped installations.
-
-  If other types of object-stored data (not kots-specific) is being used that does not use a PVC, then you must write custom backup and restore hooks for your users to be able to back up object-stored data. For example, Rook and Ceph do not use PVCs and require custom backup and restore hooks.
+* **Full snapshots (Recommended)**: Backs up the admin console and all application data, including KOTS-specific object-stored data. For embedded clusters, this also backs up the Docker registry, which is required for air gapped installations.
 
 * **Partial snapshots**: Backs up the application volumes and manifests only. This is a legacy feature and does not support disaster recovery because it only backs up the application.
 
-For limitations and considerations, see [Limitations and Considerations](/enterprise/snapshots-understanding#limitations-and-consoderations).
+For limitations and considerations, see [Limitations and Considerations](/enterprise/snapshots-understanding#limitations-and-considerations).
 
+### Pod Volume Data
+
+By default, you must opt-in to have pod volumes backed up using restic (restic is referred to as File System Backup or FSB in the Velero documentation). In the Backup resource that you configure to enable snapshots, you must annotate each specific volume that you want to back up.
+
+If you are also using using a Velero-compatible plug-in, such as the VMware Tanzu `velero-plugin-for-gcp`, you must add a label to exclude volume backups from being created for the plug-in to prevent the issue of incomplete restores.
+
+For more information about including and excluding pod volumes, see [Configuring Backups](snapshots-configuring-backups). For more information about Velero File System Backup, see [File System Backup](https://velero.io/docs/v1.10/file-system-backup/) in the Velero documentation.
+
+
+### Object-Stored Data
+
+If other types of object-stored data (not KOTS-specific) is being used that does not use a persistentVolumeClaim (PVC), then you must write custom backup and restore hooks for your users to be able to back up object-stored data. For example, Rook and Ceph do not use PVCs and require custom backup and restore hooks. For more information, see [Configuring Backup and Restore Hooks](snapshots-hooks).
 
 ## How to Enable Backup and Restore
 
 To enable the snapshots backup and restore feature for your users, you must:
 
 - Have the snapshots entitlement enabled in your Replicated vendor account. For account entitlements, contact the Replicated TAM team.
-- Define a manifest for executing snapshots and restoring previous snapshots. For more information, see [Configuring Backups](snapshots-configuring-backups).
+- Define a manifest for creating backups. For more information, see [Configuring Backups](snapshots-configuring-backups).
 - Enable the Allow Snapshot option in customer licenses. For more information, see [Creating a Customer](releases-creating-customer).
 
 Additionally, your end users must install Velero to access the snapshot functionality in the Replicated admin console. For more information about the enterprise snapshots procedures, see [Understanding Snapshots](../enterprise/snapshots-understanding) in the _Enterprise_ documentation.


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/71228/clarify-how-volumes-are-backed-up

and SC: https://app.shortcut.com/replicated/story/38953/kots-snapshots-documentation-suggests-mentions-using-opt-in-for-volume-backups-which-only-works-with-restic

Using the same PR for both of these SC because they are closely related.

Also, note that one of the SC stories addresses an issue that a vendor opened here: https://github.com/replicatedhq/kots.io/issues/598

Previews:

- https://deploy-preview-995--replicated-docs.netlify.app/vendor/snapshots-overview#pod-volume-data
- https://deploy-preview-995--replicated-docs.netlify.app/vendor/snapshots-configuring-backups