### PR TITLE
fix cli registry test example

### DIFF
--- a/docs/vendor/packaging-private-images.md
+++ b/docs/vendor/packaging-private-images.md
@@ -99,7 +99,7 @@ This will ensure that the the saved credentials on our servers can pull the imag
 For example:
 
 ```bash
-replicated registry test index.docker.io my-company/my-image:v1.2.3
+replicated registry test index.docker.io --image my-company/my-image:v1.2.3
 ```
 
 


### PR DESCRIPTION
The example does not use the `--image` flag, which will result in the following:
```
$ replicated registry test index.docker.io my-company/my-image:v1.2.3
Error: required flag(s) "image" not set
```

With the flag, it runs the check, as expected:
```
$ replicated registry test index.docker.io --image my-company/my-image:v1.2.3
Registry conection appears ok
```