### PR TITLE
HOLD FOR RELEASE - Document replicated instance types for VMs

### DIFF
--- a/docs/reference/replicated-cli-cluster-create.md
+++ b/docs/reference/replicated-cli-cluster-create.md
@@ -35,12 +35,7 @@ replicated cluster create [flags]
   <tr>
     <td>--instance-type</td>
     <td>string</td>
-    <td>The type of instance to use for cloud-based clusters, such as x5.xlarge.</td>
-  </tr>
-  <tr>
-    <td>--memory</td>
-    <td>integer</td>
-    <td>The amount of memory (GiB) to request per node. Required for VM clusters. <strong>Default:</strong> 4</td>
+    <td>The type of instance to use for nodes in the cluster, such as x5.xlarge.</td>
   </tr>
   <tr>
     <td>--name</td>
@@ -63,11 +58,6 @@ replicated cluster create [flags]
     <td>The cluster Time to Live (TTL) duration, in hours, before the cluster is automatically deleted by the service. TTL starts when the cluster is in a Ready state. <strong>Valid values:</strong> 1 - 48. <strong>Default:</strong> 1</td>
   </tr>
   <tr>
-    <td>--vcpu</td>
-    <td>integer</td>
-    <td>The number of vCPUs to request per node. Required for VM clusters. <strong>Default:</strong> 4</td>
-  </tr>
-  <tr>
     <td>--version</td>
     <td>string</td>
     <td>The Kubernetes version to provision. For OpenShift clusters, provide the supported OpenShift version. The format is distribution dependent. <strong>Default:</strong> v1.25.3<br></br><br></br>For supported versions, see <a href="/vendor/testing-supported-clusters">Supported Clusters</a>.</td>
@@ -87,6 +77,3 @@ For an EKS distribution:
   replicated cluster create --name eks-example --distribution eks --version 1.27 --node-count 3 --instance-type m5.xlarge
   ```
 
-:::note
-For VM distributions, you must specify `--vpcu` and `--memory` instead of `--instance-type`.
-:::

--- a/docs/reference/replicated-cli-cluster-create.md
+++ b/docs/reference/replicated-cli-cluster-create.md
@@ -35,7 +35,7 @@ replicated cluster create [flags]
   <tr>
     <td>--instance-type</td>
     <td>string</td>
-    <td>The type of instance to use for nodes in the cluster, such as x5.xlarge.</td>
+    <td>The type of instance to use for nodes in the cluster, such as x5.xlarge. For VM-based clusters, see <a href="/vendor/testing-replicated-instance-types">Replicated Instance Types</a>.</td>
   </tr>
   <tr>
     <td>--name</td>

--- a/docs/vendor/testing-replicated-instance-types.md
+++ b/docs/vendor/testing-replicated-instance-types.md
@@ -1,0 +1,37 @@
+# Replicated Instance Types
+
+When creating a VM-based cluster, you must specify a Replicated instance type.
+
+
+<table>
+  <tr>
+        <th width="30%">Type</th>
+        <th width="35%">Memory (GiB)</th>
+        <th width="35%">VCPU Count</th>
+  </tr>
+  <tr>
+    <th>r1.small</th>
+    <td>8 GB</td>
+    <td>2 VCPUs</td>
+  </tr>
+  <tr>
+    <th>r1.medium</th>
+    <td>16 GB</td>
+    <td>4 VCPUs</td>
+  </tr>
+  <tr>
+    <th>r1.large</th>
+    <td>32 GB</td>
+    <td>8 VCPUs</td>
+  </tr>
+  <tr>
+    <th>r1.xlarge</th>
+    <td>64 GB</td>
+    <td>16 VCPUs</td>
+  </tr>      
+  <tr>
+    <th>r1.2xlarge</th>
+    <td>128 GB</td>
+    <td>32 VCPUs</td>
+  </tr>  
+</table>

--- a/docs/vendor/testing-supported-clusters.md
+++ b/docs/vendor/testing-supported-clusters.md
@@ -28,6 +28,11 @@ The compatibility matrix supports creating single-node [kind](https://kind.sigs.
     <td>See <a href="testing-how-to#limitations">Limitations</a></td>
   </tr>
   <tr>
+    <th>Node and Supported Instance Types</th>
+    <td><ul><li>Specify a Replicated instance type for the nodes.
+</li></ul></td>
+  </tr>  
+  <tr>
     <th>Common Use Cases</th>
     <td>Smoke tests</td>
   </tr>
@@ -50,6 +55,11 @@ The compatibility matrix supports creating single-node [k3s](https://k3s.io) clu
     <th>Supported Kubernetes Versions</th>
     <td>1.24, 1.25, 1.26</td>
   </tr>
+  <tr>
+    <th>Node and Supported Instance Types</th>
+    <td><ul><li>Specify a Replicated instance type for the nodes.
+</li></ul></td>
+  </tr>  
   <tr>
     <th>Limitations</th>
     <td>You can only choose a minor version, not a patch version. The K3s installer chooses the latest patch for that minor version. See <a href="https://docs.k3s.io/upgrades/manual">k3s</a>.<br></br><br></br>For additional limitations, see <a href="testing-how-to#limitations">Limitations</a>.</td>
@@ -77,6 +87,40 @@ The compatibility matrix supports creating single-node [Red Hat OpenShift OKD](h
     <th>Limitations</th>
     <td>See <a href="testing-how-to#limitations">Limitations</a></td>
   </tr>
+  <tr>
+    <th>Node and Supported Instance Types</th>
+    <td><ul><li>Specify a Replicated instance type for the nodes.
+</li></ul></td>
+  </tr>  
+  <tr>
+    <th>Common Use Cases</th>
+    <td>Customer release tests</td>
+  </tr>
+</table>
+
+
+### Helm VM
+
+The compatibility matrix supports creating single-node [HelmVM](https://github.com/replicatedhq/helmbin) clusters, which is a version of Kubernetes that has a Helm chart embedded and runs as a single binary.
+
+<table>
+  <tr>
+        <th width="35%">Type</th>
+        <th width="65%">Description</th>
+  </tr>
+  <tr>
+    <th>Supported HelmVM Version</th>
+    <td>1.27</td>
+  </tr>
+  <tr>
+    <th>Limitations</th>
+    <td>See <a href="testing-how-to#limitations">Limitations</a></td>
+  </tr>
+  <tr>
+    <th>Node and Supported Instance Types</th>
+    <td><ul><li>Specify a Replicated instance type for the nodes.
+</li></ul></td>
+  </tr>  
   <tr>
     <th>Common Use Cases</th>
     <td>Customer release tests</td>

--- a/sidebars.js
+++ b/sidebars.js
@@ -582,6 +582,7 @@ const sidebars = {
       items: [
         'vendor/testing-about',
         'vendor/testing-supported-clusters',
+        'vendor/testing-replicated-instance-types',
         'vendor/testing-how-to',
       ],
     },


### PR DESCRIPTION
Moving VM based Compatibility Matrix instances from VCPUs and Memory to instance types.