### PR TITLE
Update kURL upgrade docs for new K8s upgrade process

### DIFF
--- a/docs/enterprise/updating-embedded-cluster.md
+++ b/docs/enterprise/updating-embedded-cluster.md
@@ -16,21 +16,17 @@ For more information about how the script updates the versions of Kubernetes, th
 
 ### Kubernetes Updates {#kubernetes}
 
+You can use the installation script to upgrade from any Kubernetes minor versions to the latest supported Kubernetes version using a single spec. This upgrade process steps through minor versions one at a time. For example, upgrades from Kubernetes 1.19.x to 1.26.x step through versions 1.20.x, 1.21x, 1.22.x, 1.23.x, 1.24.x, and 1.25.x before installing 1.26.x.
+
 The installation script automatically detects when the Kubernetes version in your cluster must be updated. When a Kubernetes upgrade is required, the script first prints a prompt: `Drain local node and apply upgrade?`. When you confirm the prompt, it drains and upgrades the local primary node where the script is running.
 
 Then, if there are any remote primary nodes to upgrade, the script drains each sequentially and prints a command that you must run on the node to upgrade. For example, the command that that script prints might look like the following: `curl -sSL https://kurl.sh/myapp/upgrade.sh | sudo bash -s hostname-check=master-node-2 kubernetes-version=v1.24.3`.
 
 The script polls the status of each remote node until it detects that the Kubernetes upgrade is complete. Then, it uncordons the node and proceeds to cordon and drain the next node. This process ensures that only one node is cordoned at a time. After upgrading all primary nodes, the script performs the same operation sequentially on all remote secondary nodes.
 
-### Multi-version Kubernetes Updates {#kubernetes-multi}
+### Air Gap Kubernetes Updates {#kubernetes-air-gap}
 
-The Kubernetes installer supports upgrading at most two minor versions of Kubernetes at a time. When upgrading two minor versions at one time, the installation script first installs the skipped minor version before installing the target version. For example, when you upgrade directly from Kubernetes 1.22.x to 1.24.x, the script first completes the installation of 1.23.x before installing 1.24.x. 
-
-If the script detects that the version of Kubernetes in your cluster is more than two minor versions earlier than the target version, it prints an error message similar to the following: `The currently installed kubernetes version is 1.23.16. The requested version to upgrade to is 1.26.0. Kurl can only be upgraded two minor versions at time. Please install 1.25.x. first.`
-
-To update Kubernetes when your currently installed version is more than two minor versions behind the target version, contact your application vendor for an additional Kubernetes installer installation script that specifies the prerequisite Kubernetes version indicated in the error message.
-
-After you update Kubernetes in your cluster to the prerequisite version, you can continue with the upgrade by running the target installation script. For example, to upgrade from Kubernetes 1.23.x to 1.26.x, first run an installation script that specifies Kubernetes 1.25.x. Then, run the target installation script that specifies 1.26.x.
+For air gap clusters, 
 
 ### Add-ons and App Manager Updates {#add-ons}
 

--- a/docs/enterprise/updating-embedded-cluster.md
+++ b/docs/enterprise/updating-embedded-cluster.md
@@ -127,5 +127,5 @@ To update the cluster in an air gap environment:
 1. <UpgradePrompt/>
    
    :::note
-   If Kubernetes must be upgraded by more than one minor version, the script automatically searches for the required Kubernetes assets in the `/var/lib/kurl/assets/` directory. If the assets are not available, the script provides a command to download the assets as a `tar.gz` package.
+   If Kubernetes must be upgraded by more than one minor version, the script automatically searches for the required Kubernetes assets in the `/var/lib/kurl/assets/` directory. If the assets are not available, the script prints a command to download the assets as a `tar.gz` package. Download and provide the absolute path to the package when prompted to continue with the upgrade.
    :::

