### PR TITLE
Add info about custom status informer requirements

### DIFF
--- a/docs/partials/replicated-sdk/_overview.mdx
+++ b/docs/partials/replicated-sdk/_overview.mdx
@@ -1,7 +1,5 @@
-The Replicated SDK is a Helm chart that can be installed as a small service alongside your application Helm chart. The Replicated SDK allows you to install your application with Helm while having access to Replicated features such as:
+The Replicated SDK is a Helm chart that can be installed as a small service alongside your application Helm chart. The Replicated SDK provides an in-cluster API that you can use to embed Replicated features into your application such as:
 
-* Insights and telemetry for instances of your application running in customer environments 
-* Support for customer license entitlement checks before installation and at runtime 
-* Support for update checks to alert your customers when new versions of your application are available for upgrade
-
-To get started with the Replicated SDK, edit your application Helm chart to declare the SDK as a dependency, then promote a new release with your Helm chart to a development channel in the Replicated vendor portal.
+* Insights and operational telemetry for instances of your application running in customer environments, including support for collecting custom metrics. See [About Instance and Event Data](/vendor/instance-insights-event-data) and [Enabling and Understanding Application Status](insights-app-status).
+* Support for checking customer license entitlements at runtime, including signature verification. See [Checking Entitlements for Helm Installations (Beta)](/vendor/licenses-reference-helm) and [Verifying License Field Signatures for Helm Installations (Beta)](/vendor/licenses-verify-fields-sdk-api). 
+* Support for update checks to alert your customers when new versions of your application are available for upgrade. See [Support Update Checks in Your Admin Console](/reference/replicated-sdk-apis#support-update-checks-in-your-admin-console) in _Replicated SDK API (Beta)_.

--- a/docs/vendor/insights-app-status.md
+++ b/docs/vendor/insights-app-status.md
@@ -27,21 +27,26 @@ To enable status informers for your application, do one of the following, depend
 
 ### Helm Installations 
 
-For applications installed with Helm, the Replicated SDK automatically detects and reports the status of the resources that are part of the Helm release. For information, see [How to Distribute the SDK](replicated-sdk-overview#how-to-distribute-the-sdk) in _About the Replicated SDK_..
+To get instance status data for applications installed with Helm, include the Replicated SDK as a dependency of your application. For information about how to distribute the SDK with your application, see [About the Replicated SDK](replicated-sdk-overview).
 
-You can optionally configure custom status informers by overriding the `statusInformers` value in the Replicated SDK chart. For example:
+After you include the SDK as a dependency, the requirements for enabling status informers vary depending on how your Helm chart-based application is installed:
 
-```yaml
-# Helm chart values.yaml file 
+* For applications installed by running `helm install` or `helm upgrade`, the Replicated SDK automatically detects and reports the status of the resources that are part of the Helm release. No additional configuration is required to get instance status data.
 
-replicated-sdk:
-  statusInformers:
-    - deployment/nginx
-    - statefulset/mysql
-```
-:::note
-When the `replicated-sdk.statusInformers` field is set, the SDK detects and reports the status of only the resources included in the `replicated-sdk.statusInformers` field. 
-:::
+* For applications installed by running `helm template` then `kubectl apply`, the SDK cannot automatically detect and report the status of resources. You must configure custom status informers by overriding the `statusInformers` value in the Replicated SDK chart. For example:
+
+  ```yaml
+  # Helm chart values.yaml file 
+
+  replicated-sdk:
+    statusInformers:
+      - deployment/nginx
+      - statefulset/mysql
+  ```
+
+  :::note
+  Applications installed by running `helm install` or `helm upgrade` can also use custom status informers. When the `replicated-sdk.statusInformers` field is set, the SDK detects and reports the status of only the resources included in the `replicated-sdk.statusInformers` field.
+  :::
 
 ### KOTS Installations
 

--- a/docs/vendor/install-with-helm.md
+++ b/docs/vendor/install-with-helm.md
@@ -1,17 +1,15 @@
 # Installing with Helm
 
-This topic describes how to use Helm to install releases that contain one or more Helm charts.
+This topic describes how to use Helm to install releases that contain one or more Helm charts. For more information about the `helm install` command, including how to override values in a chart during installation, see [Helm Install](https://helm.sh/docs/helm/helm_install/) in the Helm documentation.
 
 ## Prerequisites
 
 Before you install, complete the following prerequisites:
 
-* You must have a customer in the Replicated vendor portal with a valid email address. This email address is only used as a username for the Replicated registry and is never contacted in any way. For more information about creating and editing customers in the vendor portal, see [Creating a Customer](/vendor/releases-creating-customer).
-* If you want to install the SDK with custom RBAC, create a custom Role, RoleBinding, and ServiceAccount then provide the name of the ServiceAccount during installation. For more information, see [Customizing RBAC for the SDK](replicated-sdk-rbac).
+* You must have a customer in the Replicated vendor portal with a valid email address. This email address is only used as a username for the Replicated registry and is never contacted. For more information about creating and editing customers in the vendor portal, see [Creating a Customer](/vendor/releases-creating-customer).
+* (Recommended) To install the Replicated SDK alongside the application, declare the SDK as a dependency. For more information, see [How to Distribute the SDK](replicated-sdk-overview#how-to-distribute-the-sdk) in _About the Replicated SDK (Beta)_.
 
 ## Install
-
-If you declared the Replicated SDK as a dependency of your Helm chart, then the SDK is installed alongside your application. For more information about the SDK, see [About the Replicated SDK (Beta)](replicated-sdk-overview). You can also install the SDK as a standalone component, rather than installing it alongside the application. For more information, see [Developing Against the SDK API](replicated-sdk-development).
 
 To install a Helm chart:
 
@@ -40,7 +38,11 @@ To install a Helm chart:
     Replace `RELEASE_NAME`, `APP_SLUG`, `CHANNEL_SLUG`, and `CHART_NAME`, with the values provided in the command in the **Helm install instructions** dialog.
 
     :::note
-    The channel slug is not required if the release is promoted to the Stable channel.
+    The channel slug is not required for releases promoted to the Stable channel.
+    :::
+
+    :::note
+    To install the SDK with custom RBAC permissions, include the `--set` flag to override the value of the `replicated-sdk.serviceAccountName` field with a custom service account. For more information, see [Customizing RBAC for the SDK](/vendor/replicated-sdk-rbac).
     :::
 
 1. (Optional) In the vendor portal, click **Customers**. You can see that the customer you used to install is marked as **Active** and the details about the application instance are listed under the customer name. 

--- a/docs/vendor/install-with-helm.md
+++ b/docs/vendor/install-with-helm.md
@@ -42,7 +42,7 @@ To install a Helm chart:
     :::
 
     :::note
-    To install the SDK with custom RBAC permissions, include the `--set` flag to override the value of the `replicated-sdk.serviceAccountName` field with a custom service account. For more information, see [Customizing RBAC for the SDK](/vendor/replicated-sdk-rbac).
+    To install the SDK with custom RBAC permissions, include the `--set` flag with the `helm install` command to override the value of the `replicated-sdk.serviceAccountName` field with a custom service account. For more information, see [Customizing RBAC for the SDK](/vendor/replicated-sdk-rbac).
     :::
 
 1. (Optional) In the vendor portal, click **Customers**. You can see that the customer you used to install is marked as **Active** and the details about the application instance are listed under the customer name. 

--- a/docs/vendor/replicated-sdk-overview.md
+++ b/docs/vendor/replicated-sdk-overview.md
@@ -17,13 +17,13 @@ For more information about the Replicated SDK API, see [Replicated SDK API (Beta
 
 The Replicated SDK has the following limitations:
 
-* **SDK-Enabled Helm Charts with KOTS**: When a Helm chart that includes the SDK as a dependency is installed with KOTS, instance data might be duplicated because both KOTS and the SDK are reporting data. To install a SDK-enabled Helm chart with KOTS, you must update both the chart and the HelmChart custom resource so that the SDK is excluded from KOTS installations. For more information, see [Using an SDK-Enabled Chart for KOTS Installations](helm-kots-using-sdk).
+* **SDK-Enabled Helm Charts with KOTS**: When a Helm chart that includes the SDK as a dependency is installed with KOTS, instance data might be duplicated because both KOTS and the SDK are reporting data. To install an SDK-enabled Helm chart with KOTS, you must update both the chart and the HelmChart custom resource so that the SDK is excluded from KOTS installations. For more information, see [Using an SDK-Enabled Chart for KOTS Installations](helm-kots-using-sdk).
 
-* **Installing with `helm template` and `kubectl apply`**: Some popular enterprise continuous delivery tools, such as ArgoCD and Pulumi, deploy Helm charts by running `helm template` then `kubectl apply` on the generated manifests, rather than running `helm install` or `helm upgrade`.  The following limitations apply if your Helm chart-based application is installed by running `helm template` then `kubectl apply`:
+* **Installing with `helm template` and `kubectl apply`**: Some popular enterprise continuous delivery tools, such as ArgoCD and Pulumi, deploy Helm charts by running `helm template` then `kubectl apply` on the generated manifests, rather than running `helm install` or `helm upgrade`.  The following limitations apply to applications installed by running `helm template` then `kubectl apply`:
 
-  * The `/api/v1/app/history` SDK API endpoint always returns an empty array because there is no Helm history in the cluster. See [Replicated SDK API (Beta)](/reference/replicated-sdk-apis).
+  * The `/api/v1/app/history` SDK API endpoint always returns an empty array because there is no Helm history in the cluster. See [GET /app/history](/reference/replicated-sdk-apis#get-apphistory) in _Replicated SDK API (Beta)_.
 
-  * The SDK does not automatically generate status informers to report instance status data. To get application status insights, you must enable custom status informers by overriding the `replicated-sdk.statusInformers` Helm value. See [Enable Application Status Insights](/vendor/insights-app-status#enable-application-status-insights) in _Enabling and Understanding Application Status_.
+  * The SDK does not automatically generate status informers to report status data for installed instances of the application. To get instance status data, you must enable custom status informers by overriding the `replicated-sdk.statusInformers` Helm value. See [Enable Application Status Insights](/vendor/insights-app-status#enable-application-status-insights) in _Enabling and Understanding Application Status_.
 
 
 ## How to Distribute the SDK

--- a/docs/vendor/replicated-sdk-overview.md
+++ b/docs/vendor/replicated-sdk-overview.md
@@ -11,6 +11,21 @@ This topic provides an introduction to using the Replicated SDK with your Helm c
 
 <SDKOverview/>
 
+For more information about the Replicated SDK API, see [Replicated SDK API (Beta)](/reference/replicated-sdk-apis). For information about developing against the SDK API locally, see [Developing Against the SDK API (Beta)](replicated-sdk-development).
+
+## Limitations
+
+The Replicated SDK has the following limitations:
+
+* **SDK-Enabled Helm Charts with KOTS**: When a Helm chart that includes the SDK as a dependency is installed with KOTS, instance data might be duplicated because both KOTS and the SDK are reporting data. To install a SDK-enabled Helm chart with KOTS, you must update both the chart and the HelmChart custom resource so that the SDK is excluded from KOTS installations. For more information, see [Using an SDK-Enabled Chart for KOTS Installations](helm-kots-using-sdk).
+
+* **Installing with `helm template` and `kubectl apply`**: Some popular enterprise continuous delivery tools, such as ArgoCD and Pulumi, deploy Helm charts by running `helm template` then `kubectl apply` on the generated manifests, rather than running `helm install` or `helm upgrade`.  The following limitations apply if your Helm chart-based application is installed by running `helm template` then `kubectl apply`:
+
+  * The `/api/v1/app/history` SDK API endpoint always returns an empty array because there is no Helm history in the cluster. See [Replicated SDK API (Beta)](/reference/replicated-sdk-apis).
+
+  * The SDK does not automatically generate status informers to report instance status data. To get application status insights, you must enable custom status informers by overriding the `replicated-sdk.statusInformers` Helm value. See [Enable Application Status Insights](/vendor/insights-app-status#enable-application-status-insights) in _Enabling and Understanding Application Status_.
+
+
 ## How to Distribute the SDK
 
 You can distribute the Replicated SDK with your application by declaring it as a dependency in your application Helm chart `Chart.yaml` file:
@@ -35,17 +50,11 @@ Finally, the SDK is initialized in the customer environment using values that th
 
 For more information about installing with Helm, see [Installing with Helm](install-with-helm).
 
-## SDK Resiliency
-
-At startup and when serving requests, the SDK retrieves and caches the latest information from the upstream Replicated APIs, including customer license information.
-
-If the upstream APIs are not available at startup, the SDK does not accept connections or serve requests until it is able to communicate with the upstream APIs. If communication fails, the SDK retries every 10 seconds and the SDK pod is at `0/1` ready.
-
-When serving requests, if the upstream APIs become unavailable, the SDK serves from the memory cache and sets the `X-Replicated-Served-From-Cache` header to `true`.
-
-## Replicated Helm Values {#replicated-values}
+### Replicated Helm Values {#replicated-values}
 
 When a customer installs your Helm chart from the Replicated registry, the Replicated registry injects values into the `global.replicated` field of the Helm chart values file. Additionally, when the Replicated SDK is installed alongside your application, the registry injects values into the `replicated-sdk` field. 
+
+The Replicated SDK uses the values in the `replicated-sdk` field to initialize in a customer environment and to send information about the instance back to the vendor portal, such as the Kubernetes version and distribution of the cluster and the cloud provider where the instance is running.
 
 The following is an example of a Helm values file containing both the `global.replicated` and `replicated-sdk` fields injected by the Replicated registry:
 
@@ -99,39 +108,10 @@ The values in the `replicated-sdk` field provide information about the following
 * The full customer license and the license ID
 * The target application release from the vendor portal
 
-The Replicated SDK uses the values in the `replicated-sdk` field to initialize in a customer environment.
+### SDK Resiliency
 
-## SDK API 
+At startup and when serving requests, the SDK retrieves and caches the latest information from the upstream Replicated APIs, including customer license information.
 
-The Replicated SDK provides an API that you can use to embed Replicated functionality into your application.
+If the upstream APIs are not available at startup, the SDK does not accept connections or serve requests until it is able to communicate with the upstream APIs. If communication fails, the SDK retries every 10 seconds and the SDK pod is at `0/1` ready.
 
-For example, if your application includes a UI where users manage their application instance, then you can use the `/api/v1/app/updates` endpoint to include messages in the UI that encourage users to upgrade when new versions are available. You could also revoke access to the application during runtime when a license expires using the `/api/v1/license/fields` endpoint.
-
-For more information about the Replicated SDK API endpoints, see [Replicated SDK API (Beta)](/reference/replicated-sdk-apis).
-
-## Customer Reporting and Instance Insights {#insights}
-
-The Replicated SDK provides access to operational telemetry including customer reporting and insights on application instances running in customer environments. When you distribute your application with the SDK, you can view these insights in the vendor portal.
-
-The SDK uses the values injected by the Replicated registry in your Helm chart values file to automatically send information about the instance back to the vendor portal, such as the Kubernetes version and distribution of the cluster and the cloud provider where the instance is running.
-
-Additionally, the SDK automatically detects and reports the status of the resources that are part of the Helm release. The vendor portal uses this resource status data to provide insights on the aggregate status of the application, such as if the instance is in a ready, degraded, or down state. You can customize which resources report their status back to the vendor portal by listing the resources in the `replicated-sdk.statusInformers` field of your Helm chart values file. For more information, see [Enabling and Understanding Application Status](insights-app-status).
-
-The following shows an example of the **Instance Details** page in the vendor portal, including application version and status details, instance uptime, and cluster details such as the cloud provider, cloud region, and the Kubernetes version and distribution:
-
-![instance details full page](/images/instance-details.png)
-[View a larger version of this image](/images/instance-details.png)
-
-For more information about viewing customer and instance insights in the vendor portal, see [Customer Reporting](customer-reporting) and [Instance Details](instance-insights-details).
-
-## Integration Mode
-
-You can run the Replicated SDK in integration mode to more quickly test new functionality for your application. Integration mode allows you to use mock data to test changes locally without having to create a release in the vendor portal and then install your Helm chart from the Replicated registry.
-
-For more information, see [Developing Against the SDK API (Beta)](replicated-sdk-development).
-
-## SDK-Enabled Helm Charts with KOTS
-
-Distributing your application as one or more Helm charts is recommended because you can use the same Helm charts to support installations with both Replicated KOTS and with the Helm CLI. However, when an SDK-enabled Helm chart is installed with KOTS, instance data in the vendor portal and related APIs can be duplicated as both KOTS and the SDK are reporting data.
-
-To install a Helm chart that includes the SDK with KOTS, you must update the chart and the HelmChart custom resource so that the SDK is excluded from KOTS installations. For more information, see [Using an SDK-Enabled Chart for KOTS Installations](helm-kots-using-sdk).
+When serving requests, if the upstream APIs become unavailable, the SDK serves from the memory cache and sets the `X-Replicated-Served-From-Cache` header to `true`.


### PR DESCRIPTION
New Limitations section in About the Replicated SDK topic: https://deploy-preview-1419--replicated-docs.netlify.app/vendor/replicated-sdk-overview#limitations

Updated the "Enabling and Understanding Application Status" topic to explain the different requirements depending on Helm install method: https://deploy-preview-1419--replicated-docs.netlify.app/vendor/insights-app-status#helm-installations

I also made a handful of semi-related editorial updates that are explained further in the comments 🙂 
