### PR TITLE
How to consume prometheus metrics externally

### DIFF
--- a/docs/enterprise/monitoring-applications.md
+++ b/docs/enterprise/monitoring-applications.md
@@ -75,9 +75,9 @@ To connect the admin console to a Prometheus endpoint:
 
 You can use the commands below to access Prometheus, Grafana, and Alertmanager dashboards using `kubectl port-forward` after you install the manifests.
 
-For Kubernetes installer clusters, you can also consume Prometheus metrics from an external monitoring solution by connecting to the Prometheus NodePort service running in the cluster. For more information, see [Consuming Prometheus Metrics Externally](monitoring-external-prometheus). 
-
 You can also expose these pods on NodePorts or behind an ingress controller. This is an advanced use case. For information about exposing the pods on NodePorts, see [NodePorts](https://github.com/prometheus-operator/kube-prometheus/blob/main/docs/customizations/node-ports.md) in the kube-prometheus GitHub repository. For information about exposing the pods behind an ingress controller, see [Expose via Ingress](https://github.com/prometheus-operator/kube-prometheus/blob/main/docs/customizations/exposing-prometheus-alertmanager-grafana-ingress.md) in the kube-prometheus GitHub repository.
+
+For Kubernetes installer clusters, you can consume Prometheus metrics from an external monitoring solution by connecting to the Prometheus NodePort service running in the cluster. For more information, see [Consuming Prometheus Metrics Externally](monitoring-external-prometheus). 
 
 ### Access Prometheus
 

--- a/docs/enterprise/monitoring-applications.md
+++ b/docs/enterprise/monitoring-applications.md
@@ -1,6 +1,6 @@
 # Monitoring Applications
 
-This topic describes monitoring applications and clusters with Prometheus. It includes information about how to configure Prometheus monitoring for existing clusters as well as how to access dashboard using a port forward.
+This topic describes monitoring applications and clusters with Prometheus. It includes information about how to configure Prometheus monitoring for existing clusters and how to access dashboard using a port forward.
 
 ## About Prometheus
 
@@ -30,7 +30,7 @@ The following screenshot shows an example of the Monitoring section on the admin
 
 ## Configure Monitoring in Existing Clusters {#configure-existing}
 
-To configure Prometheus monitoring for applications installed in an existing cluster, you must connect the admin console to the endpoint of an installed instance of Prometheus on the cluster. See:
+To configure Prometheus monitoring for applications installed in an existing cluster, you must connect the admin console to the endpoint of an installed instance of Prometheus on the cluster. See the following sections:
 
 * [Install Prometheus](#install-prometheus)
 * [Connect to a Prometheus Endpoint](#connect-to-a-prometheus-endpoint)

--- a/docs/enterprise/monitoring-applications.md
+++ b/docs/enterprise/monitoring-applications.md
@@ -10,6 +10,10 @@ Prometheus uses a multi-dimensional data model with time series data and a flexi
 
 For more information about Prometheus, see [What is Prometheus?](https://prometheus.io/docs/introduction/overview/) in the Prometheus documentation.
 
+Prometheus is included by default on clusters provisioned by the Replicated Kubernetes installer, and no additional configuration is required to view graphs on the admin console dashboard.
+
+For information about how to set up Prometheus monitoring in existing clusters, see [Configure Monitoring in Existing Clusters](#configure-existing).
+
 ## About Admin Console Dashboards
 
 The admin console exposes graphs with key metrics collected by Prometheus in the Monitoring section of the dashboard. By default, the admin console includes the following graphs:
@@ -23,10 +27,6 @@ In addition to these default graphs, application developers can also expose busi
 The following screenshot shows an example of the Monitoring section on the admin console dashboard with the Disk Usage, CPU Usage, and Memory Usage default graphs.
 
 ![Graphs on the admin console dashboard](/images/kotsadm-dashboard-graph.png) 
-
-Prometheus is included by default on clusters provisioned by the Replicated Kubernetes installer, and no additional configuration is required to view graphs on the admin console dashboard.
-
-For information about how to set up Prometheus monitoring in existing clusters, see [Configure Monitoring in Existing Clusters](#configure-existing).
 
 ## Configure Monitoring in Existing Clusters {#configure-existing}
 

--- a/docs/enterprise/monitoring-applications.md
+++ b/docs/enterprise/monitoring-applications.md
@@ -1,16 +1,16 @@
 # Monitoring Applications
 
-This topic describes monitoring applications and clusters with Prometheus, including information about how to configure Prometheus monitoring for applications installed on an existing Kubernetes cluster.
+This topic describes monitoring applications and clusters with Prometheus. It includes information about how to configure Prometheus monitoring for existing clusters as well as how to access dashboard using a port forward.
 
 ## About Prometheus
 
-The Replicated admin console uses the open source systems monitoring tool, Prometheus, to collect metrics on an application and the cluster where the application is installed.
+The Replicated admin console uses the open source systems monitoring tool Prometheus to collect metrics on an application and the cluster where the application is installed.
 
 Prometheus uses a multi-dimensional data model with time series data and a flexible query language. Prometheus components include the main Prometheus server, which scrapes and stores time series data, and an Alertmanager for alerting on metrics.
 
 For more information about Prometheus, see [What is Prometheus?](https://prometheus.io/docs/introduction/overview/) in the Prometheus documentation.
 
-## Overview of Monitoring with Prometheus
+## About Admin Console Dashboards
 
 The admin console exposes graphs with key metrics collected by Prometheus in the Monitoring section of the dashboard. By default, the admin console includes the following graphs:
 
@@ -22,15 +22,15 @@ In addition to these default graphs, application developers can also expose busi
 
 The following screenshot shows an example of the Monitoring section on the admin console dashboard with the Disk Usage, CPU Usage, and Memory Usage default graphs.
 
-![Graphs on the admin console dashboard](/images/kotsadm-dashboard-graph.png)
+![Graphs on the admin console dashboard](/images/kotsadm-dashboard-graph.png) 
 
-Prometheus is included by default on clusters provisioned by the Replicated Kubernetes installer, and no additional configuration is required to monitor the application and cluster.
+Prometheus is included by default on clusters provisioned by the Replicated Kubernetes installer, and no additional configuration is required to view graphs on the admin console dashboard.
 
-If you installed on an existing cluster, see [Configure Monitoring on an Existing Cluster](#configure-monitoring-on-an-existing-cluster) below for information about how to monitor the application and cluster with Prometheus.
+For information about how to set up Prometheus monitoring in existing clusters, see [Configure Monitoring in Existing Clusters](#configure-existing).
 
-## Configure Monitoring on an Existing Cluster
+## Configure Monitoring in Existing Clusters {#configure-existing}
 
-To configure Prometheus monitoring for applications installed on an existing cluster, you must connect the admin console to the endpoint of an installed instance of Prometheus on the cluster. See:
+To configure Prometheus monitoring for applications installed in an existing cluster, you must connect the admin console to the endpoint of an installed instance of Prometheus on the cluster. See:
 
 * [Install Prometheus](#install-prometheus)
 * [Connect to a Prometheus Endpoint](#connect-to-a-prometheus-endpoint)
@@ -75,15 +75,13 @@ To connect the admin console to a Prometheus endpoint:
 
 You can use the commands below to access Prometheus, Grafana, and Alertmanager dashboards using `kubectl port-forward` after you install the manifests.
 
-You can also expose these pods on NodePorts or behind an ingress controller. This is an advanced use case.
+For Kubernetes installer clusters, you can also consume Prometheus metrics from an external monitoring solution by connecting to the Prometheus NodePort service running in the cluster. For more information, see [Consuming Prometheus Metrics Externally](monitoring-external-prometheus). 
 
-For information about exposing the pods on NodePorts, see [NodePorts](https://github.com/prometheus-operator/kube-prometheus/blob/main/docs/customizations/node-ports.md) in the kube-prometheus GitHub repository.
-
-For information about exposing the pods behind an ingress controller, see [Expose via Ingress](https://github.com/prometheus-operator/kube-prometheus/blob/main/docs/customizations/exposing-prometheus-alertmanager-grafana-ingress.md) in the kube-prometheus GitHub repository.
+You can also expose these pods on NodePorts or behind an ingress controller. This is an advanced use case. For information about exposing the pods on NodePorts, see [NodePorts](https://github.com/prometheus-operator/kube-prometheus/blob/main/docs/customizations/node-ports.md) in the kube-prometheus GitHub repository. For information about exposing the pods behind an ingress controller, see [Expose via Ingress](https://github.com/prometheus-operator/kube-prometheus/blob/main/docs/customizations/exposing-prometheus-alertmanager-grafana-ingress.md) in the kube-prometheus GitHub repository.
 
 ### Access Prometheus
 
-To access the Prometheus dashboard with a port foward:
+To access the Prometheus dashboard with a port forward:
 
 1. Run the following command to create the port forward:
 
@@ -95,7 +93,7 @@ To access the Prometheus dashboard with a port foward:
 
 ### Access Grafana
 
-To access the Grafana dashboard with a port foward:
+To access the Grafana dashboard with a port forward:
 
 1. Run the following command to create the port forward:
 
@@ -115,7 +113,7 @@ To access the Grafana dashboard with a port foward:
 
 ### Access Alertmanager
 
-To access the Alertmanager dashboard with a port foward:
+To access the Alertmanager dashboard with a port forward:
 
 1. Run the following command to create the port forward:
 

--- a/docs/enterprise/monitoring-external-prometheus.md
+++ b/docs/enterprise/monitoring-external-prometheus.md
@@ -23,7 +23,7 @@ As shown in the example above, port 9090 on the `prometheus-k8s` service maps to
 
 ## Prerequisite
 
-Before you can consume Prometheus metrics in Kubernetes installer clusters externally, ensure that firewall rules on all nodes in the cluster allow TCP traffic on port 30900. 
+Before you can consume Prometheus metrics in Kubernetes installer clusters externally, ensure that firewall rules on all nodes in the cluster allow inbound TCP traffic on port 30900. 
 
 ## Consume Metrics from External Services
 
@@ -38,7 +38,13 @@ To consume Prometheus metrics from an external service:
    ```
    kubectl describe node NODE_NAME
    ```
-   Where `NODE_NAME` is the name of a node in the Kubernetes installer cluster.   
+   Where `NODE_NAME` is the name of a node in the Kubernetes installer cluster.
+
+   :::note
+   Depending on the node's network configuration, there might be different IP addresses for accessing the node from an external or internal network. For example, the IP address 10.128.0.35 might be assigned to the node in the internal network, whereas the IP address used to access the node from external or public networks is 34.28.178.93.
+   
+   Consult your infrastructure team to assist you in determining which IP address to use.
+   :::   
 
 1. In a browser, go to `http://NODE_IP_ADDRESS:30900` to verify that you can connect to the `prometheus-k8s` NodePort service. Replace `NODE_IP_ADDRESS` with the external IP address that you copied in the first step. For example, `http://34.28.178.93:30900`.
 

--- a/docs/enterprise/monitoring-external-prometheus.md
+++ b/docs/enterprise/monitoring-external-prometheus.md
@@ -1,0 +1,50 @@
+# Consuming Prometheus Metrics Externally
+
+This topic describes how to consume Prometheus metrics in Replicated Kubernetes installer clusters from a monitoring service that is outside the cluster.
+
+## About the Prometheus NodePort Service
+
+By default, Prometheus is included in Kubernetes installer clusters as a NodePort service named `prometheus-k8s` in the `monitoring` namespace. The `prometheus-k8s` service is exposed on the IP address for each node in the cluster at port 30900.
+
+For more information about NodePort services, see [Type NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) in _Services_ in the Kubernetes documentation.  
+
+You can run the following command to view the `prometheus-k8s` service in your cluster:
+
+```
+kubectl get services -l app=kube-prometheus-stack-prometheus -n monitoring
+```
+The output of the command includes details about the Prometheus service, including the type of service and the ports where the service is exposed. For example:
+
+```
+NAME            TYPE      CLUSTER_IP   EXTERNAL_IP  PORT(S)         AGE
+prometheus-k8s  NodePort  10.96.2.229  <none>       9090:30900/TCP  5hr
+```
+As shown in the example above, port 9090 on the `prometheus-k8s` service maps to port 30900 on each of the nodes.
+
+## Prerequisite
+
+Before you can consume Prometheus metrics in Kubernetes installer clusters externally, ensure that firewall rules on all nodes in the cluster allow TCP traffic on port 30900. 
+
+## Consume Metrics from External Services
+
+You can connect to the 
+
+To consume Prometheus metrics from an external service:
+
+1. Get the IP address of one of the nodes in the cluster. You will use this IP address in the next step to access the `prometheus-k8s` service.
+
+   You can find the IP address for a node in the output of the following command:
+
+   ```
+   kubectl describe node NODE_NAME
+   ```
+   Where `NODE_NAME` is the name of a node in the Kubernetes installer cluster.   
+
+1. (Optional) Verify that 
+
+1. From your external monitoring solution, add Prometheus as a data source using the following format: 
+
+   ```
+   NODE_IP_ADDRESS:9000/30900
+   ```
+   Where `NODE_IP_ADDRESS` is the node IP address that you copied in the first step. 

--- a/docs/enterprise/monitoring-external-prometheus.md
+++ b/docs/enterprise/monitoring-external-prometheus.md
@@ -27,11 +27,11 @@ Before you can consume Prometheus metrics in Kubernetes installer clusters exter
 
 ## Consume Metrics from External Services
 
-You can connect to the 
+You can connect to the `prometheus-k8s` service on port 30900 from any node in the cluster to access Prometheus metrics emitted by Kubernetes installer clusters.
 
 To consume Prometheus metrics from an external service:
 
-1. Get the IP address of one of the nodes in the cluster. You will use this IP address in the next step to access the `prometheus-k8s` service.
+1. Get the external IP address for one of the nodes in the cluster. You will use this IP address in the next step to access the `prometheus-k8s` service.
 
    You can find the IP address for a node in the output of the following command:
 
@@ -40,11 +40,8 @@ To consume Prometheus metrics from an external service:
    ```
    Where `NODE_NAME` is the name of a node in the Kubernetes installer cluster.   
 
-1. (Optional) Verify that 
+1. In a browser, go to `http://NODE_IP_ADDRESS:30900` to verify that you can connect to the `prometheus-k8s` NodePort service. Replace `NODE_IP_ADDRESS` with the external IP address that you copied in the first step. For example, `http://34.28.178.93:30900`.
 
-1. From your external monitoring solution, add Prometheus as a data source using the following format: 
+   If the connection is successful, the Prometheus UI displays in the browser.
 
-   ```
-   NODE_IP_ADDRESS:9000/30900
-   ```
-   Where `NODE_IP_ADDRESS` is the node IP address that you copied in the first step. 
+1. From your external monitoring solution, add Prometheus as an HTTP data source using the same URL from the previous step: `http://NODE_IP_ADDRESS:30900`.

--- a/sidebars.js
+++ b/sidebars.js
@@ -541,8 +541,12 @@ const sidebars = {
           ],
         },
         {
-          type: 'doc',
-          id: 'enterprise/monitoring-applications'
+          type: 'category',
+          label: 'Monitoring',
+          items: [
+             'enterprise/monitoring-applications',
+             'enterprise/monitoring-external-prometheus',
+          ],   
         },
         {
           type: 'category',


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/71548/update-docs-on-how-to-consume-prometheus-metrics-externally

Preview: 
- New topic that explains how to consume metrics from the Prometheus service in k8s installer clusters: https://deploy-preview-1010--replicated-docs.netlify.app/enterprise/monitoring-external-prometheus
- Made some edits to this one and added a link to the new topic: https://deploy-preview-1010--replicated-docs.netlify.app/enterprise/monitoring-applications