### PR TITLE
Bring CRs up one level in KOTS sidebar

### DIFF
--- a/docs/enterprise/snapshots-creating.md
+++ b/docs/enterprise/snapshots-creating.md
@@ -90,7 +90,7 @@ To schedule automatic backups in the admin console:
 1. Configure the automatic backup schedule for the type of snapshots that you selected:
 
    * For **Schedule**, select Hourly, Daily, Weekly, or Custom.
-   * For **Cron Expression**, enter a cron expression to create a custom automatic backup schedule. For information about supported cron expressions, see [Cron Expressions](/reference/cron-expressions) in _Reference_.
+   * For **Cron Expression**, enter a cron expression to create a custom automatic backup schedule. For information about supported cron expressions, see [Cron Expressions](/reference/cron-expressions).
 
 1. (Optional) For **Retention Policy**, edit the amount of time that backup data is saved. By default, backup data is saved for 30 days.
 

--- a/docs/partials/linter-rules/_linter-definition.mdx
+++ b/docs/partials/linter-rules/_linter-definition.mdx
@@ -1,1 +1,1 @@
-The linter checks the manifest files for applications packaged with Replicated to ensure that there are no YAML syntax errors, that all required manifest files are present in the release, and more.
+The linter checks the manifest files in Replicated KOTS releases to ensure that there are no YAML syntax errors, that all required manifest files are present in the release to support installation with KOTS, and more.

--- a/docs/reference/cron-expressions.md
+++ b/docs/reference/cron-expressions.md
@@ -1,6 +1,6 @@
-# Cron Expressions for Scheduling Updates
+# Cron Expressions
 
