### PR TITLE
add kots/app/:id/license/:id/airgap/password rbac resource to docs

### DIFF
--- a/docs/vendor/team-management-rbac-resource-names.md
+++ b/docs/vendor/team-management-rbac-resource-names.md
@@ -90,6 +90,10 @@ Grants the holder permission to view the license specified by ID. If this is den
 
 Grants the holder permission to edit the license specified (by ID) for the specified application(s).
 
+### kots/app/[:appId]/license/[:licenseId]/airgap/password
+
+Grants the holder permission to generate a new download portal password for the license specified (by ID) for the specified application(s).
+
 ### kots/license/[:licenseId]/archive
 
 Grants the holder permission to archive the specified license (by ID).


### PR DESCRIPTION
Adds the missing `kots/app/:id/license/:id/airgap/password` resource to the docs.

Related story: https://app.shortcut.com/replicated/story/72052/add-missing-airgap-password-rbac-resourced-to-docs

Preview: https://deploy-preview-1011--replicated-docs-upgrade.netlify.app/vendor/team-management-rbac-resource-names#kotsappappidlicenselicenseidairgappassword