### PR TITLE
update supported k8s versions for app manager

### DIFF
--- a/.github/workflows/app-manager-release-notes.yml
+++ b/.github/workflows/app-manager-release-notes.yml
@@ -22,7 +22,7 @@ jobs:
         owner-repo: replicatedhq/kots
         head: $KOTS_VERSION
         title: ${KOTS_VERSION#v}
-        description: 'Support for Kubernetes: 1.23, 1.24, 1.25, and 1.26'
+        description: 'Support for Kubernetes: 1.24, 1.25, and 1.26'
         include-pr-links: false
         github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Removes stated support for k8s 1.23 as it went EOL on 2023-02-28