-This topic describes the supported cron expressions that are used to schedule checking for application updates in the Replicated admin console.
+This topic describes the supported cron expressions that youc an use to schedule automatic application update checks and automatic backups in the Replicated admin console. For more information, see [Configure Automatic Updates](/enterprise/updating-apps#configure-automatic-updates) in _Updating an Application_ and [Schedule Automatic Backups](/enterprise/snapshots-creating#schedule-automatic-backups) in _Creating and Scheduling Backups_.
 
 ## Syntax
 

--- a/docs/reference/cron-expressions.md
+++ b/docs/reference/cron-expressions.md
@@ -1,4 +1,4 @@
-# Cron Expressions
+# Cron Expressions for Scheduling Updates
 
 This topic describes the supported cron expressions that are used to schedule checking for application updates in the Replicated admin console.
 

--- a/docs/reference/custom-resource-about.md
+++ b/docs/reference/custom-resource-about.md
@@ -11,7 +11,7 @@ The custom resources defined here are included to control the application experi
 | troubleshoot.replicated.com/v1beta2 | [Preflight](custom-resource-preflight) | Defines custom preflight checks for an application version. |
 | troubleshoot.sh/v1beta2 | [Support Bundle](custom-resource-preflight) | Defines the custom diagnostic data to collect and analyze in a support bundle. |
 | troubleshoot.replicated.com/v1beta2 | [Redactor](https://troubleshoot.sh/reference/redactors/overview/) | Defines custom redactors that apply to support bundle contents. Only configurable using the admin console. |
-| app.k8s.io/v1beta1 | [SIG Application](custom-resource-sig-application) | Defines metadata about the application. |
+| app.k8s.io/v1beta1 | [SIG Application](https://github.com/kubernetes-sigs/application#kubernetes-applications) | Defines metadata about the application. |
 | kots.io/v1beta2 | [HelmChart](custom-resource-helmchart-v2) | Identifies an instantiation of a Helm Chart. |
 | kots.io/v1beta1 (Deprecated) | [HelmChart](custom-resource-helmchart) | Identifies an instantiation of a Helm Chart. |
 | velero.io/v1 | [Backup](https://velero.io/docs/v1.10/api-types/backup/) | A Velero backup request, triggered when the user initiates a [snapshot](/vendor/snapshots-overview). |

--- a/docs/reference/custom-resource-backup.md
+++ b/docs/reference/custom-resource-backup.md
@@ -1,4 +1,4 @@
-# Backup
+# Velero Backup Custom Resource
 
 The Backup custom resource enables the Replicated snapshots backup and restore feature. The backend of this feature uses the Velero open source project to back up Kubernetes manifests and persistent volumes.
 

--- a/docs/reference/custom-resource-preflight.md
+++ b/docs/reference/custom-resource-preflight.md
@@ -1,4 +1,4 @@
-# Preflight and Support Bundle Custom Resources
+# Preflight and Support Bundle
 
 You can define preflight checks and support bundle specifications for Replicated KOTS and Helm installations. 
 

--- a/docs/reference/custom-resource-preflight.md
+++ b/docs/reference/custom-resource-preflight.md
@@ -1,4 +1,4 @@
-# Preflight and Support Bundle
+# Preflight and Support Bundle Custom Resources
 
 You can define preflight checks and support bundle specifications for Replicated KOTS and Helm installations. 
 

--- a/docs/reference/custom-resource-redactor.md
+++ b/docs/reference/custom-resource-redactor.md
@@ -1,4 +1,4 @@
-# Redactor Custom Resource (KOTS-Only)
+# Redactor (KOTS-Only)
 
 Preflight checks and support bundles include built-in redactors that hide sensitive customer data before it is analyzed. These default redactors hide passwords, tokens, AWS secrets, database connection strings, and URLs that contain usernames and passwords.
 

--- a/docs/reference/custom-resource-redactor.md
+++ b/docs/reference/custom-resource-redactor.md
@@ -1,4 +1,4 @@
-# Redactor (KOTS)
+# Redactor Custom Resource (KOTS-Only)
 
 Preflight checks and support bundles include built-in redactors that hide sensitive customer data before it is analyzed. These default redactors hide passwords, tokens, AWS secrets, database connection strings, and URLs that contain usernames and passwords.
 

--- a/docs/reference/custom-resource-sig-application.md
+++ b/docs/reference/custom-resource-sig-application.md
@@ -1,7 +1,0 @@
-# SIG Application
-
-The Kubernetes SIG Application custom resource provides a standard API for creating, viewing, and managing applications. For more information, see [Kubernetes Applications](https://github.com/kubernetes-sigs/application#kubernetes-applications) in the `kubernetes-sigs/application` Github repository.
-
-The `spec.descriptor.links` field can be used to configure buttons on the Replicated admin console that link to application dashboards or landing pages. For more information see, [Adding Buttons and Links](/vendor/admin-console-adding-buttons-links).
-
-This custom resource is optional.

--- a/docs/reference/linter.mdx
+++ b/docs/reference/linter.mdx
@@ -41,20 +41,20 @@ import LinterDefinition from "../partials/linter-rules/_linter-definition.mdx"
 
 # Linter Rules
 
-This topic describes the linter and the rules for the linter.
+This topic describes the release linter and the linter rules.
 
-## Using the Linter
+## Overview
 
 <LinterDefinition/>
 
-The linter runs automatically against releases that you create in the Replicated vendor portal, and displays any error or warning messages in the vendor portal UI.
+The linter runs automatically against KOTS releases that you create in the Replicated vendor portal, and displays any error or warning messages in the vendor portal UI.
 
-To lint your application manifest files, you can run the replicated CLI `replicated release lint` command against the root directory of your application manifest files. You can also use the `--lint` flag when you create a release with the `replicated release create` command. For more information, see [release lint](/reference/replicated-cli-release-lint) and [release create](/reference/replicated-cli-release-create) in the _replicated CLI_ section.
-
-You can customize the default rule levels in the Replicated LinterConfig custom resource.
-For more information, see [LintConfig](custom-resource-lintconfig).
+To lint manifest files from the command line, you can run the replicated CLI `replicated release lint` command against the root directory of your application manifest files. You can also use the `--lint` flag when you create a release with the `replicated release create` command. For more information, see [release lint](/reference/replicated-cli-release-lint) and [release create](/reference/replicated-cli-release-create) in the _replicated CLI_ section.
 
 ## Linter Rules
+
+This section lists the linter rules and the default rule levels (Info, Warn, Error). You can customize the default rule levels in the Replicated LinterConfig custom resource.
+For more information, see [LintConfig](custom-resource-lintconfig).
 
 ### allow-privilege-escalation
 

--- a/docs/vendor/admin-console-adding-buttons-links.md
+++ b/docs/vendor/admin-console-adding-buttons-links.md
@@ -1,5 +1,9 @@
 # Adding Buttons and Links
 
+This topic describes how to use the Kubernetes and KOTS Application custom resources to add buttons and links to the Replicated admin console dashboard.
+
+## Overview
+
 When distributing an application, it’s helpful to make sure that the person or process performing the installation can easily verify that the application is running.
 Networking and ingress is handled differently in each cluster and this makes it difficult to provide a consistent URL at application packaging time, and even likely requires that the cluster operator creates firewall rules before they can test the application installation.
 
@@ -7,24 +11,23 @@ Replicated KOTS can provide a port-forward tunnel that will work more consistent
 
 To export a port and a button on the Replicated admin console dashboard to the application, a couple of additional steps are necessary.
 
-## Add a button to the dashboard
+## Add A Button to the Dashboard
 
-It’s recommended that every application include an application custom resource as defined by [Kubernetes SIG Apps](https://github.com/kubernetes-sigs/application).
+Replicated recommends that every application include a Kubernetes SIG Application custom resource. The Kubernetes SIG Application custom resource provides a standard API for creating, viewing, and managing applications. For more information, see [Kubernetes Applications](https://github.com/kubernetes-sigs/application#kubernetes-applications) in the `kubernetes-sigs/application` Github repository.
+
 KOTS uses this as metadata and will not require or use an in-cluster controller to handle this custom resource.
 An application that follows best practices will never require cluster admin privileges or any cluster-wide components to be installed.
 
-The Application custom resource includes many fields, but the one that we are going to examine in this document is the links:
+The Kubernetes Application custom resource `spec.descriptor.links` field is an array of links that reference the application, after the application is deployed. The `spec.descriptor.links` field can be used to configure buttons on the Replicated admin console that link to application dashboards or landing pages.
 
-The `spec.descriptor.links` field is an array of links that reference the application, once it’s deployed.
-
-Each link contains two fields, description and url.
+Each link contains two fields, description and url. 
 
 The description field is the title of the button that will be added to the admin console.
 The url field should be the url of your application.
 
 You can use the service name in place of the host name and KOTS will rewrite the URL with hostname in the browser.
 
-#### Example
+For example:
 
 ```yaml
 apiVersion: app.k8s.io/v1beta1
@@ -44,7 +47,7 @@ spec:
         url: https://my-application-url
 ```
 
-## Additional ports and port forwarding
+## Additional Ports and Port Forwarding
 
 When running the `kubectl` plugin for the kots CLI, KOTS can add additional ports that are defined in the application to the port-forward tunnel.
 This is useful for internal services such as application admin controls and other services that should not be exposed to all users.

--- a/docs/vendor/releases-creating-cli.mdx
+++ b/docs/vendor/releases-creating-cli.mdx
@@ -77,7 +77,7 @@ To create and promote a new release:
 
         Replace `PATH_TO_APP_DIR` with path to the local directory with your application files.
 
-        For more information about linting, see [release lint](/reference/replicated-cli-release-lint) and [Linter Rules](/reference/linter) in _Reference_.
+        For more information about linting, see [release lint](/reference/replicated-cli-release-lint) and [Linter Rules](/reference/linter).
 
       1. Create a new release:
 

--- a/docs/vendor/releases-creating-customer.md
+++ b/docs/vendor/releases-creating-customer.md
@@ -61,7 +61,7 @@ To create a customer:
         </tr>
         <tr>
           <td>Allow Snapshot</td>
-          <td>Enables customers to create snapshots for backup and restore. Vendors must also add a Backup custom resource. See <a href="/reference/custom-resource-backup">Backup</a>.</td>
+          <td>Enables customers to create snapshots for backup and restore. Vendors must also add a Backup custom resource. See <a href="/reference/custom-resource-backup">Velero Backup Custom Resource</a>.</td>
         </tr>
       </table>
 

--- a/docs/vendor/snapshots-configuring-backups.md
+++ b/docs/vendor/snapshots-configuring-backups.md
@@ -10,7 +10,7 @@ To configure backups:
 
 1. Enable backups:
 
-    1. Add a Backup resource (`kind: Backup`) using `apiVersion: velero.io/v1` to the application manifest files. The following minimal YAML example enables backups in the application. For more information about Backup resource options, see [Backup](/reference/custom-resource-backup) in _Reference_.
+    1. Add a Backup resource (`kind: Backup`) using `apiVersion: velero.io/v1` to the application manifest files. The following minimal YAML example enables backups in the application. For more information about Backup resource options, see [Velero Backup Custom Resource](/reference/custom-resource-backup).
 
         **Example:**
 

--- a/docs/vendor/tutorial-ui-create-release.md
+++ b/docs/vendor/tutorial-ui-create-release.md
@@ -109,7 +109,7 @@ To create a release:
                 message: This cluster has enough nodes.
   ```
 
-  Preflight checks are designed to help ensure that the environment meets the minimum system and software requirements to run the application. Software vendors define preflight checks in the Preflight custom resource. For more information, see [Preflight and Support Bundle](/reference/custom-resource-preflight) in _Reference_.
+  Preflight checks are designed to help ensure that the environment meets the minimum system and software requirements to run the application. Software vendors define preflight checks in the Preflight custom resource. For more information, see [Preflight and Support Bundle](/reference/custom-resource-preflight).
 
 1. Check the linter messages in the **Help** pane. If there are no errors, a message displays letting you know that everything looks good. If there are errors, information about the errors displays with a link to the reference documentation. For more information about the linter, see [Linter Rules](/reference/linter).
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -187,6 +187,10 @@
   from="https://docs.replicated.com/reference/replicated-cli-tokens"
   to="https://docs.replicated.com/vendor/replicated-api-tokens"
 
+[[redirects]]
+  from="https://docs.replicated.com/reference/custom-resource-sig-application"
+  to="https://docs.replicated.com/vendor/admin-console-adding-buttons-links"  
+
 ###################################################
 # Redirects To the Release Notes Section
 ###################################################

--- a/sidebars.js
+++ b/sidebars.js
@@ -199,7 +199,6 @@ const sidebars = {
             'enterprise/updating-embedded-cluster',
             'enterprise/updating-licenses',
             'enterprise/updating-tls-cert',
-            'reference/cron-expressions',
           ],
         },
         {
@@ -260,110 +259,116 @@ const sidebars = {
         },
     {
       type: 'category',
-      label: 'kots CLI',
-      items: [
-        'reference/kots-cli-getting-started',
-        'reference/kots-cli-global-flags',
-        {
-            type: 'category',
-            label: 'admin console',
-            items: [
-              'reference/kots-cli-admin-console-index',
-              'reference/kots-cli-admin-console-garbage-collect-images',
-              'reference/kots-cli-admin-console-generate-manifests',
-              'reference/kots-cli-admin-console-push-images',
-              'reference/kots-cli-admin-console-upgrade',
-          ],
-        },
+      label: 'Reference',
+      items: [   
         {
           type: 'category',
-          label: 'backup',
+          label: 'kots CLI',
           items: [
-            'reference/kots-cli-backup-index',
-            'reference/kots-cli-backup-ls',
+            'reference/kots-cli-getting-started',
+            'reference/kots-cli-global-flags',
+            {
+                type: 'category',
+                label: 'admin console',
+                items: [
+                  'reference/kots-cli-admin-console-index',
+                  'reference/kots-cli-admin-console-garbage-collect-images',
+                  'reference/kots-cli-admin-console-generate-manifests',
+                  'reference/kots-cli-admin-console-push-images',
+                  'reference/kots-cli-admin-console-upgrade',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'backup',
+              items: [
+                'reference/kots-cli-backup-index',
+                'reference/kots-cli-backup-ls',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'docker',
+              items: [
+                'reference/kots-cli-docker-index',
+                'reference/kots-cli-docker-ensure-secret',
+              ],
+            },
+            'reference/kots-cli-download',
+            'reference/kots-cli-enable-ha',
+            {
+              type: 'category',
+              label: 'get',
+              items: [
+                'reference/kots-cli-get-index',
+                'reference/kots-cli-get-apps',
+                'reference/kots-cli-get-backups',
+                'reference/kots-cli-get-config',
+                'reference/kots-cli-get-restores',
+                'reference/kots-cli-get-versions',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'identity-service',
+              items: [
+                'reference/kots-cli-identity-service-index',
+                'reference/kots-cli-identity-service-enable-shared-password',
+              ],
+            },
+            'reference/kots-cli-install',
+            'reference/kots-cli-pull',
+            'reference/kots-cli-remove',
+            'reference/kots-cli-reset-password',
+            'reference/kots-cli-reset-tls',
+            {
+              type: 'category',
+              label: 'restore',
+              items: [
+                'reference/kots-cli-restore-index',
+                'reference/kots-cli-restore-ls',
+              ],
+            },
+            {
+                type: 'category',
+                label: 'set',
+                items: [
+                  'reference/kots-cli-set-index',
+                  'reference/kots-cli-set-config',
+              ],
+            },
+            'reference/kots-cli-upload',
+            {
+                type: 'category',
+                label: 'upstream',
+                items: [
+                  'reference/kots-cli-upstream',
+                  'reference/kots-cli-upstream-download',
+                  'reference/kots-cli-upstream-upgrade',
+              ],
+            },
+            {
+                type: 'category',
+                label: 'velero',
+                items: [
+                  
+                  'reference/kots-cli-velero-configure-aws-s3',
+                  'reference/kots-cli-velero-configure-azure',
+                  'reference/kots-cli-velero-configure-gcp',
+                  'reference/kots-cli-velero-configure-hostpath',
+                  'reference/kots-cli-velero-configure-internal',
+                  'reference/kots-cli-velero-configure-nfs',
+                  'reference/kots-cli-velero-configure-other-s3',
+                  'reference/kots-cli-velero-ensure-permissions',
+                  'reference/kots-cli-velero-index',
+                  'reference/kots-cli-velero-print-fs-instructions',
+              ],
+            },
           ],
-        },
-        {
-          type: 'category',
-          label: 'docker',
-          items: [
-            'reference/kots-cli-docker-index',
-            'reference/kots-cli-docker-ensure-secret',
-          ],
-        },
-        'reference/kots-cli-download',
-        'reference/kots-cli-enable-ha',
-        {
-          type: 'category',
-          label: 'get',
-          items: [
-            'reference/kots-cli-get-index',
-            'reference/kots-cli-get-apps',
-            'reference/kots-cli-get-backups',
-            'reference/kots-cli-get-config',
-            'reference/kots-cli-get-restores',
-            'reference/kots-cli-get-versions',
-          ],
-        },
-        {
-          type: 'category',
-          label: 'identity-service',
-          items: [
-            'reference/kots-cli-identity-service-index',
-            'reference/kots-cli-identity-service-enable-shared-password',
-          ],
-        },
-        'reference/kots-cli-install',
-        'reference/kots-cli-pull',
-        'reference/kots-cli-remove',
-        'reference/kots-cli-reset-password',
-        'reference/kots-cli-reset-tls',
-        {
-          type: 'category',
-          label: 'restore',
-          items: [
-            'reference/kots-cli-restore-index',
-            'reference/kots-cli-restore-ls',
-          ],
-        },
-        {
-            type: 'category',
-            label: 'set',
-            items: [
-              'reference/kots-cli-set-index',
-              'reference/kots-cli-set-config',
-          ],
-        },
-        'reference/kots-cli-upload',
-        {
-            type: 'category',
-            label: 'upstream',
-            items: [
-              'reference/kots-cli-upstream',
-              'reference/kots-cli-upstream-download',
-              'reference/kots-cli-upstream-upgrade',
-          ],
-        },
-        {
-            type: 'category',
-            label: 'velero',
-            items: [
-              
-              'reference/kots-cli-velero-configure-aws-s3',
-              'reference/kots-cli-velero-configure-azure',
-              'reference/kots-cli-velero-configure-gcp',
-              'reference/kots-cli-velero-configure-hostpath',
-              'reference/kots-cli-velero-configure-internal',
-              'reference/kots-cli-velero-configure-nfs',
-              'reference/kots-cli-velero-configure-other-s3',
-              'reference/kots-cli-velero-ensure-permissions',
-              'reference/kots-cli-velero-index',
-              'reference/kots-cli-velero-print-fs-instructions',
-          ],
-        },
+        }, 
+        'reference/cron-expressions',
       ],
-    }, 
-
+    },  
   ],
   // MAIN SIDEBAR
   main: [

--- a/sidebars.js
+++ b/sidebars.js
@@ -79,6 +79,7 @@ const sidebars = {
         'vendor/snapshots-overview',
         'vendor/snapshots-configuring-backups',
         'vendor/snapshots-hooks',
+        'reference/custom-resource-backup',
       ],
     },
     {
@@ -125,37 +126,26 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Reference',
+      label: 'Custom Resources',
       items: [
-        'reference/cron-expressions',
-        {
-          type: 'category',
-          label: 'Custom Resources',
-          items: [
-            'reference/custom-resource-about',
-            'reference/custom-resource-application',
-            'reference/custom-resource-backup',
-            'reference/custom-resource-config',
-            'reference/custom-resource-helmchart-v2',
-            'reference/custom-resource-helmchart',
-            'reference/custom-resource-lintconfig',
-            'reference/custom-resource-sig-application',  
-          ],
-        },
-        'reference/linter',
-        {
-          type: 'category',
-          label: 'Template Functions',
-          items: [
-            'reference/template-functions-about',
-            'reference/template-functions-config-context',
-            'reference/template-functions-identity-context',
-            'reference/template-functions-kurl-context',
-            'reference/template-functions-license-context',
-            'reference/template-functions-static-context',
-          ],
-        },
-        
+        'reference/custom-resource-about',
+        'reference/custom-resource-application',
+        'reference/custom-resource-config',
+        'reference/custom-resource-helmchart-v2',
+        'reference/custom-resource-helmchart',
+        'reference/custom-resource-lintconfig',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Template Functions',
+      items: [
+        'reference/template-functions-about',
+        'reference/template-functions-config-context',
+        'reference/template-functions-identity-context',
+        'reference/template-functions-kurl-context',
+        'reference/template-functions-license-context',
+        'reference/template-functions-static-context',
       ],
     },
     
@@ -209,6 +199,7 @@ const sidebars = {
             'enterprise/updating-embedded-cluster',
             'enterprise/updating-licenses',
             'enterprise/updating-tls-cert',
+            'reference/cron-expressions',
           ],
         },
         {
@@ -498,6 +489,7 @@ const sidebars = {
         'vendor/releases-creating-releases',
         'vendor/releases-creating-cli',
         'vendor/helm-install-release',
+        'reference/linter',
       ],
     },
     {
@@ -545,7 +537,7 @@ const sidebars = {
         'vendor/preflight-sb-helm-templates-about',
         {
           type: 'category',
-          label: 'Preflight Checks',
+          label: 'Defining Preflight Checks',
           items: [
              'vendor/preflight-helm-defining',
              'vendor/preflight-kots-defining',
@@ -553,7 +545,7 @@ const sidebars = {
         },
         {
           type: 'category',
-          label: 'Support Bundles',
+          label: 'Customizing Support Bundles',
           items: [
             'vendor/support-bundle-helm-customizing',
             'vendor/support-bundle-kots-customizing',
@@ -561,13 +553,12 @@ const sidebars = {
         },
         {
           type: 'category',
-          label: 'Custom Resources',
+          label: 'Troubleshoot Custom Resources',
           items: [
             'reference/custom-resource-preflight',
             'reference/custom-resource-redactor',
-
-         ],
-        },
+          ],
+        },    
         {
           type: 'category',
           label: 'Supporting Your Application',

--- a/sidebars.js
+++ b/sidebars.js
@@ -553,7 +553,7 @@ const sidebars = {
         },
         {
           type: 'category',
-          label: 'Troubleshoot Custom Resources',
+          label: 'Custom Resources',
           items: [
             'reference/custom-resource-preflight',
             'reference/custom-resource-redactor',


### PR DESCRIPTION
Changes:
- KOTS Custom Resources and Template Functions are top-level in the KOTS sidebar (rather than being nested under Reference section)
- Removed that References bucket all together and redistributed the other topics that were there:
  - Cron Expressions topic is moved to the "Install and Manage" section in the KOTS sidebar since enterprise customers are the ones who would need that info when configuring auto updates or backups
  - Linter Rules is moved to Channel and Release Management section in the main sidebar
  - The Velero Backup custom resource was moved to Backup and Restore section in the KOTS sidebar (so that only the kots.io custom resources are under Custom Resources)
  - Remove the SIG Application custom resource topic as it was only about 3 sentence long. Condense the info into the topic about Adding Buttons and Links using the SIG Application CR. Update xrefs and add a redirect