### PR TITLE
add replicated sdk release notes to sidebar

### DIFF
--- a/docs/release-notes/rn-replicated-sdk.md
+++ b/docs/release-notes/rn-replicated-sdk.md
@@ -34,7 +34,7 @@ To avoid this breaking change, do the following before upgrading:
 
 * Update any requests to the SDK service in the cluster to use `replicated-sdk:3000` instead of `replicated:3000`.
 
-* Update any automation that references the installation command for integration mode to `install replicated-sdk oci://registry.replicated.com/library/replicated-sdk --version 0.0.1-beta.1`.
+* Update any automation that references the installation command for integration mode to `helm install replicated-sdk oci://registry.replicated.com/library/replicated-sdk --version 0.0.1-beta.1`.
 
 * If the SDK's values are modified in the `values.yaml` file of the parent chart, change the field name for the SDK subchart in the `values.yaml` file from `replicated` to `replicated-sdk`.
 

--- a/docs/release-notes/rn-replicated-sdk.md
+++ b/docs/release-notes/rn-replicated-sdk.md
@@ -10,12 +10,34 @@ pagination_prev: null
 
 ## 0.0.1-beta.1
 
-:::important
-This Beta release of the Replicated SDK includes a [name change](#improvements-0-0-1-beta-1) that will break previous integrations that were done with the alpha versions.
-If you were previously using an alpha version of the Replicated SDK make sure to update the library SDK chart name from `replicated` to `replicated-sdk`.
-:::
-
 Released on July 28, 2023
 
+:::important
+v0.0.1-beta.1 of the Replicated SDK includes a name change that can cause existing integrations to break. For information about how to avoid this breaking change, see [Breaking Change](#breaking-changes-0-0-1-beta-1).
+:::
 ### Improvements {#improvements-0-0-1-beta-1}
 * Renames the SDK's Kubernetes resources and the library SDK chart from `replicated` to `replicated-sdk` to distinguish them from other replicated components.
+### Breaking Change {#breaking-changes-0-0-1-beta-1}
+
+v0.0.1-beta.1 renames the SDK's Kubernetes resources and the library SDK chart. This can cause existing integrations that use an alpha version of the SDK to break.
+
+To avoid this breaking change, do the following before upgrading:
+
+* Update the dependencies entry for the SDK in the parent chart:
+
+   ```yaml
+   dependencies:
+   - name: replicated-sdk
+     repository: oci://registry.replicated.com/library
+     version: 0.0.1-beta.1
+   ```
+
+* Update any requests to the SDK service in the cluster to use `replicated-sdk:3000` instead of `replicated:3000`.
+
+* Update any automation that references the installation command for integration mode to `install replicated-sdk oci://registry.replicated.com/library/replicated-sdk --version 0.0.1-beta.1`.
+
+* If the SDK's values are modified in the `values.yaml` file of the parent chart, change the field name for the SDK subchart in the `values.yaml` file from `replicated` to `replicated-sdk`.
+
+* Change the field name of any values that are provided at runtime to the SDK from `replicated` to `replicated-sdk`. For example, `--set replicated-sdk.integration.enabled=false`.
+
+For more information, see [About the Replicated SDK](/vendor/replicated-sdk-overview).

--- a/docs/release-notes/rn-replicated-sdk.md
+++ b/docs/release-notes/rn-replicated-sdk.md
@@ -10,6 +10,11 @@ pagination_prev: null
 
 ## 0.0.1-beta.1
 
+:::important
+This Beta release of the Replicated SDK includes a [name change](#improvements-0-0-1-beta-1) that will break previous integrations that were done with the alpha versions.
+If you were previously using an alpha version of the Replicated SDK make sure to update the library SDK chart name from `replicated` to `replicated-sdk`.
+:::
+
 Released on July 28, 2023
 
 ### Improvements {#improvements-0-0-1-beta-1}

--- a/sidebars.js
+++ b/sidebars.js
@@ -388,7 +388,8 @@ const sidebars = {
       items: [
         'release-notes/rn-whats-new',
         'release-notes/rn-app-manager',
-        'release-notes/rn-kubernetes-installer'
+        'release-notes/rn-kubernetes-installer',
+        'release-notes/rn-replicated-sdk'
       ],
     },
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -248,6 +248,17 @@ h3[id^="bug-fixes"] {
   font-size: 20px;
 }
 
+h3[id^="breaking-changes"] {
+  background-color: #E65DAD;
+  /* background-color: #D64399; */
+  border-radius: 7px!important;
+  color: #fff;
+  width: max-content;
+  padding: 0.2em 0.6em 0.2em;
+  font-weight: 500;
+  font-size: 20px;
+}
+
 h3[id^="new-features"] a {
   color: #fff;
   opacity: .5;
@@ -266,4 +277,8 @@ h3[id^="bug-fixes"] a {
   text-decoration: none;
 }
 
-
+h3[id^="breaking-changes"] a {
+  color: #fff;
+  opacity: .5;
+  text-decoration: none;
+}


### PR DESCRIPTION
This PR: 
- adds the replicated sdk release notes page to the sidebar so that they are visible in `docs.replicated.com`
- includes a note about the breaking change in the beta release