### PR TITLE
update velero version compatibility matrix

### DIFF
--- a/docs/enterprise/snapshots-understanding.md
+++ b/docs/enterprise/snapshots-understanding.md
@@ -82,4 +82,4 @@ The app manager is based on the open source KOTS project, which is maintained by
 |------|-------------|
 | 1.15 to 1.20.2 | 1.2.0 |
 | 1.20.3 and later | 1.5.1 through 1.9.x |
-| 1.94.1 and later | 1.6.x and later |
+| 1.94.1 and later | 1.6.x through 1.10.2 |


### PR DESCRIPTION
updates the velero version compatibility matrix to indicate compatibility through version 1.10.2 because of this known upstream issue: https://docs.replicated.com/enterprise/snapshots-troubleshooting-backup-restore#partial-snapshot-restore-finishes-with-warnings