### PR TITLE
80224: Clarify `when` and `select_one` config usage

### DIFF
--- a/docs/partials/config/_property-when.mdx
+++ b/docs/partials/config/_property-when.mdx
@@ -1,6 +1,6 @@
 The `when` property denotes conditional user inputs that are only displayed on the admin console Config page when a condition evaluates to true. The equality check in the conditional statement of the `when` property must match exactly, without quotes.
 
-The `when` property can be used on groups, items, and `select_one` options.
+The `when` property can be used as a group or item property. The `select_one` item type can be used as an option under the `when` property. However, `when` is not an item type, so it cannot be used as an option under `select_one`.
 
 When the `when` property for a group or item evaluates to `false`, the group or item is not displayed on the Config page.
 

--- a/docs/partials/config/_property-when.mdx
+++ b/docs/partials/config/_property-when.mdx
@@ -1,6 +1,6 @@
 The `when` property denotes conditional user inputs that are only displayed on the admin console Config page when a condition evaluates to true. The equality check in the conditional statement of the `when` property must match exactly, without quotes.
 
-The `when` property can be used as a group or item property. The `select_one` item type can be used as an option under the `when` property. However, `when` is not an item type, so it cannot be used as an option under `select_one`.
+The `when` property can be used as a group or item property. The `select_one` item type can be used as an option under the `when` property. However, `when` is not an item type, and so it cannot be used as an option under `select_one`.
 
 When the `when` property for a group or item evaluates to `false`, the group or item is not displayed on the Config page.
 


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/80224/replicated-docs-for-when-and-select-one-are-misleading

Preview: https://deploy-preview-1373--replicated-docs-upgrade.netlify.app/reference/custom-resource-config#when