### PR TITLE
Revert "Update custom-resource-lintconfig.mdx"

### DIFF
--- a/docs/reference/custom-resource-lintconfig.mdx
+++ b/docs/reference/custom-resource-lintconfig.mdx
@@ -49,7 +49,3 @@ spec:
   - name: application-statusInformers
     level: "error"
 ```
-
-## Limitation
-
-The LintConfig custom resource does not support configuring the `nonexistent-status-informer-object` rule. For information about this rule, see [nonexistent-status-informer-object](linter#nonexistent-status-informer-object) in _Linter Rules_.

--- a/docs/reference/linter.mdx
+++ b/docs/reference/linter.mdx
@@ -794,11 +794,8 @@ For more information, see [LintConfig](custom-resource-lintconfig).
     <th>Description</th>
     <td>
       <p>Requires that each <code>statusInformers</code> entry references an existing Kubernetes workload.</p>
-      <p>The <code>nonexistent-status-informer-object</code> rule has the following limitations:</p>
-      <ul>
-        <li>The linter cannot evaulate <code>statusInformers</code> for Helm-managed resources because it does not template Helm charts during analysis. If you configure status informers for Helm-managed resources, you can ignore <code>nonexistent-status-informer-object</code> warnings for those workloads.</li>
-        <li>The LintConfig custom resource does not support configuring the <code>nonexistent-status-informer-object</code> rule. See <a href="custom-resource-lintconfig">LintConfig</a> in <em>Custom Resources</em>.</li>
-      </ul>
+      <p>The linter cannot evaulate <code>statusInformers</code> for Helm-managed resources because it does not template Helm charts during analysis.</p>
+      <p>If you configure status informers for Helm-managed resources, you can ignore <code>nonexistent-status-informer-object</code> warnings for those workloads. To disable <code>nonexistent-status-informer-object</code> warnings, change the level for this rule to <code>info</code> or <code>off</code> in the LintConfig custom resource manifest file. See <a href="custom-resource-lintconfig">LintConfig</a> in <em>Custom Resources</em>.</p>
     </td>
   </tr>
   <tr>

--- a/docs/reference/linter.mdx
+++ b/docs/reference/linter.mdx
@@ -794,7 +794,7 @@ For more information, see [LintConfig](custom-resource-lintconfig).
     <th>Description</th>
     <td>
       <p>Requires that each <code>statusInformers</code> entry references an existing Kubernetes workload.</p>
-      <p>The linter cannot evaulate <code>statusInformers</code> for Helm-managed resources because it does not template Helm charts during analysis.</p>
+      <p>The linter cannot evaluate <code>statusInformers</code> for Helm-managed resources because it does not template Helm charts during analysis.</p>
       <p>If you configure status informers for Helm-managed resources, you can ignore <code>nonexistent-status-informer-object</code> warnings for those workloads. To disable <code>nonexistent-status-informer-object</code> warnings, change the level for this rule to <code>info</code> or <code>off</code> in the LintConfig custom resource manifest file. See <a href="custom-resource-lintconfig">LintConfig</a> in <em>Custom Resources</em>.</p>
     </td>
   </tr>


### PR DESCRIPTION
Reverts replicatedhq/replicated-docs#1000

Now that https://github.com/replicatedhq/kots-lint/pull/142 is merged and deployed this functionality is supported again. The docs were updated to set expectations correctly while it was still broken.

Ref [sc-65163](https://app.shortcut.com/replicated/story/65163/lintconfig-doesn-t-affect-nonexistent-status-informer-object-warning)

I've tested the functionality myself and was satisfied it's working now :) 