### PR TITLE
SDK release notes

### DIFF
--- a/.github/workflows/replicated-sdk-release-notes.yml
+++ b/.github/workflows/replicated-sdk-release-notes.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   generate-release-notes-pr:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 
@@ -20,8 +20,8 @@ jobs:
       uses: replicatedhq/release-notes-generator@main
       with:
         owner-repo: replicatedhq/replicated-sdk
-        head: v$SDK_VERSION
-        title: $SDK_VERSION
+        head: v$REPLICATED_SDK_VERSION
+        title: $REPLICATED_SDK_VERSION
         include-pr-links: false
         github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/replicated-sdk-release-notes.yml
+++ b/.github/workflows/replicated-sdk-release-notes.yml
@@ -20,7 +20,7 @@ jobs:
       uses: replicatedhq/release-notes-generator@main
       with:
         owner-repo: replicatedhq/replicated-sdk
-        head: $SDK_VERSION
+        head: v$SDK_VERSION
         title: $SDK_VERSION
         include-pr-links: false
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/replicated-sdk-release-notes.yml
+++ b/.github/workflows/replicated-sdk-release-notes.yml
@@ -4,7 +4,7 @@ on:
     types: [replicated-sdk-release-notes]
     inputs:
       version:
-        description: SDK version
+        description: Replicated SDK version
         required: true
 
 jobs:
@@ -16,12 +16,12 @@ jobs:
     - name: Generate Release Notes
       id: release-notes
       env:
-        KOTS_VERSION: ${{ github.event.client_payload.version }}
+        REPLICATED_SDK_VERSION: ${{ github.event.client_payload.version }}
       uses: replicatedhq/release-notes-generator@main
       with:
         owner-repo: replicatedhq/replicated-sdk
         head: $SDK_VERSION
-        title: ${SDK_VERSION#v}
+        title: $SDK_VERSION
         include-pr-links: false
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -62,4 +62,4 @@ jobs:
             "pull_request_url": "${{steps.cpr.outputs.pull-request-url}}"
           }
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SDK_RELEASE_NOTES_SLACK_WEBHOOK }}
+        SLACK_WEBHOOK_URL: ${{ secrets.REPLICATED_SDK_RELEASE_NOTES_SLACK_WEBHOOK }}

--- a/.github/workflows/replicated-sdk-release-notes.yml
+++ b/.github/workflows/replicated-sdk-release-notes.yml
@@ -1,0 +1,65 @@
+name: replicated-sdk-release-notes
+on:
+  repository_dispatch:
+    types: [replicated-sdk-release-notes]
+    inputs:
+      version:
+        description: SDK version
+        required: true
+
+jobs:
+  generate-release-notes-pr:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Generate Release Notes
+      id: release-notes
+      env:
+        KOTS_VERSION: ${{ github.event.client_payload.version }}
+      uses: replicatedhq/release-notes-generator@main
+      with:
+        owner-repo: replicatedhq/replicated-sdk
+        head: $SDK_VERSION
+        title: ${SDK_VERSION#v}
+        include-pr-links: false
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Update Release Notes
+      env:
+        PATTERN: ".+RELEASE_NOTES_PLACEHOLDER.+"
+      run: |
+        cat <<EOT >> /tmp/release-notes.txt
+
+        ${{ steps.release-notes.outputs.release-notes }}
+        EOT
+        sed -i -E "/$PATTERN/r /tmp/release-notes.txt" docs/release-notes/rn-replicated-sdk.md
+        rm -rf /tmp/release-notes.txt
+
+    - name: Create Pull Request # creates a PR if there are differences
+      uses: peter-evans/create-pull-request@v3
+      id: cpr
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: Replicated SDK ${{ github.event.client_payload.version }} release notes
+        title: Replicated SDK ${{ github.event.client_payload.version }} release notes
+        branch: automation/replicated-sdk-release-notes-${{ github.event.client_payload.version }}
+        delete-branch: true
+        base: "main"
+        body: "Automated changes by the [replicated-sdk-release-notes](https://github.com/replicatedhq/replicated-docs/blob/main/.github/workflows/replicated-sdk-release-notes.yml) GitHub action"
+
+    - name: Check outputs
+      run: |
+        echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+        echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+
+    - name: Slack Notification
+      uses: slackapi/slack-github-action@v1.16.0
+      with: 
+        payload: |
+          {
+            "version": "${{ github.event.client_payload.version }}",
+            "pull_request_url": "${{steps.cpr.outputs.pull-request-url}}"
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SDK_RELEASE_NOTES_SLACK_WEBHOOK }}

--- a/docs/release-notes/rn-replicated-sdk.md
+++ b/docs/release-notes/rn-replicated-sdk.md
@@ -1,0 +1,9 @@
+---
+toc_max_heading_level: 2
+pagination_next: null
+pagination_prev: null
+---
+
+# Replicated SDK Release Notes
+
+<!--RELEASE_NOTES_PLACEHOLDER-->

--- a/docs/release-notes/rn-replicated-sdk.md
+++ b/docs/release-notes/rn-replicated-sdk.md
@@ -8,7 +8,7 @@ pagination_prev: null
 
 <!--RELEASE_NOTES_PLACEHOLDER-->
 
-## v0.0.1-beta.1
+## 0.0.1-beta.1
 
 Released on July 28, 2023
 

--- a/docs/release-notes/rn-replicated-sdk.md
+++ b/docs/release-notes/rn-replicated-sdk.md
@@ -7,3 +7,10 @@ pagination_prev: null
 # Replicated SDK Release Notes
 
 <!--RELEASE_NOTES_PLACEHOLDER-->
+
+## v0.0.1-beta.1
+
+Released on July 28, 2023
+
+### Improvements {#improvements-0-0-1-beta-1}
+* Renames the SDK's Kubernetes resources and the library SDK chart from `replicated` to `replicated-sdk` in order to better distinguish from other replicated components.

--- a/docs/release-notes/rn-replicated-sdk.md
+++ b/docs/release-notes/rn-replicated-sdk.md
@@ -13,4 +13,4 @@ pagination_prev: null
 Released on July 28, 2023
 
 ### Improvements {#improvements-0-0-1-beta-1}
-* Renames the SDK's Kubernetes resources and the library SDK chart from `replicated` to `replicated-sdk` in order to better distinguish from other replicated components.
+* Renames the SDK's Kubernetes resources and the library SDK chart from `replicated` to `replicated-sdk` to distinguish them from other replicated components.

--- a/sidebars.js
+++ b/sidebars.js
@@ -388,7 +388,8 @@ const sidebars = {
       items: [
         'release-notes/rn-whats-new',
         'release-notes/rn-app-manager',
-        'release-notes/rn-kubernetes-installer'
+        'release-notes/rn-kubernetes-installer',
+        'release-notes/rn-replicated-sdk'
       ],
     },
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -388,8 +388,7 @@ const sidebars = {
       items: [
         'release-notes/rn-whats-new',
         'release-notes/rn-app-manager',
-        'release-notes/rn-kubernetes-installer',
-        'release-notes/rn-replicated-sdk'
+        'release-notes/rn-kubernetes-installer'
       ],
     },
 


### PR DESCRIPTION
[SC-83240](https://app.shortcut.com/replicated/story/83240/create-release-notes-for-the-sdk)

This PR:
- adds a page for the Replicated-SDK release notes.
- adds `replicated-sdk-release-notes` workflow to open a PR to update the release notes when there is a new version of the SDK released.

Adding the replicated sdk release notes to the sidebar will be part of a different PR: https://github.com/replicatedhq/replicated-docs/pull/1344
This is so that this workflow can be merged and tested before the page is visible in our docs site.