### PR TITLE
Remove duplicate customer reporting info

### DIFF
--- a/docs/vendor/customer-reporting.md
+++ b/docs/vendor/customer-reporting.md
@@ -36,16 +36,16 @@ In this section, you can also view the Helm CLI installation instructions for th
 
 ## Time to Install
 
-If the customer has one or more application instances that have reached a Ready status at least one time, then the **Time to Install** section displays _License time to install_ and _Instance time to install_ metrics:
+If the customer has one or more application instances that have reached a Ready status at least one time, then the **Time to install** section displays _License time to install_ and _Instance time to install_ metrics:
 
 * **License time to install**: The time between when you create the customer license in the vendor portal, and when the application instance reaches a Ready status in the customer environment.
 * **Instance time to install**: The time between when the vendor portal records the first event for the application instance in the customer environment, and when the instance reaches a Ready status.
 
 A _Ready_ status indicates that all Kubernetes resources that you added as status informers for the application are Ready. For example, if you defined a Deployment resource as a status informer, then the Deployment resource is considered Ready when the number of Ready replicas equals the total desired number of replicas. For more information about how to configure status informers for your application, see [Displaying Application Status](admin-console-display-app-status).
 
-If the customer has no application instances that have ever reported a Ready status, or if you have not configured status informers for your application, then the **Time to Install** section displays a **No Ready Instances** message.
+If the customer has no application instances that have ever reported a Ready status, or if you have not configured status informers for your application, then the **Time to install** section displays a **No Ready Instances** message.
 
-If the customer has more than one application instance that has previously reported a Ready status, then the Time to Install section displays metrics for the instance that most recently reported a Ready status for the first time.
+If the customer has more than one application instance that has previously reported a Ready status, then the **Time to install** section displays metrics for the instance that most recently reported a Ready status for the first time.
 
 For example, Instance A reported its first Ready status at 9:00 AM today. Instance B reported its first Ready status at 8:00 AM today, moved to a Degraded status, then reported a Ready status again at 10:00 AM today. In this case, the vendor portal displays the time to install metrics for Instance A, which reported its _first_ Ready status most recently.
 
