### PR TITLE
Add note to docs for enabling helm and kots install with private registries

### DIFF
--- a/docs/vendor/helm-image-registry.md
+++ b/docs/vendor/helm-image-registry.md
@@ -203,6 +203,10 @@ To update the image name to reference the proxy service:
 
       Helm Install installations ignore this static value, and instead use the `proxy.replicated.com` URL that you added to the `values.yaml` file in a previous step.
 
+   :::note
+   Setting this annotation to have a URL with the proxy prefix in the `values.yaml` file and without in the `HelmChart` enables the same manifest to be used for both Helm CLI and KOTS install methods. If installing with KOTS, the URL from the `HelmChart` will be used and KOTS will prefix the proxy to the URL, but if installing with the Helm CLI, the URL from the `values.yaml` file will be used unmodified.
+   :::
+
    **Example:**
 
    ```yaml

--- a/docs/vendor/helm-image-registry.md
+++ b/docs/vendor/helm-image-registry.md
@@ -204,7 +204,7 @@ To update the image name to reference the proxy service:
       Helm Install installations ignore this static value, and instead use the `proxy.replicated.com` URL that you added to the `values.yaml` file in a previous step.
 
    :::note
-   Setting this annotation to have a URL with the proxy prefix in the `values.yaml` file and without in the `HelmChart` enables the same manifest to be used for both Helm CLI and KOTS install methods. If installing with KOTS, the URL from the `HelmChart` will be used and KOTS will prefix the proxy to the URL, but if installing with the Helm CLI, the URL from the `values.yaml` file will be used unmodified.
+   Setting this field to a URL with the proxy prefix in the `values.yaml` file and without the prefix in the `HelmChart` custom resource enables the same release to be used for both Helm CLI and KOTS install methods. If installing with KOTS, the URL from the `HelmChart` custom resource will be used and KOTS will prefix the proxy to the URL, but if installing with the Helm CLI, the URL from the `values.yaml` file will be used unmodified.
    :::
 
    **Example:**


### PR DESCRIPTION
In [this support case](https://github.com/replicated-collab/git-guardian-kots/issues/72), a customer was having trouble figuring out how to configure a `HelmChart` KOTS manifest to support both Helm CLI and KOTS install methods with a private registry. Even though the docs already have a section for this case that includes example configurations and a link to that doc was posted, both the customer and the support engineers ended up iterating to a similar solution without noticing the solution in the documentation.

Even though this is all described in the docs (step 5 of the "Update the image name to reference the proxy service" [here](http://localhost:3000/vendor/helm-image-registry#proxy-service)), it was still missed by everyone, so this PR adds a note to that step for a more attention grabbing call out about what it does and how it helps to enable both install methods, hopefully making it more obvious how to handle this case appropriately.

Shortcut issue: https://app.shortcut.com/replicated/story/73764/improve-docs-for-helm-kots-installs-with-private-registry