### PR TITLE
Issue #1077: Clarify kots CLI installation steps in the upgrade procedures

### DIFF
--- a/docs/enterprise/updating-app-manager.md
+++ b/docs/enterprise/updating-app-manager.md
@@ -31,7 +31,7 @@ To update the app manager in an online existing cluster:
       ```
       curl https://kots.io/install/VERSION | bash
       ```
-      Where `VERSION` is the desired app manager version.
+      Where `VERSION` is the target app manager version.
 
     For more kots CLI installation options, including information about how to install or update without root access, see [Installing the kots CLI](/reference/kots-cli-getting-started).
 
@@ -46,11 +46,11 @@ To update the app manager in an online existing cluster:
 
 ### Air Gap Environments
 
-For air gap installations, you first download the air gap bundle for the desired version of the app manager and push the images from the air gap bundle to a private image registry.
+For air gap installations, you first download the air gap bundle for the target version of the app manager and push the images from the air gap bundle to a private image registry.
 
 To update the app manager in an existing air gap cluster:
 
-1. Download the desired version of the app manager air gap bundle from [Github](https://github.com/replicatedhq/kots/releases) or from the customer download page provided by your vendor. The air gap bundle is named `kotsadm.tar.gz`.
+1. Download the target version of the app manager air gap bundle from [Github](https://github.com/replicatedhq/kots/releases) or from the customer download page provided by your vendor. The air gap bundle is named `kotsadm.tar.gz`.
 
 1. Install or update the kots CLI to the _same_ version of the air gap bundle:
 

--- a/docs/enterprise/updating-app-manager.md
+++ b/docs/enterprise/updating-app-manager.md
@@ -8,21 +8,32 @@ Downgrading the app manager to a version earlier than what is currently deployed
 
 ## Update the App Manager in Existing Clusters
 
-Updating the version of the app manager in an existing cluster requires that you first update the kots CLI. You have the option to update to the latest version of the kots CLI or to a specific version.
+Updating the version of the app manager in an existing cluster requires that you first install or update the kots CLI.
 
-You then run the kots CLI `admin-console upgrade` command to update the app manager to the same version as the version of the kots CLI that you use to perform the update. For example, if you use version 1.56.0 of the kots CLI to run the `admin-console upgrade` command, then the app manager is updated to 1.56.0.
+You then run the kots CLI `admin-console upgrade` command to update the app manager to the same version of the kots CLI. For example, if you use version 1.97.0 of the kots CLI to run the `admin-console upgrade` command, then the app manager is updated to 1.97.0.
 
 ### Online Environments
 
 To update the app manager in an online existing cluster:
 
-1. (Optional) Run the `kubectl kots version` command to see the current version of the kots CLI.
+1. (Optional) If you already have the kots CLI installed, run `kubectl kots version` to see the currently installed version.
 
-1. Do _one_ of the following actions to update your kots CLI version:
+1. Run _one_ of the following commands to install or update the kots CLI:
 
-    - For the latest version, run `curl https://kots.io/install | bash`.
+    - **Install or update to the latest version**:
 
-    - For a specific version, run `curl https://kots.io/install/VERSION | bash`, where `VERSION` is the desired app manager version.
+      ```
+      curl https://kots.io/install | bash
+      ```
+
+    - **Install or update to a specific version**:
+
+      ```
+      curl https://kots.io/install/VERSION | bash
+      ```
+      Where `VERSION` is the desired app manager version.
+
+    For more kots CLI installation options, including information about how to install or update without root access, see [Installing the kots CLI](/reference/kots-cli-getting-started).
 
 1. Run the following command to update the app manager to the same version as the kots CLI:
 
@@ -31,9 +42,7 @@ To update the app manager in an online existing cluster:
   ```
   Replace `NAMESPACE` with the namespace in your cluster where the app manager is installed.
 
-  :::note
   For help information, run `kubectl kots admin-console upgrade -h`.
-  :::
 
 ### Air Gap Environments
 
@@ -43,12 +52,14 @@ To update the app manager in an existing air gap cluster:
 
 1. Download the desired version of the app manager air gap bundle from [Github](https://github.com/replicatedhq/kots/releases) or from the customer download page provided by your vendor. The air gap bundle is named `kotsadm.tar.gz`.
 
-1. Update your kots CLI version to the _same_ version as the air gap bundle:
+1. Install or update the kots CLI to the _same_ version of the air gap bundle:
 
    ```
    curl https://kots.io/install/VERSION | bash
    ```
    Replace `VERSION` with the same version of the app manager that is in the air gap bundle that you downloaded.
+
+   For more kots CLI installation options, including information about how to install or update without root access, see [Installing the kots CLI](/reference/kots-cli-getting-started).
 
 1. Push the app manager images from the air gap bundle to a private registry:
 
@@ -77,10 +88,12 @@ To update the app manager in an existing air gap cluster:
     * `RO_PASSWORD` with the password associated with the username.
     * `NAMESPACE` with the namespace on your cluster where the app manager is installed.
 
+    For help information, run `kubectl kots admin-console upgrade -h`.
+
 ## Update the App Manager in Kubernetes Installer Clusters
 
-To update the version of the app manager running in clusters created by the Kubernetes installer, you re-run the installation script. The installation script uses the specification provided by the application vendor to determine if any updates are required to the version of Kubernetes running in the cluster, or to any of the add-ons that the vendor included.
+To update the version of the app manager running in clusters created by the Kubernetes installer, you rerun the installation script. The installation script uses the specification provided by the application vendor to determine if any updates are required to the version of Kubernetes running in the cluster, or to any of the add-ons that the vendor included.
 
 The version of the KOTS add-on provided in the Kubernetes installer specification determines the version of the app manager installed in your cluster. For example, if the version of the app manager running in your cluster is 1.92.0, and the vendor updates the KOTS add-on in the Kubernetes installer specification to use 1.92.1, then you can run the installation script to update the app manager version in your cluster to 1.92.1.
 
-For information about how to re-run the installation script to update the app manager in Kubernetes installer clusters, see [Updating Kubernetes Installer Clusters](updating-embedded-cluster).
+For information about how to rerun the installation script to update Kubernetes installer clusters, see [Updating Kubernetes Installer Clusters](updating-embedded-cluster).


### PR DESCRIPTION
https://github.com/replicatedhq/replicated-docs/issues/1077

This PR:
- Clarifies that the commands listed will either update the kots CLI version _or_ install the kots CLI if it isn't already installed
- Adds a link to the Installing the kots CLI topic for more information (installing without root access, etc)

Preview: https://deploy-preview-1079--replicated-docs.netlify.app/enterprise/updating-app-manager#online-environments