### PR TITLE
83756: Clarify affix field settings

### DIFF
--- a/docs/partials/config/_affixExample.mdx
+++ b/docs/partials/config/_affixExample.mdx
@@ -1,12 +1,17 @@
 ```yaml
-- name: username
-  title: Username
-  type: text
-  required: true
-  affix: left
-- name: password
-  title: Password
-  type: password
-  required: true
-  affix: right
+groups:
+- name: example_settings
+  title: My Example Config
+  description: Configuration to serve as an example for creating your own.
+  items:
+  - name: username
+    title: Username
+    type: text
+    required: true
+    affix: left
+  - name: password
+    title: Password
+    type: password
+    required: true
+    affix: right
 ```

--- a/docs/reference/custom-resource-config.md
+++ b/docs/reference/custom-resource-config.md
@@ -184,7 +184,7 @@ Items have a `name`, `title`, `type`, and other optional properties.
   <tr>
     <th>Description</th>
     <td>
-      <p>Items can be affixed <code>left</code> or <code>right</code>. Affixing items allows them to appear in the admin console on the same line.<br></br><br></br>Specify the <code>affix</code> field to all of the items in a particular group to prevent the appearance of crowded text. </p>
+      <p>Items can be affixed <code>left</code> or <code>right</code>. Affixing items allows them to appear in the admin console on the same line.<br></br><br></br>Specify the <code>affix</code> field to all of the items in a particular group to preserve the line spacing and prevent the appearance of crowded text. </p>
     </td>
   </tr>
   <tr>

--- a/docs/reference/custom-resource-config.md
+++ b/docs/reference/custom-resource-config.md
@@ -184,7 +184,7 @@ Items have a `name`, `title`, `type`, and other optional properties.
   <tr>
     <th>Description</th>
     <td>
-      <p>Items can be affixed <code>left</code> or <code>right</code>. Affixing items allows them to appear in the admin console on the same line.</p>
+      <p>Items can be affixed <code>left</code> or <code>right</code>. Affixing items allows them to appear in the admin console on the same line.<br></br><br></br>Specify the <code>affix</code> field to all of the items in a particular group to prevent the appearance of crowded text. </p>
     </td>
   </tr>
   <tr>

--- a/docs/vendor/admin-console-customize-config-screen.md
+++ b/docs/vendor/admin-console-customize-config-screen.md
@@ -84,7 +84,7 @@ To add fields to the admin console configuration screen:
 
    The example above includes a single group with the name `smtp_settings`.
 
-   The `items` array for the `smtp_settings` group includes the following user-input fields: `enable_smtp`, `smtp_host`, `smtp_port`, `smtp_user`, and `smtp_password`.
+   The `items` array for the `smtp_settings` group includes the following user-input fields: `enable_smtp`, `smtp_host`, `smtp_port`, `smtp_user`, and `smtp_password`. Additional item properties are available, such as `affix` to make items appear horizontally on the same line. For more information about item properties, see [Item Properties](/reference/custom-resource-config#item-properties) in Config.
 
    The following screenshot shows how the SMTP Settings group from the example YAML above displays in the admin console configuration screen during application installation:
 


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/83756/affix-parameter-in-kots-config-needs-to-be-set-on-all-objects-in-a-group-otherwise-it-doesn-t-get-applied

Previews:
- https://deploy-preview-1339--replicated-docs.netlify.app/reference/custom-resource-config#affix
- https://deploy-preview-1339--replicated-docs.netlify.app/vendor/admin-console-customize-config-screen#add-fields-to-the-configuration-screen
