### PR TITLE
pass previous tag as base to release notes generator

### DIFF
--- a/.github/workflows/replicated-sdk-release-notes.yml
+++ b/.github/workflows/replicated-sdk-release-notes.yml
@@ -6,8 +6,8 @@ on:
       version:
         description: Replicated SDK version
         required: true
-      base:
-        description: Previous SDK release tag
+      prev_version:
+        description: Previous Replicated SDK version
         required: true
 
 jobs:
@@ -20,11 +20,11 @@ jobs:
       id: release-notes
       env:
         REPLICATED_SDK_VERSION: ${{ github.event.client_payload.version }}
-        BASE_TAG: ${{ github.event.client_payload.base }}
+        PREV_REPLICATED_SDK_VERSION: ${{ github.event.client_payload.prev_version }}
       uses: replicatedhq/release-notes-generator@main
       with:
         owner-repo: replicatedhq/replicated-sdk
-        base: $BASE_TAG
+        base: $PREV_REPLICATED_SDK_VERSION
         head: v$REPLICATED_SDK_VERSION
         title: $REPLICATED_SDK_VERSION
         include-pr-links: false

--- a/.github/workflows/replicated-sdk-release-notes.yml
+++ b/.github/workflows/replicated-sdk-release-notes.yml
@@ -6,6 +6,9 @@ on:
       version:
         description: Replicated SDK version
         required: true
+      base:
+        description: Previous SDK release tag
+        required: true
 
 jobs:
   generate-release-notes-pr:
@@ -13,23 +16,15 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Get previous tag
-      id: get-previous-tag
-      run: |
-        git fetch -a
-        tags=($(git tag --sort="-committerdate"))
-        previous_tag=${tags[1]}
-        echo "::set-output name=previous_tag::$previous_tag"
-
     - name: Generate Release Notes
       id: release-notes
       env:
         REPLICATED_SDK_VERSION: ${{ github.event.client_payload.version }}
-        PREVIOUS_TAG: ${{ steps.get-previous-tag.outputs.previous_tag }}
+        BASE_TAG: ${{ github.event.client_payload.base }}
       uses: replicatedhq/release-notes-generator@main
       with:
         owner-repo: replicatedhq/replicated-sdk
-        base: $PREVIOUS_TAG
+        base: $BASE_TAG
         head: v$REPLICATED_SDK_VERSION
         title: $REPLICATED_SDK_VERSION
         include-pr-links: false

--- a/.github/workflows/replicated-sdk-release-notes.yml
+++ b/.github/workflows/replicated-sdk-release-notes.yml
@@ -24,7 +24,7 @@ jobs:
       uses: replicatedhq/release-notes-generator@main
       with:
         owner-repo: replicatedhq/replicated-sdk
-        base: $PREV_REPLICATED_SDK_VERSION
+        base: v$PREV_REPLICATED_SDK_VERSION
         head: v$REPLICATED_SDK_VERSION
         title: $REPLICATED_SDK_VERSION
         include-pr-links: false

--- a/.github/workflows/replicated-sdk-release-notes.yml
+++ b/.github/workflows/replicated-sdk-release-notes.yml
@@ -13,13 +13,23 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Get previous tag
+      id: get-previous-tag
+      run: |
+        git fetch -a
+        tags=($(git tag --sort="-committerdate"))
+        previous_tag=${tags[1]}
+        echo "::set-output name=previous_tag::$previous_tag"
+
     - name: Generate Release Notes
       id: release-notes
       env:
         REPLICATED_SDK_VERSION: ${{ github.event.client_payload.version }}
+        PREVIOUS_TAG: ${{ steps.get-previous-tag.outputs.previous_tag }}
       uses: replicatedhq/release-notes-generator@main
       with:
         owner-repo: replicatedhq/replicated-sdk
+        base: $PREVIOUS_TAG
         head: v$REPLICATED_SDK_VERSION
         title: $REPLICATED_SDK_VERSION
         include-pr-links: false


### PR DESCRIPTION
This PR modifies the release notes workflow for the replicated-sdk:
- passes the previous tag in the repo to the release notes generator to use as the base.