--- a/docs/enterprise/updating-embedded-cluster.md
+++ b/docs/enterprise/updating-embedded-cluster.md
@@ -11,12 +11,12 @@ The application vendor uses a Kubernetes installer specification file to specify
 
 For more information about how the script updates the versions of Kubernetes, the app manager, and any additional add-ons running in your cluster, see the following sections:
 * [Kubernetes Updates](#kubernetes)
-* [Multi-version Kubernetes Updates](#kubernetes-multi)
+* [Air Gap Multi-version Kubernetes Updates](#kubernetes-multi)
 * [Add-ons and App Manager Updates](#add-ons)
 
 ### Kubernetes Updates {#kubernetes}
 
-You can use the installation script to upgrade from any Kubernetes minor versions to the latest supported Kubernetes version using a single spec. This upgrade process steps through minor versions one at a time. For example, upgrades from Kubernetes 1.19.x to 1.26.x step through versions 1.20.x, 1.21x, 1.22.x, 1.23.x, 1.24.x, and 1.25.x before installing 1.26.x.
+You can use the installation script to upgrade Kubernetes by one or more minor versions. The Kubernetes upgrade process steps through one minor version at a time. For example, upgrades from Kubernetes 1.19.x to 1.26.x install versions 1.20.x, 1.21x, 1.22.x, 1.23.x, 1.24.x, and 1.25.x before installing 1.26.x.
 
 The installation script automatically detects when the Kubernetes version in your cluster must be updated. When a Kubernetes upgrade is required, the script first prints a prompt: `Drain local node and apply upgrade?`. When you confirm the prompt, it drains and upgrades the local primary node where the script is running.
 
@@ -24,9 +24,28 @@ Then, if there are any remote primary nodes to upgrade, the script drains each s
 
 The script polls the status of each remote node until it detects that the Kubernetes upgrade is complete. Then, it uncordons the node and proceeds to cordon and drain the next node. This process ensures that only one node is cordoned at a time. After upgrading all primary nodes, the script performs the same operation sequentially on all remote secondary nodes.
 
-### Air Gap Kubernetes Updates {#kubernetes-air-gap}
+### Air Gap Multi-version Kubernetes Updates {#kubernetes-multi}
 
-For air gap clusters, 
+To upgrade Kubernetes by more than one minor version in air gap clusters, you must provide a package that includes the assets required for the upgrade.
+
+When you run the installation script to upgrade, the script searches for the package in the `/var/lib/kurl/assets/` directory. The script then lists any required assets that are missing, prints a command to download the missing assets as a `.tar.gz` package, and prompts you to provide an absolute path to the package in your local directory. For example:
+
+```
+⚙  Upgrading Kubernetes from 1.23.17 to 1.26.3
+This involves upgrading from 1.23 to 1.24, 1.24 to 1.25, and 1.25 to 1.26.
+This may take some time.
+⚙  Downloading assets required for Kubernetes 1.23.17 to 1.26.3 upgrade
+The following packages are not available locally, and are required:
+   kubernetes-1.24.12.tar.gz
+   kubernetes-1.25.8.tar.gz
+
+You can download them with the following command:
+
+   curl -LO https://kurl.sh/bundle/version/v2023.04.24-0/19d41b7/packages/kubernetes-1.24.12,kubernetes-1.25.8.tar.gz
+
+Please provide the path to the file on the server.
+Absolute path to file:
+```
 
 ### Add-ons and App Manager Updates {#add-ons}
 
@@ -106,3 +125,7 @@ To update the cluster in an air gap environment:
       <InstallerRequirements/>
 
 1. <UpgradePrompt/>
+   
+   :::note
+   If Kubernetes must be upgraded by more than one minor version, the script automatically searches for the required Kubernetes assets in the `/var/lib/kurl/assets/` directory. If the assets are not available, the script provides a command to download the assets as a `tar.gz` package.
+   :::

--- a/docs/partials/updating/_installerRequirements.mdx
+++ b/docs/partials/updating/_installerRequirements.mdx
@@ -1,12 +1,12 @@
-* **installer-spec-file**: If you used the `installer-spec-file` flag to pass a `patch.yaml` file when you ran the installation script previously, you must include the `installer-spec-file` flag with the same `patch.yaml` file when you rerun the installation script. This prevents the installer from overwriting any configuration from your `patch.yaml` file and making changes to the add-ons in your cluster. For example: `curl https://kurl.sh/latest | sudo bash -s installer-spec-file="./patch.yaml"`
+* **installer-spec-file**: If you used the `installer-spec-file` flag to pass a `patch.yaml` file when you installed, you must pass the same `patch.yaml` file when you upgrade. This prevents the installer from overwriting any configuration from your `patch.yaml` file and making changes to the add-ons in your cluster. For example:
 
-* **app-version-label**: By default, the KOTS add-on in the Kubernetes installer specification also upgrades your application to the latest version when you run the installation script.
+   ```
+   curl https://kurl.sh/latest | sudo bash -s installer-spec-file="./patch.yaml"
+   ```
 
-   You can specify a target application version with the `app-version-label` flag. Or, to avoid upgrading your application version, set the `app-version-label` flag to the currently installed application version.
+* **app-version-label**: By default, the script also upgrades your application to the latest version when you run the installation script.
 
-   **Example**
-
-   In the following example, the script updates the application to version 1.5.0:
+   You can specify a target application version with the `app-version-label` flag. To avoid upgrading your application version, set the `app-version-label` flag to the currently installed application version. For example:
 
    ```
    curl https://kurl.sh/latest | sudo bash -s app-version-label=1.5.0

--- a/docs/partials/updating/_upgradePrompt.mdx
+++ b/docs/partials/updating/_upgradePrompt.mdx
@@ -1,7 +1,3 @@
-(Kubernetes Upgrades Only) If the script detects that the version of Kubernetes in your cluster must be upgraded, it prints a `Drain local node and apply upgrade?` prompt. Confirm the prompt to drain the local primary node and apply the Kubernetes upgrade to the control plane.
+(Kubernetes Upgrades Only) If a Kubernetes upgrade is required, the script automatically prints a `Drain local node and apply upgrade?` prompt. Confirm the prompt to drain the local primary node and apply the Kubernetes upgrade to the control plane.
 
-   The script continues to drain and upgrade nodes sequentially. For each node, the script prints a command that you must run on the node to upgrade Kubernetes. 
-
-   After the Kubernetes upgrade on each node is complete, the script automatically updates any add-ons in your cluster.
-
-   For more information about this update process, see [About Updating Kubernetes Installer Clusters](#overview) above.
+   The script continues to drain and upgrade nodes sequentially. For each node, the script prints a command that you must run on the node to upgrade Kubernetes. For more information, see [About Updating Kubernetes Installer Clusters](#overview) above.

--- a/docs/vendor/installer-history.md
+++ b/docs/vendor/installer-history.md
@@ -8,9 +8,7 @@ Each release channel in the Replicated vendor portal saves the history of Kubern
 
 It can be useful to access the installation commands for inactive installers to reproduce an issue that a user is experiencing for troubleshooting purposes. For example, if the user's cluster is running the inactive installer version 1.0.0, then you can install with version 1.0.0 in a test environment to troubleshoot.
 
-You can also send the installation commands for inactive installers to your users as needed. One common use case for users to run inactive installers is when they are updating their cluster.
-
-For example, users might be required to run the installation command for an inactive installer to upgrade Kubernetes by more than two minor versions. This is because the Kubernetes installer supports upgrading no more than two minor versions of Kubernetes at a time. For more information about the cluster update process for enterprise users, see [Updating Kubernetes Installer Clusters](/enterprise/updating-embedded-cluster) in _Enterprise_. 
+You can also send the installation commands for inactive installers to your users as needed. For example, a user might have unique requirements for specific versions of Kubernetes or add-ons.
 
 ## About the Installer History Page {#about}
 


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/75353/edit-info-about-upgrading-k8s-by-more-than-2-minor-versions-for-kurl-clusters

**Enterprise docs updates**

Updated the Kubernetes Update section to explain how you can upgrade any number of minor versions at once: https://deploy-preview-1107--replicated-docs.netlify.app/enterprise/updating-embedded-cluster#kubernetes

Adds info about how you need to download a package for air gap Kubernetes upgrades of more than one minor version: https://deploy-preview-1107--replicated-docs.netlify.app/enterprise/updating-embedded-cluster#kubernetes-multi

Add a note to the air gap upgrade procedure to describe how the script looks for the assets and prints a command to download them if they can't be found: https://deploy-preview-1107--replicated-docs.netlify.app/enterprise/updating-embedded-cluster#air-gap-environments

**Vendor docs update**:

https://deploy-preview-1107--replicated-docs.netlify.app/vendor/installer-history#about-using-inactive-installers