@@ -53,10 +53,10 @@ For more information about how to interpret the time to install metrics, see [Ti
 
 ## Download Portal
 
-From the **Download Portal** section, you can:
-* Copy the URL of the download portal for the customer
+From the **Download portal** section, you can:
+* Copy the URL of the download portal for the customer.
 * Generate a new password for the download portal. The customer uses this password to log in.
-* Access the unique download portal for the customer
+* Access the unique download portal for the customer.
 
 You can use the download portal to give your customers access to the files they need to install your application, such as their license file or air gap bundles. For more information, see [Sharing Files through the Download Portal](releases-sharing-license-install-script#download-portal).
 
@@ -68,18 +68,18 @@ You can click any of the rows in the **Instances** section to open the **Instanc
 
 The **Instances** section displays the following details about each active instance:
 
-* The first seven characters of the instance ID
+* The first seven characters of the instance ID.
 
 * The status of the instance. Status is based on the status informers configured for the application. Possible statuses are Missing, Unavailable, Degraded, Ready, and Updating. For more information, see [Resource Statuses](admin-console-display-app-status#resource-statuses) in _Displaying Application Status_. 
 
-* The application version
+* The application version.
 
 * Details about the cluster where the instance is installed, including:
 
-   * The Kubernetes distribution for the cluster, if applicable
-   * The Kubernetes version running in the cluster
-   * Whether the instance is installed in a Kubernetes installer (kURL) cluster
-   * (Kubernetes Installer Clusters Only) The number of nodes ready in the cluster
+   * The Kubernetes distribution for the cluster, if applicable.
+   * The Kubernetes version running in the cluster.
+   * Whether the instance is installed in a Kubernetes installer (kURL) cluster.
+   * (Kubernetes Installer Clusters Only) The number of nodes ready in the cluster.
 
      The following shows an example of the Nodes field for an instance installed in a Kubernetes installer cluster:
      
@@ -87,8 +87,8 @@ The **Instances** section displays the following details about each active insta
 
      [View a larger version of this image](/images/kurl-instance-row.png)
 
-   * The app manager version running in the cluster
-   * The cloud provider and region, if applicable
+   * The app manager version running in the cluster.
+   * The cloud provider and region, if applicable.
 
 * Instance uptime data, including:
 

--- a/docs/vendor/customer-reporting.md
+++ b/docs/vendor/customer-reporting.md
@@ -1,16 +1,16 @@
 # Customer Reporting
 
-The **Customers > Reporting** page in the Replicated vendor portal displays details about each customer, including details about the active application instances associated with the customer.
+This topic describes the customer and instance data displayed in the **Customers > Reporting** page of the Replicated vendor portal.
 
-For more information about the instance details displayed on the Reporting page, see [Instance Details](instance-insights-details).
+## About the Customer Reporting Page {#reporting-page}
 
-The following shows an example of the Reporting page for a customer:
+The **Customers > Reporting** page displays data about the active application instances associated with each customer. The following shows an example of the **Reporting** page for a customer that has two active application instances:
 
 ![Customer reporting page showing two active instances](/images/customer-reporting-page.png)
 
 [View a larger version of this image](/images/customer-reporting-page.png)
 
-As shown in the image above, the Customer Reporting page has the following sections:
+As shown in the image above, the **Reporting** page has the following main sections:
 * [Customer Details](#customer-details)
 * [Time to Install](#time-to-install)
 * [Download Portal](#download-portal)
@@ -18,7 +18,7 @@ As shown in the image above, the Customer Reporting page has the following secti
 
 ## Customer Details
 
-The Customer Details section displays the following information about the customer:
+The customer details section displays the following information about the customer:
 
 * The customer name
 * The channel the customer is assigned
@@ -32,28 +32,28 @@ The Customer Details section displays the following information about the custom
   * Identity
   * Snapshots
   
-In this section you can also view Helm install instructions for the customer and download the customer license.
+In this section, you can also view the Helm CLI installation instructions for the customer and download the customer license.
 
 ## Time to Install
 
-The Time to Install section displays _License time to install_ and _Instance time to install_ metrics if the customer has one or more application instances that have reached a Ready status at least one time:
+If the customer has one or more application instances that have reached a Ready status at least one time, then the **Time to Install** section displays _License time to install_ and _Instance time to install_ metrics:
 
 * **License time to install**: The time between when you create the customer license in the vendor portal, and when the application instance reaches a Ready status in the customer environment.
 * **Instance time to install**: The time between when the vendor portal records the first event for the application instance in the customer environment, and when the instance reaches a Ready status.
 
-For more information about how to interpret these time to install metrics, see [Time to Install](instance-insights-details#time-to-install) in _Instance Details_.
-
 A _Ready_ status indicates that all Kubernetes resources that you added as status informers for the application are Ready. For example, if you defined a Deployment resource as a status informer, then the Deployment resource is considered Ready when the number of Ready replicas equals the total desired number of replicas. For more information about how to configure status informers for your application, see [Displaying Application Status](admin-console-display-app-status).
 
-If the customer has no application instances that have ever reported a Ready status, or if you have not configured status informers for your application, then the Time to Install section displays a **No Ready Instances** message.
+If the customer has no application instances that have ever reported a Ready status, or if you have not configured status informers for your application, then the **Time to Install** section displays a **No Ready Instances** message.
 
 If the customer has more than one application instance that has previously reported a Ready status, then the Time to Install section displays metrics for the instance that most recently reported a Ready status for the first time.
 
 For example, Instance A reported its first Ready status at 9:00 AM today. Instance B reported its first Ready status at 8:00 AM today, moved to a Degraded status, then reported a Ready status again at 10:00 AM today. In this case, the vendor portal displays the time to install metrics for Instance A, which reported its _first_ Ready status most recently.
 
+For more information about how to interpret the time to install metrics, see [Time to Install](instance-insights-details#time-to-install) in _Instance Details_.
+
 ## Download Portal
 
-From the Download Portal section, you can:
+From the **Download Portal** section, you can:
 * Copy the URL of the download portal for the customer
 * Generate a new password for the download portal. The customer uses this password to log in.
 * Access the unique download portal for the customer
@@ -62,11 +62,11 @@ You can use the download portal to give your customers access to the files they 
 
 ## Instances
 
-The Instances section displays details about the active application instances associated with the customer.
+The **Instances** section displays details about the active application instances associated with the customer.
 
-You can click any of the rows on the Instances section of the Reporting page to open the Instance details page. The Instance details page displays additional event data and computed metrics to help you understand the performance and status of each active application instance. For more information, see [Instance Details](instance-insights-details).
+You can click any of the rows in the **Instances** section to open the **Instance details** page. The **Instance details** page displays additional event data and computed metrics to help you understand the performance and status of each active application instance. For more information, see [Instance Details](instance-insights-details).
 
-The Instances section displays the following details about each active instance:
+The **Instances** section displays the following details about each active instance:
 
 * The first seven characters of the instance ID
 
@@ -96,5 +96,5 @@ The Instances section displays the following details about each active instance:
    
       <AppCheckin/>
 
-   * An uptime graph of the previous two weeks. For more information about how the vendor portal determines uptime, see [Instance Uptime](https://docs.replicated.com/vendor/instance-insights-details#instance-uptime) in _Viewing Instance Details_.
+   * An uptime graph of the previous two weeks. For more information about how the vendor portal determines uptime, see [Instance Uptime](https://docs.replicated.com/vendor/instance-insights-details#instance-uptime) in _Instance Details_.
    * The uptime ratio in the previous two weeks.

--- a/docs/vendor/licenses-about.md
+++ b/docs/vendor/licenses-about.md
@@ -83,51 +83,7 @@ The following shows an example of the **Customers** page:
 From the **Customers** page, you can do the following:
 * Create new customers
 * Download a CSV file with details about each customer
+* Click the **Manage customer** button to edit details such as the customer name and email, the custom license fields assigned to the customer, and the license expiration policy.
 * Download the license file for each customer
+* Click the **Customer reporting** button to view data about the active application instances associated with each customer. For more information, see [Customer Reporting](customer-reporting).
 * Archive customers
-* Click the **Customer reporting** button to view data about the active application instances associated with each customer on the **Reporting** page. See [About the Customer Reporting Page](#reporting) below.
-
-## About the Customer Reporting Page {#reporting}
-
-The **Reporting** page displays data about the active application instances associated with each customer. The following shows an example of the **Reporting** page for a customer:
-
-![Customer reporting page showing one active instance](/images/customer-reporting-page.png)
-
-[View a larger version of this image](/images/customer-reporting-page.png)
-
-You can click any of the rows on the **Reporting** page to open the **Instance details** page. The **Instance details** page displays additional event data and computed metrics to help you understand the performance and status of each active application instance. For more information, see [Viewing Instance Details](https://docs.replicated.com/vendor/instance-insights-details).
-
-The **Reporting** page displays the following details about each active instance:
-
-* The first seven characters of the instance ID
-
-* The status of the instance. Status is based on the status informers configured for the application. Possible statuses are Missing, Unavailable, Degraded, Ready, and Updating. For more information, see [Resource Statuses](admin-console-display-app-status#resource-statuses) in _Displaying Application Status_. 
-
-* The application version
-
-* Details about the cluster where the instance is installed, including:
-
-   * The Kubernetes distribution for the cluster, if applicable.
-   * The Kubernetes version running in the cluster
-   * Whether the instance is installed in a Kubernetes installer (kURL) cluster
-   * (Kubernetes Installer Clusters Only) The number of nodes ready in the cluster
-
-     The following shows an example of the **Nodes** field for an instance installed in a Kubernetes installer cluster:
-     
-     ![Instance with 1/1 nodes ready](/images/kurl-instance-row.png)
-
-     [View a larger version of this image](/images/kurl-instance-row.png)
-
-   * The app manager version running in the cluster
-   * The cloud provider and region, if applicable.
-
-* Instance uptime data, including:
-
-   * The timestamp of the last recorded check-in for the instance. A check-in is recorded when any of the following occur:
-   
-      <AppCheckin/>
-
-   * An uptime graph of the previous two weeks. For more information about how the vendor portal determines uptime, see [Instance Uptime](https://docs.replicated.com/vendor/instance-insights-details#instance-uptime) in _Viewing Instance Details_.
-   * The uptime ratio in the previous two weeks.
-
-   


### PR DESCRIPTION
As part of getting started on [the story to doc the adoption graph](https://app.shortcut.com/replicated/story/72696/insights-document-the-adoption-graph), I noticed that the content about the customer Reporting page was duplicated across both the "About Customers" and "Customer Reporting" topics. I wanted to clean this up before creating space to add in the new Adoption Graph content.

This PR moves the bulk of the content about customer reporting to the Customer Reporting topic, and adds a link to it from the About Customers topic.

- Some updates for style and to add a topic sentence in the Customer Reporting topic: https://deploy-preview-1050--replicated-docs.netlify.app/vendor/customer-reporting
- Removes the _About the Customer Reporting Page_ section from the About Customers topic and replaces it with a link: https://deploy-preview-1050--replicated-docs.netlify.app/vendor/licenses-about#about-the-customers-page