### PR TITLE
fix: Add bug fix section to v2023-08-07 release

### DIFF
--- a/docs/release-notes/rn-kubernetes-installer.md
+++ b/docs/release-notes/rn-kubernetes-installer.md
@@ -14,6 +14,9 @@ Released on August 7, 2023
 
 ### New Features {#new-features-v2023-08-07-0}
 * Adds [Rook add-on](https://kurl.sh/docs/add-ons/rook) versions 1.12.0, 1.12.1
+
+
+### Bug Fixes {#bug-fixes-v2023-08-07-0}
 * Fixes an issue where storage could not be moved from Longhorn to OpenEBS at the same time as Kubernetes was upgraded to 1.25 or later.
 
 ## v2023.07.31-0


### PR DESCRIPTION
Move `Fixes an issue where storage could not be moved from Longhorn to OpenEBS at the same time as Kubernetes was upgraded to 1.25 or later` to Bug Fixes section.