### PR TITLE
76117: Move Annotations, Kubernetes Jobs, and Kubernetes Objects in TOC

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -206,7 +206,7 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Managing Objects',
+      label: 'Managing Resources and Objects',
       items: [
         'vendor/packaging-include-resources',
         'vendor/packaging-cleaning-up-jobs',

--- a/sidebars.js
+++ b/sidebars.js
@@ -149,16 +149,6 @@ const sidebars = {
         'vendor/packaging-rbac',
         'vendor/packaging-using-tls-certs',
         'vendor/identity-service-configuring',
-        {
-          type: 'category',
-          label: 'Kubernetes Operators',
-          items: [
-            'vendor/operator-packaging-about',
-            'vendor/operator-defining-additional-images',
-            'vendor/operator-referencing-images',
-            'vendor/operator-defining-additional-namespaces',
-          ],
-        },
       ],
     },  
     {
@@ -220,6 +210,16 @@ const sidebars = {
       items: [
         'vendor/packaging-include-resources',
         'vendor/packaging-cleaning-up-jobs',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Kubernetes Operators',
+      items: [
+        'vendor/operator-packaging-about',
+        'vendor/operator-defining-additional-images',
+        'vendor/operator-referencing-images',
+        'vendor/operator-defining-additional-namespaces',
       ],
     },
     {

--- a/sidebars.js
+++ b/sidebars.js
@@ -145,11 +145,9 @@ const sidebars = {
         },
         'vendor/packaging-ingress',
         'vendor/packaging-kots-versions',    
-        'vendor/packaging-include-resources',
         'vendor/namespaces',
         'vendor/packaging-rbac',
         'vendor/packaging-using-tls-certs',
-        'vendor/packaging-cleaning-up-jobs',
         'vendor/identity-service-configuring',
         {
           type: 'category',
@@ -214,6 +212,14 @@ const sidebars = {
         'vendor/licenses-using-builtin-fields',
         'vendor/licenses-adding-custom-fields',
         'vendor/licenses-referencing-fields',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Managing Objects',
+      items: [
+        'vendor/packaging-include-resources',
+        'vendor/packaging-cleaning-up-jobs',
       ],
     },
     {


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/76117/move-annotations-and-cleaning-up-kubernetes-jobs-higher-up-in-toc

Moved Kubernetes Operators to higher level near bottom. Also created a new TOC category called "Managing Objects" and moved the Annotations and Cleaning Up Kubernetes Jobs under the new category.

Preview: https://deploy-preview-1127--replicated-docs-upgrade.netlify.app/