### PR TITLE
change alpha to beta for notifications

### DIFF
--- a/docs/partials/instance-insights/_notifications-about.mdx
+++ b/docs/partials/instance-insights/_notifications-about.mdx
@@ -1,5 +1,5 @@
 :::note
-Configuring notifications for customer instance changes is in Alpha. To enable this feature, log in to your vendor portal account. Select **Support** > **Request a feature**, and submit a feature request for "Instance Insights Notifications". To access a pre-filled version of this form, click [this link](https://vendor.replicated.com/support?requestType=feature&productArea=vendor&title=I+Would+Like+to+be+an+Instance+Insights+Notifications+Alpha+Tester).
+Configuring notifications for customer instance changes is in Beta.
 :::
 
 Notifications can help catch problems before they happen and let you proactively contact customers to prevent support cases. For example, you can be notified of a degraded status and you can contact your customer about fixing it before the instance goes down. This approach can make issues quicker and easier to solve, and improve the customer experience with less down time.

--- a/docs/vendor/instance-notifications-config.mdx
+++ b/docs/vendor/instance-notifications-config.mdx
@@ -1,7 +1,7 @@
 import NotificationsAbout from "../partials/instance-insights/_notifications-about.mdx"
 
 
-# Configuring Instance Notifications (Alpha)
+# Configuring Instance Notifications (Beta)
 
 <NotificationsAbout/>
 
@@ -11,7 +11,7 @@ Instance notifications can be disabled when they are no longer needed. For examp
 
 ## Prerequisite
 
-For Slack notifications, you must configure a Slack webhook in the vendor portal at the Team level before you can turn on instance notifications. For more information, see [Configuring a Slack Webhook (Alpha)](team-management-slack-config).
+For Slack notifications, you must configure a Slack webhook in the vendor portal at the Team level before you can turn on instance notifications. For more information, see [Configuring a Slack Webhook (Beta)](team-management-slack-config).
 
 For email notification, no prior configuration is required. The email address listed in your vendor portal account settings is used.
 

--- a/docs/vendor/team-management-slack-config.mdx
+++ b/docs/vendor/team-management-slack-config.mdx
@@ -1,7 +1,7 @@
 import NotificationsAbout from "../partials/instance-insights/_notifications-about.mdx"
 
 
-# Configuring a Slack Webhook (Alpha)
+# Configuring a Slack Webhook (Beta)
 
 As a vendor, anyone on your team can set up Slack notifications, which are sent to a shared Slack channel. Notifications give your team visibility into customer instance statuses and changes.
 
@@ -11,7 +11,7 @@ While email notifications are specific to each user, Slack notifications setting
 
 ## Limitations
 
-As an Alpha feature, the following limitations apply:
+As a Beta feature, the following limitations apply:
 
 - Only one Slack channel per team is supported.
 


### PR DESCRIPTION
Related story: https://app.shortcut.com/replicated/story/83134/notifications-beta-remove-feature-flag-add-beta-label-in-product-update-docs