### PR TITLE
remove outdated minio vulnerability disclosures

### DIFF
--- a/docs/vendor/policies-vulnerability-patch.md
+++ b/docs/vendor/policies-vulnerability-patch.md
@@ -65,19 +65,6 @@ In the event of a vulnerability management exception, a notice is posted contain
 
 As subsequent versions of the vulnerable software are released, Replicated continues to research to find a solution that satisfies the business and security requirements of the original exception. 
 
-## Vulnerability Management Exceptions
- 
-KOTS uses MinIO `RELEASE.2022-06-11T19-55-32Z` which includes a number of CVEs. Newer MinIO releases have fixed these CVEs but also introduced breaking product changes. Replicated is actively working to incorporate a newer MinIO version into KOTS. Until then, the following CVEs will be present in KOTS. However, each CVE has been reviewed and it has been determined none are exploitable:
-
-| CVE | CVE Summary | Rationale| Additional Reading|
-|---|---|---|---|
-| [CVE-2022-2509](https://nvd.nist.gov/vuln/detail/CVE-2022-2509) | A vulnerability found in gnutls. This security flaw happens because of a double free error occurs during verification of pkcs7 signatures in gnutls_pkcs7_verify function. | No reference to use of `gnutls_pkcs7_verify` function found in MinIO source | https://github.com/minio/minio/discussions/16535 |
-| [CVE-2020-35527](https://nvd.nist.gov/vuln/detail/CVE-2020-35527) | In SQLite 3.31.1, there is an out of bounds access problem through ALTER TABLE for views that have a nested FROM clause. | No reference to use of `ALTER TABLE` command found in MinIO source | https://github.com/minio/minio/discussions/16535 |
-| [CVE-2022-42898](https://nvd.nist.gov/vuln/detail/CVE-2022-42898) | PAC parsing in MIT Kerberos 5 before 1.19.4 and 1.20.x before 1.20.1 has integer overflows that may lead to denial of service on 32-bit platforms | No reference to `krb5` found in MinIO source | https://github.com/minio/minio/discussions/16535 |
-| [CVE-2022-37434](https://nvd.nist.gov/vuln/detail/CVE-2022-37434) | zlib through 1.2.12 has a heap-based buffer over-read or buffer overflow in inflate in inflate.c via a large gzip header extra field | No reference to use of `inflateGetHeader` function found in MinIO source | https://github.com/minio/minio/discussions/16535 |
-| [CVE-2022-40303](https://nvd.nist.gov/vuln/detail/CVE-2022-40303) | An issue was discovered in libxml2 before 2.10.3. When parsing a multi-gigabyte XML document with the XML_PARSE_HUGE parser option enabled, several integer counters can overflow. | No reference to use of `libxml2` found in MinIO source | https://github.com/minio/minio/discussions/16535 |
-| [CVE-2022-40304](https://nvd.nist.gov/vuln/detail/CVE-2022-40304) | An issue was discovered in libxml2 before 2.10.3. Certain invalid XML entity definitions can corrupt a hash table key, potentially leading to subsequent logic errors. | No reference to use of `libxml2` found in MinIO source | https://github.com/minio/minio/discussions/16535 |
-
 ## Known Disclosed Vulnerabilities in our On Premises Products
 
 | CVE | CVE Summary | Rationale | Additional Reading |


### PR DESCRIPTION
This PR removes an outdated section for MinIO vulnerability disclosures.  We updated to the latest version of MinIO in [KOTS 1.95.0](https://docs.replicated.com/release-notes/rn-app-manager#improvements-1-95-0), so we can remove these.

The entire section has been removed since it only had MinIO disclosures.  It's possible we want to keep the `## Vulnerability Management Exceptions` header, so open to suggestions here.