### PR TITLE
add k8s v1.27 for app manager release notes

### DIFF
--- a/.github/workflows/app-manager-release-notes.yml
+++ b/.github/workflows/app-manager-release-notes.yml
@@ -22,7 +22,7 @@ jobs:
         owner-repo: replicatedhq/kots
         head: $KOTS_VERSION
         title: ${KOTS_VERSION#v}
-        description: 'Support for Kubernetes: 1.24, 1.25, and 1.26'
+        description: 'Support for Kubernetes: 1.24, 1.25, 1.26 and 1.27'
         include-pr-links: false
         github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
add k8s v1.27 for app manager release notes
SC - https://app.shortcut.com/replicated/story/74929/support-k8s-v1-27-1