### PR TITLE
reorganize and add details to node-agent memory limit section

### DIFF
--- a/docs/enterprise/snapshots-troubleshooting-backup-restore.md
+++ b/docs/enterprise/snapshots-troubleshooting-backup-restore.md
@@ -149,19 +149,21 @@ kubectl -n velero set env daemonset/restic GOGC=1
 
 #### Symptom
 
-Example error message:
+In the Replicated admin console, you see an **Application failed to restore** error message that indicates the port number for a static NodePort is already in use. For example:
 
 ![Snapshot Troubleshoot Service NodePort](/images/snapshot-troubleshoot-service-nodeport.png)
 
+[View a larger version of this image](/images/snapshot-troubleshoot-service-nodeport.png)
+
 #### Cause
 
-There is a known issue in older Kubernetes versions (earlier than v1.19) where using a static NodePort for services can collide in multi-primary high availability setup when recreating the services. You can find more details about the issue here: https://github.com/kubernetes/kubernetes/issues/85894.
+There is a known issue in Kubernetes versions earlier than version 1.19 where using a static NodePort for services can collide in multi-primary high availability setups when recreating the services. For more information about this known issue, see https://github.com/kubernetes/kubernetes/issues/85894.
 
 #### Solution
 
-This issue has been fixed in Kubernetes version 1.19. You can find more details about the fix here: https://github.com/kubernetes/kubernetes/pull/89937.
+This issue is fixed in Kubernetes version 1.19. To resolve this issue, upgrade to Kubernetes version 1.19 or later.
 
-Upgrading to Kubernetes version v1.19 or later should resolve the issue.
+For more infromation about the fix, see https://github.com/kubernetes/kubernetes/pull/89937.
 
 ### Partial Snapshot Restore is Stuck in Progress
 

--- a/docs/enterprise/snapshots-troubleshooting-backup-restore.md
+++ b/docs/enterprise/snapshots-troubleshooting-backup-restore.md
@@ -56,6 +56,93 @@ When configuring Velero to use a bucket, the bucket cannot contain other data, o
 
 Configure Velero to use a bucket that does not contain other data.
 
