### PR TITLE
Add release note label for known issues

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -259,6 +259,18 @@ h3[id^="breaking-changes"] {
   font-size: 20px;
 }
 
+
+h3[id^="known-issues"] {
+  background-color: #414288;
+  /* background-color: #D64399; */
+  border-radius: 7px!important;
+  color: #fff;
+  width: max-content;
+  padding: 0.2em 0.6em 0.2em;
+  font-weight: 500;
+  font-size: 20px;
+}
+
 h3[id^="new-features"] a {
   color: #fff;
   opacity: .5;
@@ -278,6 +290,12 @@ h3[id^="bug-fixes"] a {
 }
 
 h3[id^="breaking-changes"] a {
+  color: #fff;
+  opacity: .5;
+  text-decoration: none;
+}
+
+h3[id^="known-issues"] a {
   color: #fff;
   opacity: .5;
   text-decoration: none;


### PR DESCRIPTION
![Screenshot 2023-08-04 at 9 14 07 AM](https://github.com/replicatedhq/replicated-docs/assets/11523028/44dcd32a-8cb5-41df-a2dd-04dc23cbf1fd)

I used this Coolers color palette generator using the three existing colors for the New Features, Improvements, and Bug Fixes labels.  https://coolors.co/palette/f47878-38c1ca-4bc99c-e65dad-414288

You can play around with palettes by "locking" the red, blue, and green color here, then pressing the space bar to get more suggestions for the other two colors: https://coolors.co/f47878-38c1ca-4bc99c-e65dad-414288

![Screenshot 2023-08-04 at 9 18 42 AM](https://github.com/replicatedhq/replicated-docs/assets/11523028/8ed1e695-022b-4f5c-a8e9-b224a1f75361)

Note: I had added a label for breaking changes in this PR https://github.com/replicatedhq/replicated-docs/pull/1344/files#diff-44813f307e729042af7e70beff6f32ea63a7941bc100043a49e84d229ea2570f
