### PR TITLE
fix variadic config examples and limitations

### DIFF
--- a/docs/reference/custom-resource-config.md
+++ b/docs/reference/custom-resource-config.md
@@ -674,7 +674,7 @@ Repeatable items do not use the `default` or `value` fields, but instead a `valu
 
 ### Limitations
 
-* Repeatable Items only work for text, textarea, and file types.
+* Repeatable items work only for text, textarea, and file types.
 * Repeatable config item names must only consist of lower case alphanumeric characters.
 
 ### Template Targets

--- a/docs/reference/custom-resource-config.md
+++ b/docs/reference/custom-resource-config.md
@@ -652,14 +652,12 @@ A `regex` can be used to validate whether an item's value matches the provided r
 
 A repeatable config item copies a YAML array entry or YAML document for as many values as are provided. Any number of values can be added to a repeatable item to generate additional copies.
 
-**Note**: Repeatable Items only work for text, textarea, and file types.
-
 To make an item repeatable, set `repeatable` to true:
 
 ```yaml
     - name: ports
       items:
-      - name: service_port
+      - name: serviceport
         title: Service Port
         type: text
         repeatable: true
@@ -673,6 +671,11 @@ Repeatable items do not use the `default` or `value` fields, but instead a `valu
       ports:
         port-default-1: "80"
 ```
+
+### Limitations
+
+* Repeatable Items only work for text, textarea, and file types.
+* Repeatable config item names must only consist of lower case alphanumeric characters.
 
 ### Template Targets
 
@@ -706,8 +709,8 @@ If the `yamlPath` field is not present, the entire YAML document matching the `t
 The repeat items are called with the delimeters `repl[[ .itemName ]]` or `[[repl .itemName ]]`. These delimiters can be placed anywhere inside of the `yamlPath` target node:
 
 ```yaml
-    - port: repl{{ ConfigOption "[[repl .service_port ]]" | ParseInt }}
-      name: '[[repl .service_port ]]'
+    - port: repl{{ ConfigOption "[[repl .serviceport ]]" | ParseInt }}
+      name: '[[repl .serviceport ]]'
 ```
 This repeatable templating is not compatible with sprig templating functions. It is designed for inserting repeatable `keys` into the manifest. Repeatable templating can be placed inside of Replicated config templating.
 
@@ -720,7 +723,7 @@ Repeatable items are processed in order of the template targets in the Config Sp
 ```yaml
     - name: ports
       items:
-      - name: service_port
+      - name: serviceport
         title: Service Port
         type: text
         repeatable: true
@@ -770,7 +773,7 @@ In these examples, the default service port of "80" is included with the release
 ```yaml
     - name: ports
       items:
-      - name: service_port
+      - name: serviceport
         title: Service Port
         type: text
         repeatable: true
@@ -794,10 +797,10 @@ metadata:
 spec:
   values:
     port-default-1:
-      repeatableItem: service_port
+      repeatableItem: serviceport
       value: "80"
-    service_port-8jdn2bgd:
-      repeatableItem: service_port
+    serviceport-8jdn2bgd:
+      repeatableItem: serviceport
       value: "443"
 ```
 
@@ -811,8 +814,8 @@ metadata:
 spec:
   type: NodePort
   ports:
-  - port: repl{{ ConfigOption "[[repl .service_port ]]" | ParseInt }}
-    name: '[[repl .service_port ]]'
+  - port: repl{{ ConfigOption "[[repl .serviceport ]]" | ParseInt }}
+    name: '[[repl .serviceport ]]'
   selector:
     app: repeat_example
     component: my-deployment
@@ -833,8 +836,8 @@ spec:
   ports:
   - port: repl{{ ConfigOption "port-default-1" | ParseInt }}
     name: 'port-default-1'
-  - port: repl{{ ConfigOption "service_port-8jdn2bgd" | ParseInt }}
-    name: 'service_port-8jdn2bgd'
+  - port: repl{{ ConfigOption "serviceport-8jdn2bgd" | ParseInt }}
+    name: 'serviceport-8jdn2bgd'
   selector:
     app: repeat_example
     component: my-deployment
