### PR TITLE
add invalid-rendered-yaml lint docs

### DIFF
--- a/docs/partials/linter-rules/_invalid-rendered-yaml.mdx
+++ b/docs/partials/linter-rules/_invalid-rendered-yaml.mdx
@@ -71,7 +71,7 @@ spec:
     {
       "rule": "invalid-rendered-yaml",
       "type": "error",
-      "message": "yaml: did not find expected alphabetic or numeric character: image: ***HIDDEN***/0",
+      "message": "yaml: did not find expected alphabetic or numeric character: image: ***HIDDEN***",
       "path": "nginx-chart.yaml",
       "positions": null
     }

--- a/docs/partials/linter-rules/_invalid-rendered-yaml.mdx
+++ b/docs/partials/linter-rules/_invalid-rendered-yaml.mdx
@@ -1,4 +1,3 @@
-For a given HelmChart
 ```yaml
 apiVersion: kots.io/v1beta1
 kind: HelmChart
@@ -15,7 +14,7 @@ spec:
     nginx_image: repl{{ ConfigOption `nginx_image`}}
 ```
 
-**Correct config**:
+**Correct Config**:
 ```yaml
 apiVersion: kots.io/v1beta1
 kind: Config
@@ -32,7 +31,7 @@ spec:
           default: "nginx"
 ```
 
-**resulting rendered helm chart**
+**Resulting Rendered Helm Chart**:
 ```yaml
 apiVersion: kots.io/v1beta1
 kind: HelmChart
@@ -48,7 +47,7 @@ spec:
   values:
     nginx_image: nginx
 ```
-**Incorrect config**:
+**Incorrect Config**:
 ```yaml
 apiVersion: kots.io/v1beta1
 kind: Config
@@ -64,7 +63,7 @@ spec:
           default: "***HIDDEN***"
 ```
 
-**resulting lint error**
+**Resulting Lint Error**:
 ```json
 {
   "lintExpressions": [
@@ -79,7 +78,7 @@ spec:
   "isLintingComplete": false
 }
 ```
-**incorrectly rendered helm chart**
+**Incorrectly Rendered Helm Chart**:
 ```yaml
 apiVersion: kots.io/v1beta1
 kind: HelmChart

--- a/docs/partials/linter-rules/_invalid-rendered-yaml.mdx
+++ b/docs/partials/linter-rules/_invalid-rendered-yaml.mdx
@@ -93,5 +93,5 @@ spec:
   useHelmInstall: true
   builder: {}
   values:
-    image: ***HIDDEN***/0
+    image: ***HIDDEN***
 ```

--- a/docs/partials/linter-rules/_invalid-rendered-yaml.mdx
+++ b/docs/partials/linter-rules/_invalid-rendered-yaml.mdx
@@ -1,3 +1,4 @@
+**Example Helm Chart**:
 ```yaml
 apiVersion: kots.io/v1beta1
 kind: HelmChart

--- a/docs/partials/linter-rules/_invalid-rendered-yaml.mdx
+++ b/docs/partials/linter-rules/_invalid-rendered-yaml.mdx
@@ -1,0 +1,97 @@
+For a given HelmChart
+```yaml
+apiVersion: kots.io/v1beta1
+kind: HelmChart
+metadata:
+  name: nginx-chart
+spec:
+  chart:
+    name: nginx-chart
+    chartVersion: 0.1.0
+  helmVersion: v3
+  useHelmInstall: true
+  builder: {}
+  values:
+    nginx_image: repl{{ ConfigOption `nginx_image`}}
+```
+
+**Correct config**:
+```yaml
+apiVersion: kots.io/v1beta1
+kind: Config
+metadata:
+  name: nginx-config
+spec:
+  groups:
+    - name: nginx-deployment-config
+      title: nginx deployment config
+      items:
+        - name: nginx_image
+          title: image
+          type: text
+          default: "nginx"
+```
+
+**resulting rendered helm chart**
+```yaml
+apiVersion: kots.io/v1beta1
+kind: HelmChart
+metadata:
+  name: nginx-chart
+spec:
+  chart:
+    name: nginx-chart
+    chartVersion: 0.1.0
+  helmVersion: v3
+  useHelmInstall: true
+  builder: {}
+  values:
+    nginx_image: nginx
+```
+**Incorrect config**:
+```yaml
+apiVersion: kots.io/v1beta1
+kind: Config
+metadata:
+  name: nginx-config
+spec:
+  groups:
+    - name: nginx-deployment-config
+      items:
+        - name: nginx_image
+          title: image
+          type: text
+          default: "***HIDDEN***"
+```
+
+**resulting lint error**
+```json
+{
+  "lintExpressions": [
+    {
+      "rule": "invalid-rendered-yaml",
+      "type": "error",
+      "message": "yaml: did not find expected alphabetic or numeric character: image: ***HIDDEN***/0",
+      "path": "nginx-chart.yaml",
+      "positions": null
+    }
+  ],
+  "isLintingComplete": false
+}
+```
+**incorrectly rendered helm chart**
+```yaml
+apiVersion: kots.io/v1beta1
+kind: HelmChart
+metadata:
+  name: nginx-chart
+spec:
+  chart:
+    name: nginx-chart
+    chartVersion: 0.1.0
+  helmVersion: v3
+  useHelmInstall: true
+  builder: {}
+  values:
+    image: ***HIDDEN***/0
+```

--- a/docs/reference/linter.mdx
+++ b/docs/reference/linter.mdx
@@ -34,6 +34,7 @@ import RepeatOptionMissingValuesByGroup from "../partials/linter-rules/_repeat-o
 import RepeatOptionMalformedYAMLPath from "../partials/linter-rules/_repeat-option-malformed-yamlpath.mdx"
 import ConfigOptionPasswordType from "../partials/linter-rules/_config-option-password-type.mdx"
 import ConfigOptionIsCircular from "../partials/linter-rules/_config-option-is-circular.mdx"
+import InvalidRenderedYaml from "../partials/linter-rules/_invalid-rendered-yaml.mdx"
 import InvalidType from "../partials/linter-rules/_invalid_type.mdx"
 import InvalidYaml from "../partials/linter-rules/_invalid-yaml.mdx"
 import LinterDefinition from "../partials/linter-rules/_linter-definition.mdx"
@@ -691,6 +692,31 @@ For more information, see [LintConfig](custom-resource-lintconfig).
   <tr>
     <th>Example</th>
     <td><p>Example of correct YAML for this rule:</p><InvalidMinKOTS/></td>
+  </tr>
+</table>
+
+### invalid-rendered-yaml
+
+<table>
+  <tr>
+    <th>Description</th>
+    <td>
+      <p>Enforces valid YAML after rendering the manifests using the Config spec.</p>
+    </td>
+  </tr>
+  <tr>
+    <th>Level</th>
+    <td>Error</td>
+  </tr>
+  <tr>
+    <th>Applies To</th>
+    <td>
+      YAML files
+    </td>
+  </tr>
+  <tr>
+    <th>Example</th>
+    <td><InvalidRenderedYaml/></td>
   </tr>
 </table>
 


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/80217/kots-lint-returning-an-invalid-error-when-not-able-to-parse-helmchart-manifest