### PR TITLE
remove k8s 1.27 support in KOTS

### DIFF
--- a/docs/partials/install/_kubernetes-compatibility.mdx
+++ b/docs/partials/install/_kubernetes-compatibility.mdx
@@ -1,5 +1,4 @@
 | App Manager Versions      | Kubernetes Compatibility  |
 |--------------------|---------------------------|
-| v1.99.0 and later  | v1.27, v1.26, v1.25, 1.24 |
-| v1.93.1 to v1.98.3 | v1.26, v1.25, 1.24        |
+| v1.93.1 and later  | v1.26, v1.25, 1.24        |
 | v1.71 to v1.93.0   | v1.25, 1.24               |

--- a/docs/release-notes/rn-app-manager.md
+++ b/docs/release-notes/rn-app-manager.md
@@ -16,7 +16,7 @@ The following table lists the versions of Kubernetes that are compatible with ea
 
 Released on May 18, 2023
 
-Support for Kubernetes: 1.24, 1.25, 1.26, and 1.27
+Support for Kubernetes: 1.24, 1.25, and 1.26
 
 ### New Features {#new-features-1-99-0}
 * Adds a new native Helm v2 installation method (Beta) that leverages the `kots.io/v1beta2` HelmChart custom resource. This v2 installation method does a Helm installation or upgrade of your Helm chart without modifying the chart with Kustomize. This is an improvement to the v1 installation method because it results in Helm installations that can be reproduced outside of the app manager, and it enables the use of additional Helm functionality that was not available in v1. See [HelmChart v2 (Beta)](/reference/custom-resource-helmchart-v2) in the _Custom Resources_ section.

--- a/docs/vendor/policies-support-lifecycle.md
+++ b/docs/vendor/policies-support-lifecycle.md
@@ -75,7 +75,7 @@ The End of Replicated Support date is the End Of Life (EOL) date for the Kuberne
   </tr>  
   <tr>
     <td>1.27</td>
-    <td>v1.99.0 and later</td>
+    <td>TBD</td>
     <td>v2023.05.08-0 and later</td>
     <td>2024-06-28</td>
   </tr>


### PR DESCRIPTION
There is an issue with native Helm installs in KOTS on 1.27 - it will be resolved by the next patch release, but we should remove this support from docs until then