@@ -853,7 +856,7 @@ spec:
   - port: 80
     name: port-default-1
   - port: 443
-    name: service_port-8jdn2bgd
+    name: serviceport-8jdn2bgd
   selector:
     app: repeat_example
     component: my-deployment
@@ -864,7 +867,7 @@ spec:
 ```yaml
     - name: ports
       items:
-      - name: service_port
+      - name: serviceport
         title: Service Port
         type: text
         repeatable: true
@@ -887,10 +890,10 @@ metadata:
 spec:
   values:
     port-default-1:
-      repeatableItem: service_port
+      repeatableItem: serviceport
       value: "80"
-    service_port-8jdn2bgd:
-      repeatableItem: service_port
+    serviceport-8jdn2bgd:
+      repeatableItem: serviceport
       value: "443"
 ```
 
@@ -904,10 +907,10 @@ metadata:
 spec:
   type: NodePort
   ports:
-  - port: repl{{ ConfigOption "[[repl .service_port ]]" | ParseInt }}
+  - port: repl{{ ConfigOption "[[repl .serviceport ]]" | ParseInt }}
   selector:
     app: repeat_example
-    component: repl[[ .service_port ]]
+    component: repl[[ .serviceport ]]
 ```
 
 **After repeatable config processing:**
@@ -931,15 +934,15 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: service_port-8jdn2bgd
+  name: serviceport-8jdn2bgd
   namespace: my-app
 spec:
   type: NodePort
   ports:
-  - port: repl{{ ConfigOption "service_port-8jdn2bgd" | ParseInt }}
+  - port: repl{{ ConfigOption "serviceport-8jdn2bgd" | ParseInt }}
   selector:
     app: repeat_example
-    component: service_port-8jdn2bgd
+    component: serviceport-8jdn2bgd
 ```
 
 **Resulting manifest:**
@@ -960,7 +963,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: service_port-8jdn2bgd
+  name: serviceport-8jdn2bgd
   namespace: my-app
 spec:
   type: NodePort
@@ -968,5 +971,5 @@ spec:
   - port: 443
   selector:
     app: repeat_example
-    component: service_port-8jdn2bgd
+    component: serviceport-8jdn2bgd
 ```

--- a/docs/reference/custom-resource-config.md
+++ b/docs/reference/custom-resource-config.md
@@ -675,7 +675,7 @@ Repeatable items do not use the `default` or `value` fields, but instead a `valu
 ### Limitations
 
 * Repeatable items work only for text, textarea, and file types.
-* Repeatable config item names must only consist of lower case alphanumeric characters.
+* Repeatable item names must only consist of lower case alphanumeric characters.
 
 ### Template Targets
 


### PR DESCRIPTION
This PR fixes the examples used for repeatable config items.  Two issues were discovered when working on [SC-79625](https://app.shortcut.com/replicated/story/79625/repeatable-config-option-not-working-on-ui-cli):

1. The examples use a config item named `service_port`.  KOTS uses this item name to generate the name for the dynamic fields/resources.  This will result in an invalid resource that will be rejected by k8s because it has an underscore `_` in the name and does not conform to RFC 1123.
```
{"level":"info","ts":"2023-06-16T12:59:35Z","msg":"stderr (apply) = The Service \"nginx\" is invalid: \n* spec.ports[0].name: Invalid value: \"service_port-a1060f9b\": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')\n* spec.ports[2].name: Invalid value: \"service_port-41039414\": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')\n"}
```

2. Tried to get around the first issue by changing the examples to use a hyphen `-` instead.  However, KOTS actually fails to render the variadic config templates because it uses the item name as the name for the template it's rendering and `-` is an invalid character in that context.  This fails with the error:
```
{"level":"error","ts":"2023-06-16T13:02:07Z","msg":"rewrite directory: failed to render upstream: failed to process variadic config in file k8s/service.yaml: failed to render repeat nodes for item service-port: failed to replace template value on target port: failed to parse service-port into service-port-d54e0c4d: failed to create new template: template: service-port:1: bad character U+002D '-'"}
```

This PR updates these examples and documents the limitation.