### PR TITLE
83916: Served Cached Data for SDK

### DIFF
--- a/docs/vendor/replicated-sdk-overview.md
+++ b/docs/vendor/replicated-sdk-overview.md
@@ -9,10 +9,6 @@ This topic provides an introduction to using the Replicated SDK with your Helm c
 
 <SDKOverview/>
 
-:::note
-If the application pod is running and the SDK API service (replicated.app) goes down, cached data is served from memory. Customer-specific license information will continue to work with your application.
-:::
-
 For more information about using the Replicated SDK, see [Using the SDK With Your Application (Beta)](/vendor/replicated-sdk-using).
 
 ## How the SDK Runs in a Customer Environment {#about-sdk-initialize}
@@ -24,6 +20,10 @@ The following diagram shows how the Replicated SDK is installed and runs in a cu
 <HelmDiagramOverview/>
 
 Finally, the SDK is initialized in the customer environment using values that the Replicated registry injects in the Helm chart values file. After the SDK is initialized, you can use the SDK API to get customer-specific license information from the vendor portal during runtime. You can also use the API to get details about the instance from the customer environment and from the vendor portal.
+
+:::note
+If the application pod is running and the SDK API service (replicated.app) goes down, cached data is served from memory. Customer-specific license information will continue to work with your application.
+:::
 
 For more information about installing with Helm, see [Installing an Application with Helm (Beta)](install-with-helm).
 

--- a/docs/vendor/replicated-sdk-overview.md
+++ b/docs/vendor/replicated-sdk-overview.md
@@ -21,11 +21,15 @@ The following diagram shows how the Replicated SDK is installed and runs in a cu
 
 Finally, the SDK is initialized in the customer environment using values that the Replicated registry injects in the Helm chart values file. After the SDK is initialized, you can use the SDK API to get customer-specific license information from the vendor portal during runtime. You can also use the API to get details about the instance from the customer environment and from the vendor portal.
 
-:::note
-The application and license ID are pulled by the SDK API from the replicated.app service. If the application pod is running and the replicated.app service goes down, the cached data is served from memory. Customer-specific license information will continue to work with your application.
-:::
-
 For more information about installing with Helm, see [Installing an Application with Helm (Beta)](install-with-helm).
+
+## SDK Resiliency
+
+At startup and when serving requests, the SDK retrieves and caches the latest information from the upstream Replicated APIs, including customer license information.
+
+If the upstream APIs are not available at startup, the SDK does not accept connections or serve requests until it is able to communicate with the upstream APIs. If communication fails, the SDK retries every 10 seconds and the SDK pod is at `0/1` ready.
+
+When serving requests, if the upstream APIs become unavailable, the SDK serves from the memory cache and sets the `X-Replicated-Served-From-Cache` header to `true`.
 
 ## Replicated Helm Values {#replicated-values}
 

--- a/docs/vendor/replicated-sdk-overview.md
+++ b/docs/vendor/replicated-sdk-overview.md
@@ -22,7 +22,7 @@ The following diagram shows how the Replicated SDK is installed and runs in a cu
 Finally, the SDK is initialized in the customer environment using values that the Replicated registry injects in the Helm chart values file. After the SDK is initialized, you can use the SDK API to get customer-specific license information from the vendor portal during runtime. You can also use the API to get details about the instance from the customer environment and from the vendor portal.
 
 :::note
-If the application pod is running and the SDK API service (replicated.app) goes down, cached data is served from memory. Customer-specific license information will continue to work with your application.
+The application and license ID are pulled by the SDK API from the replicated.app service. If the application pod is running and the replicated.app service goes down, the cached data is served from memory. Customer-specific license information will continue to work with your application.
 :::
 
 For more information about installing with Helm, see [Installing an Application with Helm (Beta)](install-with-helm).

--- a/docs/vendor/replicated-sdk-overview.md
+++ b/docs/vendor/replicated-sdk-overview.md
@@ -9,6 +9,10 @@ This topic provides an introduction to using the Replicated SDK with your Helm c
 
 <SDKOverview/>
 
+:::note
+If the application pod is running and the SDK API service (replicated.app) goes down, cached data is served from memory. Customer-specific license information will continue to work with your application.
+:::
+
 For more information about using the Replicated SDK, see [Using the SDK With Your Application (Beta)](/vendor/replicated-sdk-using).
 
 ## How the SDK Runs in a Customer Environment {#about-sdk-initialize}


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/83916/serve-cached-data-from-replicated-app

Preview: https://deploy-preview-1310--replicated-docs.netlify.app/vendor/replicated-sdk-overview#sdk-resiliency