+## Snapshot Creation is Failing
+
+### Timeout Error when Creating a Snapshot
+
+#### Symptom
+
+You see a backup error that includes a timeout message when attempting to create a snapshot. For example:
+
+```bash
+Error backing up item
+timed out after 12h0m0s
+```
+
+#### Cause
+
+This error message appears when the node-agent (restic) Pod operation timeout limit is reached. In Velero v1.4.2 and later, the default timeout is 240 minutes.
+
+Restic is an open-source backup tool. Velero integrates with Restic to provide a solution for backing up and restoring Kubernetes volumes. For more information about the Velero Restic integration, see [File System Backup](https://velero.io/docs/v1.10/file-system-backup/) in the Velero documentation.
+
+#### Solution
+
+Use the kubectl Kubernetes command-line tool to patch the Velero deployment to increase the timeout:
+
+**Velero version 1.10 and later**:
+
+```bash
+kubectl patch deployment velero -n velero --type json -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--fs-backup-timeout=TIMEOUT_LIMIT"}]'
+```
+
+**Velero versions less than 1.10**:
+
+```bash
+kubectl patch deployment velero -n velero --type json -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--restic-timeout=TIMEOUT_LIMIT"}]'
+```
+
+Replace `TIMEOUT_LIMIT` with a length of time for the node-agent (restic) Pod operation timeout in hours, minutes, and seconds. Use the format `0h0m0s`. For example, `48h30m0s`.
+
+:::note
+The timeout value reverts back to the default value if you rerun the `velero install` command.
+:::
+
+### Memory Limit Reached on the node-agent Pod
+
+#### Symptom
+
+The node-agent (restic) Pod is killed by the Linux kernel Out Of Memory (OOM) killer or snapshots are failing with errors simlar to:
+
+```
+pod volume backup failed: ... signal: killed
+```
+
+#### Cause
+
+Velero sets default limits for the velero Pod and the node-agent (restic) Pod during installation. There is a known issue with Restic that causes high memory usage, which can result in failures during snapshot creation when the Pod reaches the memory limit.
+
+For more information, see the [Restic backup — OOM-killed on raspberry pi after backing up another computer to same repo](https://github.com/restic/restic/issues/1988) issue in the restic GitHub repository.
+
+#### Solution
+
+Increase the default memory limit for the node-agent (restic) Pod if your application is particularly large. For more information about configuring Velero resource requests and limits, see [Customize resource requests and limits](https://velero.io/docs/v1.10/customize-installation/#customize-resource-requests-and-limits) in the Velero documentation. For example, the following kubectl commands will increase the memory limit for the node-agent (restic) daemon set from the default of 1Gi to 2Gi.
+
+**Velero  1.10 and later**:
+
+```
+kubectl -n velero patch daemonset node-agent -p '{"spec":{"template":{"spec":{"containers":[{"name":"node-agent","resources":{"limits":{"memory":"2Gi"}}}]}}}}'
+```
+
+**Velero versions earlier than 1.10**:
+
+```
+kubectl -n velero patch daemonset restic -p '{"spec":{"template":{"spec":{"containers":[{"name":"restic","resources":{"limits":{"memory":"2Gi"}}}]}}}}'
+```
+
+Alternatively, you can potentially avoid the node-agent (restic) Pod reaching the memory limit during snapshot creation by running the following kubectl command to lower the memory garbage collection target percentage on the node-agent (restic) daemon set:
+
+**Velero  1.10 and later**:
+
+```
+kubectl -n velero set env daemonset/node-agent GOGC=1
+```
+
+**Velero versions earlier than 1.10**:
+
+```
+kubectl -n velero set env daemonset/restic GOGC=1
+```
+
 ## Snapshot Restore is Failing
 
 ### Service NodePort is Already Allocated
@@ -115,74 +202,3 @@ The resource restore priority was changed in Velero 1.10.3 and 1.11.0, which lea
 #### Solution
 
 These warnings do not necessarily mean that the restore itself failed. The endpoints likely do exist as they are created by Kubernetes when the related Service resources were restored. However, to prevent encountering these warnings, use Velero version 1.10.2 or earlier.
-
-## Snapshot Creation is Failing
-
-### Timeout Error when Creating a Snapshot
-
-#### Symptom
-
-You see a backup error that includes a timeout message when attempting to create a snapshot. For example:
-
-```bash
-Error backing up item
-timed out after 12h0m0s
-```
-
-#### Cause
-
-This error message appears when the node-agent (restic) Pod operation timeout limit is reached. In Velero v1.4.2 and later, the default timeout is 240 minutes.
-
-Restic is an open-source backup tool. Velero integrates with Restic to provide a solution for backing up and restoring Kubernetes volumes. For more information about the Velero Restic integration, see [File System Backup](https://velero.io/docs/v1.10/file-system-backup/) in the Velero documentation.
-
-#### Solution
-
-Use the kubectl Kubernetes command-line tool to patch the Velero deployment to increase the timeout:
-
-**Velero version 1.10 and later**:
-
-```bash
-kubectl patch deployment velero -n velero --type json -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--fs-backup-timeout=TIMEOUT_LIMIT"}]'
-```
-
-**Velero versions less than 1.10**:
-
-```bash
-kubectl patch deployment velero -n velero --type json -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--restic-timeout=TIMEOUT_LIMIT"}]'
-```
-
-Replace `TIMEOUT_LIMIT` with a length of time for the node-agent (restic) Pod operation timeout in hours, minutes, and seconds. Use the format `0h0m0s`. For example, `48h30m0s`.
-
-:::note
-The timeout value reverts back to the default value if you rerun the `velero install` command.
-:::
-
-### Memory Limit Reached on the node-agent Pod
-
-#### Symptom
-
-The node-agent (restic) Pod is killed by the Linux kernel Out Of Memory (OOM) killer.
-
-#### Cause
-
-Velero sets default limits for the velero Pod and the node-agent (restic) Pod during installation. There is a known issue with Restic that causes high memory usage, which can result in failures during snapshot creation when the Pod reaches the memory limit.
-
-For more information, see the [Restic backup — OOM-killed on raspberry pi after backing up another computer to same repo](https://github.com/restic/restic/issues/1988) issue in the restic GitHub repository.
-
-#### Solution
-
-Increase the default memory limit for the node-agent (restic) Pod if your application is particularly large. For more information about configuring Velero resource requests and limits, see [Customize resource requests and limits](https://velero.io/docs/v1.10/customize-installation/#customize-resource-requests-and-limits) in the Velero documentation.
-
-Alternatively, you can potentially avoid the node-agent (restic) Pod reaching the memory limit during snapshot creation by running the following kubectl command to lower the memory garbage collection target percentage on the node-agent (restic) daemon set:
-
-**Velero  1.10 and later**:
-
-```
-kubectl -n velero set env daemonset (node-agent) GOGC=1
-```
-
-**Velero versions earlier than 1.10**:
-
-```
-kubectl -n velero set env daemonset/restic GOGC=1
-```


### PR DESCRIPTION
This PR is a result of some recent support escalations where snapshots failed because of the node-agent memory limit.  This is documented as a known issue here, but the goal is to make it more discoverable and add some additional details to that users can more easily identify this as the issue.

Changes:
* Moved the "Snapshot Creation is Failing" section ahead of the "Snapshot Restore is Failing" section
* Added an example of what an error might look like when a backup fails due to this memory limit being hit
* Added example commands to patch the node-agent (restic) daemonset memory limit