### PR TITLE
fix: add kotsadm-rolebinding metadata name

### DIFF
--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -22,6 +22,8 @@ rules:
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
+metadata:
+  name: kotsadm-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -58,6 +58,8 @@ rules:
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
+metadata:
+  name: kotsadm-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
```
ethan@ethanm-okd-vagrant-2:~$ kubectl -n testing create -f role.yaml
role.rbac.authorization.k8s.io/kotsadm-role created
The RoleBinding "" is invalid: metadata.name: Required value: name or generateName is required
```