### PR TITLE
Clarify that users can't replace licenses

### DIFF
--- a/docs/enterprise/updating-licenses.md
+++ b/docs/enterprise/updating-licenses.md
@@ -20,7 +20,7 @@ Click **Upload license** on the right side of the license pane and select the la
 - A **License is already up to date** note appears if no changes are detected.
 - A **License uploaded successfully** note appears when the changes are successfully applied.
 
-## Change Community Licenses
+## Upgrade from a Community License
 
 If you have a community license, you can change your license by uploading a new one. This allows you to upgrade from a community version of the software without having to reinstall the admin console and the application.
 

--- a/docs/vendor/licenses-about-types.md
+++ b/docs/vendor/licenses-about-types.md
@@ -6,9 +6,9 @@ This topic describes community licenses. For more information about other types 
 
 Community licenses are intended for use with a free or low cost version of your application. For example, you could use community licenses for an open source version of your application.
 
-After installing an application with a community license, users can replace their community license with a new license file of a different type without having to completely reinstall the application. This means that, if you have several community users who install with the same license, then you can upgrade a single community user without editing the license for all community users.
+After installing an application with a community license, users can replace their community license with a new license of a different type without having to completely reinstall the application. This means that, if you have several community users who install with the same license, then you can upgrade a single community user without editing the license for all community users.
 
