### PR TITLE
Clarify steps to support both helm CLI and kots installations

### DIFF
--- a/docs/vendor/helm-image-registry.md
+++ b/docs/vendor/helm-image-registry.md
@@ -12,7 +12,9 @@ Using an external private image registry or the Replicated private registry for 
 
 In addition to the image pull secret, using an external private registry also requires that you add credentials for the registry to the vendor portal so that Replicated can access the image through the Replicated proxy service.
 
-For installations that use the helm CLI rather than the app manager, Replicated cannot automatically inject an image pull secret nor patch the image name to reference the proxy service in the Helm chart for your application. You can complete the following procedures to use a private registry for helm CLI installations:
+For installations that use the helm CLI rather than the app manager, Replicated cannot automatically inject an image pull secret nor patch the image name to reference the proxy service in the Helm chart for your application.
+
+To use a private registry for helm CLI installations, complete the following procedures:
 1. [Deliver Image Pull Secrets](#pull-secret)
 1. [Reference the Proxy Service](#proxy-service)
 1. [(Optional) Support Both Helm CLI and App Manager Installations](#helm-and-kots)
@@ -117,9 +119,7 @@ To deliver customer-specific image pull secrets for a private registry:
 This procedure is required only for external private registries. Skip this procedure if you are using the Replicated private registry.
 :::
 
-To reference the proxy service, first create a field in the Helm chart `values.yaml` file with the URL of the location of the private image on `proxy.replicated.com`. Use template functions to reference this field from the Pod spec in the Helm chart. This allows Replicated to access the external registry through the proxy service when your users install with the helm CLI.
-
-Then, update the Replicated HelmChart custom resource manifest file with the URL for the image on your external registry. Adding this URL to the HelmChart custom resource ensures that the Replicated proxy service can automatically patch the image name to reference `proxy.replicated.com` during KOTS Install or Embedded Cluster installations.
+This procedure describes how to update your Helm chart to allow Replicated to access the external registry through the proxy service when your users install with the helm CLI.
 
 To update the image name to reference the proxy service:
 
@@ -175,7 +175,7 @@ To update the image name to reference the proxy service:
 
 ## (Optional) Step 3: Support Both Helm CLI and App Manager Installations {#helm-and-kots}
 
-To support both helm CLI and app manager (KOTS Install and Embedded Cluster) installations from the same release using the same image registry, you must add a static value with your registry URL to the HelmChart custom resource for app manager installations.
+To support both helm CLI and app manager installations with your private registry from the same release, you must update the release to add your registry URL as a static value in the HelmChart custom resource.
 
 This allows the Replicated proxy service to automatically patch the image name to reference `proxy.replicated.com` for app manager installations. Helm Install installations ignore this static value, and instead use the `proxy.replicated.com` URL that you added to the `values.yaml` file previously.
 
@@ -222,4 +222,4 @@ To support both helm CLI and app manager installations:
        apiImageRepository: quay.io/my-org/api:v1.0.1
    ```
 
-1. Save and promote the release to a development environment to test your changes.
+1. Save and promote the release to a development environment to test that you can install with both the helm CLI and the app manager (KOTS Install or Embedded Cluster).

--- a/docs/vendor/helm-image-registry.md
+++ b/docs/vendor/helm-image-registry.md
@@ -18,6 +18,7 @@ To use a private registry for helm CLI installations, complete the following pro
 1. [Deliver Image Pull Secrets](#pull-secret)
 1. [Reference the Proxy Service](#proxy-service)
 1. [(Optional) Support Both Helm CLI and App Manager Installations](#helm-and-kots)
+
 ## Step 1: Deliver Image Pull Secrets {#pull-secret}
 
 When the app manager installs an application, Replicated automatically uses the customer license to create and inject an image pull secret that is specific to a customer's license. For helm CLI installations, you must use a template function to inject a customer-specific image pull secret.
@@ -181,7 +182,7 @@ This allows the Replicated proxy service to automatically patch the image name t
 
 To support both helm CLI and app manager installations:
 
-1. In the release that you want to update, create or open the HelmChart custom resource manifest file. A HelmChart custom resource manifest file has `kind: HelmChart` and `apiVersion: kots.io/v1beta1`.
+1. In the release that you want to update, open the HelmChart custom resource manifest file. A HelmChart custom resource manifest file has `kind: HelmChart` and `apiVersion: kots.io/v1beta1`.
 
    **Template:**
 
@@ -222,4 +223,4 @@ To support both helm CLI and app manager installations:
        apiImageRepository: quay.io/my-org/api:v1.0.1
    ```
 
-1. Save and promote the release to a development environment to test that you can install with both the helm CLI and the app manager (KOTS Install or Embedded Cluster).
+1. Save and promote the release to a development environment to test that you can install with both the helm CLI and the app manager.

--- a/docs/vendor/helm-image-registry.md
+++ b/docs/vendor/helm-image-registry.md
@@ -1,6 +1,6 @@
 # Using Private Registries for helm CLI Installations (Beta)
 
-This topic describes the steps required to connect to an external private registry or the Replicated private registry to allow your users to install your application with the helm CLI. For more information about supporting installations with the helm CLI, see [Supporting helm CLI Installations (Beta)](helm-install).
+This topic describes the steps required to connect to an external private registry or the Replicated private registry to support installations with the helm CLI. For more information about supporting installations with the helm CLI, see [Supporting helm CLI Installations (Beta)](helm-install).
 
 :::note
 Allowing users to install with the helm CLI is an Beta feature. To enable this feature on your account, log in to your vendor portal account. Select **Support** > **Request a feature**, and submit a feature request for "Helm CLI install option".
@@ -8,30 +8,25 @@ Allowing users to install with the helm CLI is an Beta feature. To enable this f
 
 ## Overview of Using Private Registries
 
-Using an external private image registry or the Replicated private registry for your application requires an image pull secret for access. The unique license for each customer can grant access to the Replicated private registry, or grant proxy access to an external registry without exposing registry credentials to the customer. When the app manager installs an application, Replicated automatically uses the customer license to create and inject an image pull secret.
+Using an external private image registry or the Replicated private registry for your application requires an image pull secret for access. The unique license for each customer can grant access to the Replicated private registry, or grant proxy access to an external registry without exposing registry credentials to the customer.
 
-In addition to the image pull secret, using an external private registry also requires that you add credentials for the registry to the vendor portal so that Replicated can access the image through the Replicated proxy service. For kots CLI and Kubernetes installer installations, Replicated automatically patches the image name to reference the location of the image on the proxy service at `proxy.replicated.com`. For more information about this process, see [About Using an External Registry](/vendor/private-images-about).
+In addition to the image pull secret, using an external private registry also requires that you add credentials for the registry to the vendor portal so that Replicated can access the image through the Replicated proxy service.
 
 For installations that use the helm CLI rather than the app manager, Replicated cannot automatically inject an image pull secret nor patch the image name to reference the proxy service in the Helm chart for your application.
+## Step 1: Deliver Image Pull Secrets {#pull-secret}
 
-To use private images with your application for helm CLI installations, use Helm's template functions to inject an image pull secret into the Helm chart. If you are using an external private registry, you must also update references to the image name in your Helm chart to use the location of the image on the Replicated proxy service.
-
-For more information, see [Deliver Image Pull Secrets for a Private Registry](#pull-secret) and [Update the Image Name to Reference the Proxy Service](#proxy-service) below.
-
-## Deliver Image Pull Secrets for a Private Registry {#pull-secret}
-
-To inject an image pull secret for an external private registry or the Replicated private registry, first add the Replicated `LicenseDockerCfg` template function to the Helm chart `values.yaml` file. The `LicenseDockerCfg` template function renders a value based on the unique customer license when the Helm chart is pulled. Write this rendered value to a pull secret, then reference the pull secret in the necessary template files for the Helm chart.
-
-For more information about the `LicenseDockerCfg` template function, see [LicenseDockerCfg](/reference/template-functions-license-context#licensedockercfg) in _License Context_.
+When the app manager installs an application, Replicated automatically uses the customer license to create and inject an image pull secret that is specific to a customer's license. For helm CLI installations, you must use a template function to inject a customer-specific image pull secret.
 
 To deliver customer-specific image pull secrets for a private registry:
 
-1. Add the `LicenseDockerCfg` template function to a field in the Helm chart `values.yaml` file using the following format:
+1. Add the `LicenseDockerCfg` template function to a field in your Helm chart `values.yaml` file using the following format:
 
    ```yaml
    FIELD_NAME: "repl{{ LicenseDockerCfg }}"
    ```
-   Replace `FIELD_NAME` with any name for the field. You can add `"repl{{ LicenseDockerCfg }}"` as a flat or nested value. For more information, see [Flat or Nested Values](https://helm.sh/docs/chart_best_practices/values/#flat-or-nested-values) in the Helm documentation.
+   Replace `FIELD_NAME` with any name for the field.
+   
+   You can add `"repl{{ LicenseDockerCfg }}"` as a flat or nested value. For more information, see [Flat or Nested Values](https://helm.sh/docs/chart_best_practices/values/#flat-or-nested-values) in the Helm documentation. For more information about the `LicenseDockerCfg` template function, see [LicenseDockerCfg](/reference/template-functions-license-context#licensedockercfg) in _License Context_.
 
    **Example:**
 
@@ -108,15 +103,12 @@ To deliver customer-specific image pull secrets for a private registry:
     ```
 
 1. Package your Helm chart and add the packaged chart to a release in the Replicated vendor portal. For more information, see [Creating Releases with Helm Charts](helm-release).
-   :::note
-   If you are using an external private registry, ensure that you also complete the steps in [Update the Image Name to Reference the Proxy Service](#proxy-service) below. Otherwise, Replicated will not be able to access your private image through the proxy service.
-   :::
 
-1. Save and promote the release to a development environment to test your changes.  
+1. If you are using the Replicated private registry, save and promote the release to a development environment to test your changes.  
 
-## Update the Image Name to Reference the Proxy Service {#proxy-service}
+1. If you are using an external private registry, ensure that you also complete the steps in [Update the Image Name to Reference the Proxy Service](#proxy-service) below. Otherwise, Replicated will not be able to access your private image through the proxy service.
 
-If you are using an external private registry, you must update the location of the private image in the Helm chart to reference the Replicated proxy service at `proxy.replicated.com`. This, along with the customer-specific image pull secret, allows Replicated to access the private image for your application during Helm Install installations.
+## Step 2: Reference the Proxy Service {#proxy-service}
 
 To reference the proxy service, first create a field in the Helm chart `values.yaml` file with the URL of the location of the private image on `proxy.replicated.com`. Use template functions to reference this field from the Pod spec in the Helm chart. This allows Replicated to access the external registry through the proxy service when your users install with the helm CLI.
 
@@ -174,7 +166,19 @@ To update the image name to reference the proxy service:
 
 1. Package your Helm chart and add the packaged chart to a release in the Replicated vendor portal. For more information, see [Creating Releases with Helm Charts](helm-release).
 
-1. In the release, create or open the HelmChart custom resource manifest file. A HelmChart custom resource manifest file has `kind: HelmChart` and `apiVersion: kots.io/v1beta1`.
+1. Save and promote the release to a development environment to test your changes.
+
+1. To use the same private registry for both helm CLI and app manager installations, continue to [(Optional) Step 3: Support Both Helm CLI and App Manager Installations](#helm-and-kots) below.
+
+## (Optional) Step 3: Support Both Helm CLI and App Manager Installations {#helm-and-kots}
+
+To support both helm CLI and app manager (KOTS Install and Embedded Cluster) installations from the same release using the same image registry, you must add a static value with your registry URL to the HelmChart custom resource for app manager installations.
+
+This allows the Replicated proxy service to automatically patch the image name to reference `proxy.replicated.com` for app manager installations. Helm Install installations ignore this static value, and instead use the `proxy.replicated.com` URL that you added to the `values.yaml` file previously.
+
+To support both helm CLI and app manager installations:
+
+1. In the release that you want to update, create or open the HelmChart custom resource manifest file. A HelmChart custom resource manifest file has `kind: HelmChart` and `apiVersion: kots.io/v1beta1`.
 
    **Template:**
 
@@ -198,10 +202,6 @@ To update the image name to reference the proxy service:
    Replace:
    * `FIELD_NAME` with the same field name that you created in the previous step in the `values.yaml` file. For example, `apiImageRepository`.
    * `REGISTRY_URL` with the URL for the image on your external registry.
-
-      KOTS Install and Embedded Cluster installations use this static value from HelmChart custom resource for the registry URL. This allows the Replicated proxy service to automatically patch the image name to reference `proxy.replicated.com` for KOTS Install and Embedded Cluster installations.
-
-      Helm Install installations ignore this static value, and instead use the `proxy.replicated.com` URL that you added to the `values.yaml` file in a previous step.
 
    **Example:**
 

--- a/docs/vendor/helm-image-registry.md
+++ b/docs/vendor/helm-image-registry.md
@@ -174,13 +174,13 @@ To update the image name to reference the proxy service:
 
 1. To use the same private registry for both helm CLI and app manager installations, continue to [(Optional) Support Both Helm CLI and App Manager Installations](#helm-and-kots) below.
 
-## (Optional) Support Both Helm CLI and App Manager Installations {#helm-and-kots}
+## (Optional) Support Both helm CLI and App Manager Installations {#helm-and-kots}
 
-As an application vendor, you can support both helm CLI and app manager installations from the same release.
+As an application vendor, you can support both helm CLI and app manager installations from the same release. For more information, see [About Supporting helm CLI installations](helm-install) in _Supporting helm CLI Installations (Beta)_.
 
 To support both types of installations with your private registry from a single release, you must update the release to add your registry URL as a static value in the HelmChart custom resource. This allows the Replicated proxy service to automatically patch the image name to reference `proxy.replicated.com` for app manager installations. Helm Install installations ignore this static value, and instead use the `proxy.replicated.com` URL that you added to the `values.yaml` file previously.
 
-To support both helm CLI and app manager installations:
+To use your private registry in both helm CLI and app manager installations:
 
 1. In the release that you want to update, open the HelmChart custom resource manifest file. A HelmChart custom resource manifest file has `kind: HelmChart` and `apiVersion: kots.io/v1beta1`.
 

--- a/docs/vendor/helm-image-registry.md
+++ b/docs/vendor/helm-image-registry.md
@@ -178,7 +178,7 @@ To update the image name to reference the proxy service:
 
 As an application vendor, you can support both helm CLI and app manager installations from the same release. For more information, see [About Supporting helm CLI installations](helm-install) in _Supporting helm CLI Installations (Beta)_.
 
-To support both types of installations with your private registry from a single release, you must update the release to add your registry URL as a static value in the HelmChart custom resource. This allows the Replicated proxy service to automatically patch the image name to reference `proxy.replicated.com` for app manager installations. Helm Install installations ignore this static value, and instead use the `proxy.replicated.com` URL that you added to the `values.yaml` file previously.
+To support both types of installations with your private registry from a single release, you must update the release to add your registry URL as a static value in the HelmChart custom resource. This allows the app manager to automatically patch the image name to reference `proxy.replicated.com`. Helm Install installations ignore this static value, and instead use the `proxy.replicated.com` URL that you added to the `values.yaml` file previously.
 
 To use your private registry in both helm CLI and app manager installations:
 

--- a/docs/vendor/helm-image-registry.md
+++ b/docs/vendor/helm-image-registry.md
@@ -12,16 +12,16 @@ Using an external private image registry or the Replicated private registry for 
 
 In addition to the image pull secret, using an external private registry also requires that you add credentials for the registry to the vendor portal so that Replicated can access the image through the Replicated proxy service.
 
-For installations that use the helm CLI rather than the app manager, Replicated cannot automatically inject an image pull secret nor patch the image name to reference the proxy service in the Helm chart for your application.
+For installations that use the helm CLI rather than the app manager, Replicated cannot automatically inject an image pull secret nor patch the image name to reference the proxy service in the Helm chart for your application, so additional configuration is required.
 
 To use a private registry for helm CLI installations, complete the following procedures:
 1. [Deliver Image Pull Secrets](#pull-secret)
 1. [Reference the Proxy Service](#proxy-service)
 1. [(Optional) Support Both Helm CLI and App Manager Installations](#helm-and-kots)
 
-## Step 1: Deliver Image Pull Secrets {#pull-secret}
+## Deliver Image Pull Secrets {#pull-secret}
 
-When the app manager installs an application, Replicated automatically uses the customer license to create and inject an image pull secret that is specific to a customer's license. For helm CLI installations, you must use a template function to inject a customer-specific image pull secret.
+For helm CLI installations, you must use a template function to inject a customer-specific image pull secret.
 
 To deliver customer-specific image pull secrets for a private registry:
 
@@ -112,9 +112,9 @@ To deliver customer-specific image pull secrets for a private registry:
 
 1. Save and promote the release to a development environment to test your changes.  
 
-1. If you are using an external private registry, continue to [Step 2: Update the Image Name to Reference the Proxy Service](#proxy-service) below to allow Replicated to access your private image through the proxy service.
+1. If you are using an external private registry, continue to [Update the Image Name to Reference the Proxy Service](#proxy-service) below to allow Replicated to access your private image through the proxy service.
 
-## Step 2: Reference the Proxy Service {#proxy-service}
+## Reference the Proxy Service {#proxy-service}
 
 :::note
 This procedure is required only for external private registries. Skip this procedure if you are using the Replicated private registry.
@@ -172,13 +172,13 @@ To update the image name to reference the proxy service:
 
 1. Save and promote the release to a development environment to test your changes.
 
-1. To use the same private registry for both helm CLI and app manager installations, continue to [(Optional) Step 3: Support Both Helm CLI and App Manager Installations](#helm-and-kots) below.
+1. To use the same private registry for both helm CLI and app manager installations, continue to [(Optional) Support Both Helm CLI and App Manager Installations](#helm-and-kots) below.
 
-## (Optional) Step 3: Support Both Helm CLI and App Manager Installations {#helm-and-kots}
+## (Optional) Support Both Helm CLI and App Manager Installations {#helm-and-kots}
 
-To support both helm CLI and app manager installations with your private registry from the same release, you must update the release to add your registry URL as a static value in the HelmChart custom resource.
+As an application vendor, you can support both helm CLI and app manager installations from the same release.
 
-This allows the Replicated proxy service to automatically patch the image name to reference `proxy.replicated.com` for app manager installations. Helm Install installations ignore this static value, and instead use the `proxy.replicated.com` URL that you added to the `values.yaml` file previously.
+To support both types of installations with your private registry from a single release, you must update the release to add your registry URL as a static value in the HelmChart custom resource. This allows the Replicated proxy service to automatically patch the image name to reference `proxy.replicated.com` for app manager installations. Helm Install installations ignore this static value, and instead use the `proxy.replicated.com` URL that you added to the `values.yaml` file previously.
 
 To support both helm CLI and app manager installations:
 

--- a/docs/vendor/helm-image-registry.md
+++ b/docs/vendor/helm-image-registry.md
@@ -12,7 +12,10 @@ Using an external private image registry or the Replicated private registry for 
 
 In addition to the image pull secret, using an external private registry also requires that you add credentials for the registry to the vendor portal so that Replicated can access the image through the Replicated proxy service.
 
-For installations that use the helm CLI rather than the app manager, Replicated cannot automatically inject an image pull secret nor patch the image name to reference the proxy service in the Helm chart for your application.
+For installations that use the helm CLI rather than the app manager, Replicated cannot automatically inject an image pull secret nor patch the image name to reference the proxy service in the Helm chart for your application. You can complete the following procedures to use a private registry for helm CLI installations:
+1. [Deliver Image Pull Secrets](#pull-secret)
+1. [Reference the Proxy Service](#proxy-service)
+1. [(Optional) Support Both Helm CLI and App Manager Installations](#helm-and-kots)
 ## Step 1: Deliver Image Pull Secrets {#pull-secret}
 
 When the app manager installs an application, Replicated automatically uses the customer license to create and inject an image pull secret that is specific to a customer's license. For helm CLI installations, you must use a template function to inject a customer-specific image pull secret.
@@ -104,19 +107,19 @@ To deliver customer-specific image pull secrets for a private registry:
 
 1. Package your Helm chart and add the packaged chart to a release in the Replicated vendor portal. For more information, see [Creating Releases with Helm Charts](helm-release).
 
-1. If you are using the Replicated private registry, save and promote the release to a development environment to test your changes.  
+1. Save and promote the release to a development environment to test your changes.  
 
-1. If you are using an external private registry, ensure that you also complete the steps in [Update the Image Name to Reference the Proxy Service](#proxy-service) below. Otherwise, Replicated will not be able to access your private image through the proxy service.
+1. If you are using an external private registry, continue to [Step 2: Update the Image Name to Reference the Proxy Service](#proxy-service) below to allow Replicated to access your private image through the proxy service.
 
 ## Step 2: Reference the Proxy Service {#proxy-service}
+
+:::note
+This procedure is required only for external private registries. Skip this procedure if you are using the Replicated private registry.
+:::
 
 To reference the proxy service, first create a field in the Helm chart `values.yaml` file with the URL of the location of the private image on `proxy.replicated.com`. Use template functions to reference this field from the Pod spec in the Helm chart. This allows Replicated to access the external registry through the proxy service when your users install with the helm CLI.
 
 Then, update the Replicated HelmChart custom resource manifest file with the URL for the image on your external registry. Adding this URL to the HelmChart custom resource ensures that the Replicated proxy service can automatically patch the image name to reference `proxy.replicated.com` during KOTS Install or Embedded Cluster installations.
-
-:::note
-This procedure is not required if you are using the Replicated private registry.
-:::
 
 To update the image name to reference the proxy service:
 


### PR DESCRIPTION
Preview: https://deploy-preview-1062--replicated-docs.netlify.app/vendor/helm-image-registry (See the new section on supporting both types of installations. Also removed content in other sections to reduce noise and clutter)

Story: https://app.shortcut.com/replicated/story/73789/update-organization-to-reduce-noise-and-improve-skim-ability-of-the-using-private-registries-for-helm-cli-installations-topic