### PR TITLE
fix: correct a broken link in product docs

### DIFF
--- a/docs/vendor/distributing-workflow.md
+++ b/docs/vendor/distributing-workflow.md
@@ -49,7 +49,7 @@ Complete the following procedures to import your application files then create a
       </tr>
       <tr>
         <td>Helm charts</td>
-        <td>To create a release with your Helm chart, add your Helm chart and a Replicated HelmChart custom resource to the release. See <a href="releases-creating-release">Managing Releases with the Vendor Portal</a> and <a href="helm-release">Supporting Native Helm and Replicated Helm</a>.</td>
+        <td>To create a release with your Helm chart, add your Helm chart and a Replicated HelmChart custom resource to the release. See <a href="releases-creating-releases">Managing Releases with the Vendor Portal</a> and <a href="helm-release">Supporting Native Helm and Replicated Helm</a>.</td>
       </tr>
       <tr>
         <td>Standard manifest files</td>


### PR DESCRIPTION
The broken link is [Managing Releases with the Vendor Portal](https://docs.replicated.com/vendor/releases-creating-release) in the table located in bullet 2, `Helm Charts` row.

https://docs.replicated.com/vendor/distributing-workflow#plan-promote-and-test-your-initial-release