-For applications installed with Replicated KOTS, community license users can upload a new license file in the Replicated admin console. Upgrading from a community license cannot be reverted. For more information, see [Upgrade from a Community License](/enterprise/updating-licenses#upgrade-from-a-community-license) in _Updating Licenses_. 
+For applications installed with Replicated KOTS, community license users can upload a new license file of a different types in the Replicated admin console. Upgrading from a community license cannot be reverted. For more information, see [Upgrade from a Community License](/enterprise/updating-licenses#upgrade-from-a-community-license) in _Updating Licenses_. 
 
 ## Limitations
 

--- a/docs/vendor/licenses-about-types.md
+++ b/docs/vendor/licenses-about-types.md
@@ -1,14 +1,14 @@
 # Community Licenses
 
-This topic describes community licenses and how to update the type of a license.
+This topic describes community licenses. For more information about other types of licenses, see [License Types](licenses-about#license-types) in _About Customers_.
 
 ## Overview
 
 Community licenses are intended for use with a free or low cost version of your application. For example, you could use community licenses for an open source version of your application.
 
-After installing an application with a community license, users can change their community license to a different type of license. Because several of your community users might use the same community license, this allows you to upgrade a single user to a new license without changing the community license for all users. This also allows you to upgrade a user from a shared community license without requiring them to reinstall the application.
+After installing an application with a community license, users can replace their community license with a new license file of a different type without having to completely reinstall the application. This means that, if you have several community users who install with the same license, then you can upgrade a single community user without editing the license for all community users.
 
-For more information, see [Change Community Licenses](/enterprise/updating-licenses#change-community-licenses) in _Updating Licenses_. 
+Community license users can upload a new license file in the admin console. Upgrading from a community license cannot be reverted. For more information, see [Upgrade from a Community License](/enterprise/updating-licenses#upgrade-from-a-community-license) in _Updating Licenses_. 
 
 ## Limitations
 

--- a/docs/vendor/licenses-about-types.md
+++ b/docs/vendor/licenses-about-types.md
@@ -8,7 +8,7 @@ Community licenses are intended for use with a free or low cost version of your 
 
 After installing an application with a community license, users can replace their community license with a new license of a different type without having to completely reinstall the application. This means that, if you have several community users who install with the same license, then you can upgrade a single community user without editing the license for all community users.
 
-For applications installed with Replicated KOTS, community license users can upload a new license file of a different types in the Replicated admin console. Upgrading from a community license cannot be reverted. For more information, see [Upgrade from a Community License](/enterprise/updating-licenses#upgrade-from-a-community-license) in _Updating Licenses_. 
+For applications installed with Replicated KOTS, community license users can upload a new license file of a different type in the Replicated admin console. Upgrading from a community license cannot be reverted. For more information, see [Upgrade from a Community License](/enterprise/updating-licenses#upgrade-from-a-community-license) in _Updating Licenses_. 
 
 ## Limitations
 

--- a/docs/vendor/licenses-about-types.md
+++ b/docs/vendor/licenses-about-types.md
@@ -8,7 +8,7 @@ Community licenses are intended for use with a free or low cost version of your 
 
 After installing an application with a community license, users can replace their community license with a new license file of a different type without having to completely reinstall the application. This means that, if you have several community users who install with the same license, then you can upgrade a single community user without editing the license for all community users.
 
-Community license users can upload a new license file in the admin console. Upgrading from a community license cannot be reverted. For more information, see [Upgrade from a Community License](/enterprise/updating-licenses#upgrade-from-a-community-license) in _Updating Licenses_. 
+For applications installed with Replicated KOTS, community license users can upload a new license file in the Replicated admin console. Upgrading from a community license cannot be reverted. For more information, see [Upgrade from a Community License](/enterprise/updating-licenses#upgrade-from-a-community-license) in _Updating Licenses_. 
 
 ## Limitations
 
@@ -19,7 +19,7 @@ exceptions:
 * Community license users are not supported by the Replicated Support team.
 * Community licenses cannot support air gapped installations.
 * Community licenses cannot include an expiration date.
-* For applications installed with Replicated KOTS, the branding in the Replicated admin console for community users differs in the following ways:
+* For applications installed with KOTS, the branding in the admin console for community users differs in the following ways:
   * The license tile on the admin console **Dashboard** page is highlighted in yellow and with the words **Community Edition**.
 
      ![Community License Dashboard](/images/community-license-dashboard.png)

--- a/docs/vendor/licenses-about.md
+++ b/docs/vendor/licenses-about.md
@@ -3,7 +3,7 @@ import ChangeChannel from "../partials/customers/_change-channel.mdx"
 
 # About Customers
 
-This topic provides an overview of customer licenses, including information about license types, the **Customers** page in the Replicated vendor portal, and how Replicated uses the customer entitlement information that you provide in license files.
+This topic provides an overview of customer licenses, including information about license types, the **Customers** page in the Replicated vendor portal, and how Replicated uses the customer entitlement information that you provide in licenses.
 
 ## Overview
 
@@ -51,9 +51,9 @@ You can change the type of a license at any time in the vendor portal. For examp
 
 You can make changes to a customer in the vendor portal to edit their license details, including the license type or the customer name, at any time. The license ID, which is the unique identifier for the customer, never changes. For more information about how to edit customers, see [Edit a Customer](releases-creating-customer#edit-a-customer) in _Creating and Managing Customers_.
 
-Unless an existing customer is using a community license, it is not possible to replace one license file with another license file without reinstalling the application. When you need to make changes to a customer's entitlements, Replicated recommends that you edit the customer's license details in the vendor portal, rather than issuing a new license file.
+Unless the existing customer is using a community license, it is not possible to replace one license with another license without reinstalling the application. When you need to make changes to a customer's entitlements, Replicated recommends that you edit the customer's license details in the vendor portal, rather than issuing a new license. When you update the license in the vendor portal, the customer does not need to reinstall to get the updates, and KOTS users can synchronize the license from the admin console. Additionally, you can avoid the cost that comes with issuing another license.
 
-For more information about how Replicated KOTS users with a community license can upload a different license file in the admin console, see [Community Licenses](licenses-about-types).
+For more information about how Replicated KOTS users with a community license can upload a different license in the admin console, see [Community Licenses](licenses-about-types).
 
 ## KOTS License Handling
 
@@ -66,7 +66,7 @@ When you edit customer licenses for an application installed with KOTS, your cus
 For online instances, license updates are pulled from the vendor portal when:
 * An automatic or manual update check is performed by KOTS.
 * A customer selects **Sync license** in the admin console.
-* An app status changes. See [Current State](instance-insights-details#current-state) in _Instance Details_.
+* An application status changes. See [Current State](instance-insights-details#current-state) in _Instance Details_.
 
 For air gap instances, because air gap licenses are signed with the updated fields, customers must upload a regenerated license file to the admin console every time you modify license fields. After you update the license fields in the vendor portal, you can notify customers by either sending them a new license file or instructing them to log into their download portal to retrieve the updated license. Then, they can click **Upload license** on the **License** tab of the admin console to upload the new license file.
 

--- a/docs/vendor/licenses-about.md
+++ b/docs/vendor/licenses-about.md
@@ -44,17 +44,17 @@ of your software.
 * **Paid**: The Paid type identifies the customer as a paying customer for which
 additional information can be provided.
 * **Community**: The Community type is designed for a free or low cost version of your
-application. Community license users can change their license by uploading the new license file in the Replicated admin console. For more details about this type, see [Community Licenses](licenses-about-types).
+application. Community license users can change their license by uploading a new license file in the Replicated admin console. For more details about this type, see [Community Licenses](licenses-about-types).
 
-You can change the license type at any time in the vendor portal. For example, if a customer upgraded from a trial to a paid account, then you could change their license type from trial to paid for reporting purposes. 
+You can change the type of a license at any time in the vendor portal. For example, if a customer upgraded from a trial to a paid account, then you could change their license type from Trial to Paid for reporting purposes. 
 
 ### Updating or Replacing Licenses
 
-You can make changes to a customer in the vendor portal to edit their license details, including the license type, at any time. For more information about how to edit customers, see [Edit a Customer](releases-creating-customer#edit-a-customer) in _Creating and Managing Customers_.
+You can make changes to a customer in the vendor portal to edit their license details, including the license type or the customer name, at any time. The license ID, which is the unique identifier for the customer, never changes. For more information about how to edit customers, see [Edit a Customer](releases-creating-customer#edit-a-customer) in _Creating and Managing Customers_.
 
-With the exception of community licenses, it is not possible for existing users to replace one license file with another license file without reinstalling the application. When you need to make changes to a customer's entitlements, Replicated recommends that you edit the customer's license details in the vendor portal, rather than issuing a new license file.
+Unless an existing customer is using a community license, it is not possible to replace one license file with another license file without reinstalling the application. When you need to make changes to a customer's entitlements, Replicated recommends that you edit the customer's license details in the vendor portal, rather than issuing a new license file.
 
-For more information about how community license users can upload a new license file to the admin console, see [Community Licenses](licenses-about-types).
+For more information about how community license users can upload a different license file to the admin console, see [Community Licenses](licenses-about-types).
 
 ## KOTS License Handling
 

--- a/docs/vendor/licenses-about.md
+++ b/docs/vendor/licenses-about.md
@@ -44,7 +44,7 @@ of your software.
 * **Paid**: The Paid type identifies the customer as a paying customer for which
 additional information can be provided.
 * **Community**: The Community type is designed for a free or low cost version of your
-application. Community license users can change their license by uploading the new license file in the admin console. For more details about this type, see [Community Licenses](licenses-about-types).
+application. Community license users can change their license by uploading the new license file in the Replicated admin console. For more details about this type, see [Community Licenses](licenses-about-types).
 
 You can change the license type at any time in the vendor portal. For example, if a customer upgraded from a trial to a paid account, then you could change their license type from trial to paid for reporting purposes. 
 
@@ -52,7 +52,7 @@ You can change the license type at any time in the vendor portal. For example, i
 
 You can make changes to a customer in the vendor portal to edit their license details, including the license type, at any time. For more information about how to edit customers, see [Edit a Customer](releases-creating-customer#edit-a-customer) in _Creating and Managing Customers_.
 
-With the exception of community licenses, it is not possible for existing users to use a different license file without reinstalling the application. When you need to make changes to a customer's entitlements, Replicated recommends that you edit the customer's license details in the vendor portal, rather than issuing a new license file.
+With the exception of community licenses, it is not possible for existing users to replace one license file with another license file without reinstalling the application. When you need to make changes to a customer's entitlements, Replicated recommends that you edit the customer's license details in the vendor portal, rather than issuing a new license file.
 
 For more information about how community license users can upload a new license file to the admin console, see [Community Licenses](licenses-about-types).
 
@@ -62,7 +62,7 @@ This section describes the license handling features for installations with Repl
 
 ### License Updates
 
-When you edit customer licenses for an application installed with KOTS, your customers can use the Replicated admin console to update their license.
+When you edit customer licenses for an application installed with KOTS, your customers can use the admin console to update their license.
 
 For online instances, license updates are pulled from the vendor portal when:
 * An automatic or manual update check is performed by KOTS.

--- a/docs/vendor/licenses-about.md
+++ b/docs/vendor/licenses-about.md
@@ -43,8 +43,7 @@ team for testing and integration.
 of your software.
 * **Paid**: The Paid type identifies the customer as a paying customer for which
 additional information can be provided.
-* **Community**: The Community type is designed for a free or low cost version of your
-application. Community license users can change their license by uploading a new license file in the Replicated admin console. For more details about this type, see [Community Licenses](licenses-about-types).
+* **Community**: The Community type is designed for a free or low cost version of your application. For more details about this type, see [Community Licenses](licenses-about-types).
 
 You can change the type of a license at any time in the vendor portal. For example, if a customer upgraded from a trial to a paid account, then you could change their license type from Trial to Paid for reporting purposes. 
 

--- a/docs/vendor/licenses-about.md
+++ b/docs/vendor/licenses-about.md
@@ -19,7 +19,7 @@ You assign customers to channels in the vendor portal to control their access to
 
 <ChangeChannel/>
 
-For example, if the latest release promoted to the Beta channel is version 1.25.0 and version 1.10.0 is marked as required, when you edit an existing customer to assign them to the Beta channel, then the admin console always fetches 1.25.0, even though 1.10.0 is marked as required. The required release 1.10.0 is ignored and is not available to the customer for upgrade.
+For example, if the latest release promoted to the Beta channel is version 1.25.0 and version 1.10.0 is marked as required, when you edit an existing customer to assign them to the Beta channel, then the Replicated admin console always fetches 1.25.0, even though 1.10.0 is marked as required. The required release 1.10.0 is ignored and is not available to the customer for upgrade.
 
 For more information about how to mark a release as required, see [Release Properties](releases-about#release-properties) in _About Releases_. For more information about how to synchronize licenses in the admin console, see [Updating Licenses](/enterprise/updating-licenses).
 
@@ -47,19 +47,19 @@ additional information can be provided.
 
 You can change the type of a license at any time in the vendor portal. For example, if a customer upgraded from a trial to a paid account, then you could change their license type from Trial to Paid for reporting purposes. 
 
-### Updating or Replacing Licenses
+### Updating and Replacing Licenses
 
 You can make changes to a customer in the vendor portal to edit their license details, including the license type or the customer name, at any time. The license ID, which is the unique identifier for the customer, never changes. For more information about how to edit customers, see [Edit a Customer](releases-creating-customer#edit-a-customer) in _Creating and Managing Customers_.
 
 Unless an existing customer is using a community license, it is not possible to replace one license file with another license file without reinstalling the application. When you need to make changes to a customer's entitlements, Replicated recommends that you edit the customer's license details in the vendor portal, rather than issuing a new license file.
 
-For more information about how community license users can upload a different license file to the admin console, see [Community Licenses](licenses-about-types).
+For more information about how Replicated KOTS users with a community license can upload a different license file in the admin console, see [Community Licenses](licenses-about-types).
 
 ## KOTS License Handling
 
-This section describes the license handling features for installations with Replicated KOTS.
+This section describes the license handling features for applications installed with KOTS.
 
-### License Updates
+### Synchronizing Licenses
 
 When you edit customer licenses for an application installed with KOTS, your customers can use the admin console to update their license.
 
@@ -70,7 +70,7 @@ For online instances, license updates are pulled from the vendor portal when:
 
 For air gap instances, because air gap licenses are signed with the updated fields, customers must upload a regenerated license file to the admin console every time you modify license fields. After you update the license fields in the vendor portal, you can notify customers by either sending them a new license file or instructing them to log into their download portal to retrieve the updated license. Then, they can click **Upload license** on the **License** tab of the admin console to upload the new license file.
 
-For more information about how to update licenses in the admin console for KOTS installations, see [Updating Licenses](/enterprise/updating-licenses).
+For more information about community licenses, including how KOTS users can update licenses in the admin console, see [Updating Licenses](/enterprise/updating-licenses).
 
 ### License Expiration Handling
 

--- a/docs/vendor/licenses-about.md
+++ b/docs/vendor/licenses-about.md
@@ -51,9 +51,9 @@ You can change the type of a license at any time in the vendor portal. For examp
 
 You can make changes to a customer in the vendor portal to edit their license details, including the license type or the customer name, at any time. The license ID, which is the unique identifier for the customer, never changes. For more information about how to edit customers, see [Edit a Customer](releases-creating-customer#edit-a-customer) in _Creating and Managing Customers_.
 
-Unless the existing customer is using a community license, it is not possible to replace one license with another license without reinstalling the application. When you need to make changes to a customer's entitlements, Replicated recommends that you edit the customer's license details in the vendor portal, rather than issuing a new license. When you update the license in the vendor portal, the customer does not need to reinstall to get the updates, and KOTS users can synchronize the license from the admin console. Additionally, you can avoid the cost that comes with issuing another license.
+Unless the existing customer is using a community license, it is not possible to replace one license with another license without reinstalling the application. When you need to make changes to a customer's entitlements, Replicated recommends that you edit the customer's license details in the vendor portal, rather than issuing a new license. When you update the license in the vendor portal, the customer does not need to reinstall to get the updates, and Replicated KOTS users can synchronize the license from the admin console. Additionally, you can avoid the cost that comes with issuing another license.
 
-For more information about how Replicated KOTS users with a community license can upload a different license in the admin console, see [Community Licenses](licenses-about-types).
+For more information about how KOTS users with a community license can upload a different license in the admin console, see [Community Licenses](licenses-about-types).
 
 ## KOTS License Handling
 

--- a/docs/vendor/licenses-about.md
+++ b/docs/vendor/licenses-about.md
@@ -33,7 +33,7 @@ You can also create custom license fields to define entitlements specific to the
 
 ### License Types
 
-Each customer license includes a `license_type` field. The type of customer defined by the `license_type` field is used solely for reporting purposes. A customer's access to your application is not affected by the type that you assign.
+Each customer license includes a type. The license type is used solely for reporting purposes. A customer's access to your application is not affected by the type that you assign.
 
 The customer types are:
 
@@ -44,24 +44,36 @@ of your software.
 * **Paid**: The Paid type identifies the customer as a paying customer for which
 additional information can be provided.
 * **Community**: The Community type is designed for a free or low cost version of your
-application. For more details about this type, see [Community Licenses](licenses-about-types).
+application. Community license users can change their license by uploading the new license file in the admin console. For more details about this type, see [Community Licenses](licenses-about-types).
 
-### KOTS License Updates
+You can change the license type at any time in the vendor portal. For example, if a customer upgraded from a trial to a paid account, then you could change their license type from trial to paid for reporting purposes. 
 
-You can make changes to a customer in the vendor portal to edit their license details at any time. For more information about how to edit customers, see [Edit a Customer](releases-creating-customer#edit-a-customer) in _Creating and Managing Customers_.
+### Updating or Replacing Licenses
+
+You can make changes to a customer in the vendor portal to edit their license details, including the license type, at any time. For more information about how to edit customers, see [Edit a Customer](releases-creating-customer#edit-a-customer) in _Creating and Managing Customers_.
+
+With the exception of community licenses, it is not possible for existing users to use a different license file without reinstalling the application. When you need to make changes to a customer's entitlements, Replicated recommends that you edit the customer's license details in the vendor portal, rather than issuing a new license file.
+
+For more information about how community license users can upload a new license file to the admin console, see [Community Licenses](licenses-about-types).
+
+## KOTS License Handling
+
+This section describes the license handling features for installations with Replicated KOTS.
+
+### License Updates
 
 When you edit customer licenses for an application installed with KOTS, your customers can use the Replicated admin console to update their license.
 
 For online instances, license updates are pulled from the vendor portal when:
-  * An automatic or manual update check is performed by KOTS.
-  * A customer selects **Sync license** in the admin console.
-  * An app status changes. See [Current State](instance-insights-details#current-state) in _Instance Details_.
+* An automatic or manual update check is performed by KOTS.
+* A customer selects **Sync license** in the admin console.
+* An app status changes. See [Current State](instance-insights-details#current-state) in _Instance Details_.
 
 For air gap instances, because air gap licenses are signed with the updated fields, customers must upload a regenerated license file to the admin console every time you modify license fields. After you update the license fields in the vendor portal, you can notify customers by either sending them a new license file or instructing them to log into their download portal to retrieve the updated license. Then, they can click **Upload license** on the **License** tab of the admin console to upload the new license file.
 
 For more information about how to update licenses in the admin console for KOTS installations, see [Updating Licenses](/enterprise/updating-licenses).
 
-### KOTS License Expiration Handling
+### License Expiration Handling
 
 The built-in `expires_at` license field defines the expiration date for a customer license. When you set an expiration date in the vendor portal, the `expires_at` field is set to midnight UTC on the date selected.
 


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/82541/add-info-that-licenses-types-can-t-be-replaced

Previews:
- New section: https://deploy-preview-1273--replicated-docs-upgrade.netlify.app/vendor/licenses-about#updating-and-replacing-licenses
- Updated license types section: https://deploy-preview-1273--replicated-docs-upgrade.netlify.app/vendor/licenses-about#license-types
- Community license topic: https://deploy-preview-1273--replicated-docs-upgrade.netlify.app/vendor/licenses-about-types