### PR TITLE
89383: Update KOTS Minimal RBAC docs

### DIFF
--- a/docs/enterprise/installing-general-requirements.mdx
+++ b/docs/enterprise/installing-general-requirements.mdx
@@ -1,6 +1,5 @@
 import DockerCompatibility from "../partials/image-registry/_docker-compatibility.mdx"
 import KubernetesCompatibility from "../partials/install/_kubernetes-compatibility.mdx"
-import MinRBAC from "../partials/install/_min-rbac.mdx"
 
 # Installation Requirements
 

--- a/docs/enterprise/installing-general-requirements.mdx
+++ b/docs/enterprise/installing-general-requirements.mdx
@@ -1,5 +1,6 @@
 import DockerCompatibility from "../partials/image-registry/_docker-compatibility.mdx"
 import KubernetesCompatibility from "../partials/install/_kubernetes-compatibility.mdx"
+import MinRBAC from "../partials/install/_min-rbac.mdx"
 
 # Installation Requirements
 
@@ -135,7 +136,7 @@ To install or upgrade KOTS with namespace-scoped access, the user must have _one
     ```
 
     :::note
-    The minimum RBAC requirements can vary slightly depending on the cluster's Kubernetes distribution and the version of KOTS. Contact your application vendor if you have the required RBAC permissions listed above and you see an error related to RBAC during installation or upgrade.
+    The minimum RBAC requirements can vary slightly depending on the cluster's Kubernetes distribution and the version of KOTS. Contact your software vendor if you have the required RBAC permissions listed above and you see an error related to RBAC during installation or upgrade.
     ::: 
 
    1. Save the following ServiceAccount, Role, and RoleBinding to a single YAML file, such as `rbac.yaml`:
@@ -204,7 +205,7 @@ To install or upgrade KOTS with namespace-scoped access, the user must have _one
     1. If the application contains any Custom Resource Definitions (CRDs), add the CRDs to the Role in the YAML file that you created in the previous step with as many permissions as possible: `["get", "list", "watch", "create", "update", "patch", "delete"]`.
 
       :::note
-      Contact your application vendor for information about any CRDs that are included in the application.
+      Contact your software vendor for information about any CRDs that are included in the application.
       :::
 
       **Example**
@@ -288,6 +289,6 @@ No outbound internet access is required for air gapped installations.
 | k8s.kurl.sh<br />s3.kurl.sh          | Not Required                  | Required                      | Embedded cluster installation scripts and artifacts are served from [kurl.sh](https://kurl.sh). An application identifier is sent in a URL path, and bash scripts and binary executables are served from kurl.sh. This domain is owned by Replicated, Inc., which is headquartered in Los Angeles, CA.                                                     |
 | amazonaws.com        | Not Required                  | Required                      | tar.gz packages are downloaded from Amazon S3 during embedded cluster installations. For information about dynamically scraping the IP ranges to allowlist for accessing these packages, see [AWS IP address ranges](https://docs.aws.amazon.com/general/latest/gr/aws-ip-ranges.html#aws-ip-download) in the AWS documentation.                                                         |
 
-&#42; Required only if the application uses the Replicated proxy service. Contact your application vendor for more information.
+&#42; Required only if the application uses the Replicated proxy service. Contact your software vendor for more information.
 
-&#42;&#42; Required only if the application uses the Replicated registry. Contact your application vendor for more information.
+&#42;&#42; Required only if the application uses the Replicated registry. Contact your software vendor for more information.

--- a/docs/enterprise/installing-general-requirements.mdx
+++ b/docs/enterprise/installing-general-requirements.mdx
@@ -102,17 +102,9 @@ To install or upgrade KOTS with namespace-scoped access, the user must have _one
 
   To use the minimum KOTS RBAC permissions to install or upgrade:
 
-  1. Ensure that the user has the minimum RBAC permissions required by KOTS. The following Role lists the minimum RBAC permissions under `rules`:
+  1. Ensure that the user has the minimum RBAC permissions required by KOTS. The following lists the minimum RBAC permissions:
 
     ```yaml
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-      labels:
-        kots.io/backup: velero
-        kots.io/kotsadm: "true"
-      name: kotsadm-role
-    rules:
       - apiGroups: [""]
         resources: ["configmaps", "persistentvolumeclaims", "pods", "secrets", "services", "limitranges"]
         verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
@@ -144,7 +136,7 @@ To install or upgrade KOTS with namespace-scoped access, the user must have _one
 
     :::note
     The minimum RBAC requirements can vary slightly depending on the cluster's Kubernetes distribution and the version of KOTS. Contact your application vendor if you have the required RBAC permissions listed above and you see an error related to RBAC during installation or upgrade.
-    :::
+    ::: 
 
    1. Save the following ServiceAccount, Role, and RoleBinding to a single YAML file, such as `rbac.yaml`:
 
@@ -209,6 +201,21 @@ To install or upgrade KOTS with namespace-scoped access, the user must have _one
           name: kotsadm
       ```
 
+    1. If the application contains any Custom Resource Definitions (CRDs), add the CRDs to the Role in the YAML file that you created in the previous step with as many permissions as possible: `["get", "list", "watch", "create", "update", "patch", "delete"]`.
+
+      :::note
+      Contact your application vendor for information about any CRDs that are included in the application.
+      :::
+
+      **Example**
+
+      ```yaml
+       rules:
+       - apiGroups: ["stable.example.com"]
+         resources: ["crontabs"]
+         verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+      ```
+    
     1. Run the following command to create the RBAC resources for KOTS in the namespace:
 
      ```
@@ -216,7 +223,7 @@ To install or upgrade KOTS with namespace-scoped access, the user must have _one
      ```
 
      Replace:
-       * `RBAC_YAML_FILE` with the name of the YAML file that you saved in the previous step.
+       * `RBAC_YAML_FILE` with the name of the YAML file with the ServiceAccount, Role, and RoleBinding and that you created.
        * `TARGET_NAMESPACE` with the namespace where the user will install KOTS.
 
   :::note

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -2,7 +2,7 @@
 
 This topic describes role-based access control (RBAC) for Replicated KOTS in existing cluster installations. It includes information about how to change the default cluster-scoped RBAC permissions granted to KOTS.
 
-## About Cluster-scoped RBAC
+## Cluster-scoped RBAC
 
 When a user installs your application in an existing cluster, Kubernetes RBAC resources are created to allow KOTS to install and manage the application.
 
@@ -36,13 +36,9 @@ subjects:
 
 Alternatively, if your application does not require access to resources across all namespaces in the cluster, then you can enable namespace-scoped RBAC for KOTS. For information, see [About Namespace-scoped RBAC](#min-rbac) below.
 
-## About Namespace-scoped RBAC {#min-rbac}
+## Namespace-scoped RBAC {#min-rbac}
 
-Rather that use the default cluster-scoped RBAC, you can configure your application so that the RBAC permissions granted to KOTS are limited to a target namespace or namespaces.
-
-Namespace-scoped RBAC is supported for applications that use Kubernetes Operators or multiple namespaces. During application installation, if there are `additionalNamespaces` specified in the Application custom resource manifest file, then Roles and RoleBindings are created to grant KOTS access to resources in all specified namespaces.
-
-By default, for namespace-scoped installations, the following Role and RoleBinding resources are created that grant KOTS permissions to all resources in a target namespace:
+Rather that use the default cluster-scoped RBAC, you can configure your application so that the RBAC permissions granted to KOTS are limited to a target namespace or namespaces. By default, for namespace-scoped installations, the following Role and RoleBinding resources are created that grant KOTS permissions to all resources in a target namespace:
 
 ```yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
@@ -70,7 +66,7 @@ subjects:
   namespace: appnamespace
 ```
 
-For information about how to enable namespace-scoped RBAC for your application, see [Enable Namespace-scoped RBAC](#enable) below.
+Namespace-scoped RBAC is supported for applications that use Kubernetes Operators or multiple namespaces. During application installation, if there are `additionalNamespaces` specified in the Application custom resource manifest file, then Roles and RoleBindings are created to grant KOTS access to resources in all specified namespaces.
 
 ### Enable Namespace-scoped RBAC {#enable}
 
@@ -82,7 +78,17 @@ To enable namespace-scoped RBAC permissions for KOTS, specify one of the followi
 
 For more information about these options, see [requireMinimalRBACPrivileges](/reference/custom-resource-application#requireMinimalRBACPrivileges) and [supportMinimalRBACPrivileges](/reference/custom-resource-application#supportMinimalRBACPrivileges) in _Application_.
 
-For information about limitations that apply to using namespace-scoped access, see [Limitations](#limitations) below.
+### About Installing with Minimal RBAC
+
+In some cases, it is not possible to grant the user `* * *` permissions in the target namespace. For example, an organization might have security policies that prevent this level of permissions.
+
+If the user installing or upgrading KOTS cannot be granted `* * *` permissions in the namespace, then they can instead request the following:
+* The minimum RBAC permissions required by KOTS
+* RBAC permissions for any CustomResourceDefinitions (CRDs) that your application includes
+
+Installing with the minimum KOTS RBAC permissions also requires that the user manually creates a ServiceAccount, Role, and RoleBinding for KOTS, rather than allowing KOTS to automatically create a Role with `* * *` permissions.
+
+For more information about how users can install KOTS with minimal RBAC when namespace-scoped RBAC is enabled, see [Namespace-scoped RBAC Requirements](/enterprise/installing-general-requirements#namespace-scoped) in _Installation Requirements_.
 
 ### Limitations
 

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -38,7 +38,7 @@ Alternatively, if your application does not require access to resources across a
 
 ## Namespace-scoped RBAC {#min-rbac}
 
-Rather that use the default cluster-scoped RBAC, you can configure your application so that the RBAC permissions granted to KOTS are limited to a target namespace or namespaces. By default, for namespace-scoped installations, the following Role and RoleBinding resources are created that grant KOTS permissions to all resources in a target namespace:
+Rather than use the default cluster-scoped RBAC, you can configure your application so that the RBAC permissions granted to KOTS are limited to a target namespace or namespaces. By default, for namespace-scoped installations, the following Role and RoleBinding resources are created that grant KOTS permissions to all resources in a target namespace:
 
 ```yaml
 apiVersion: "rbac.authorization.k8s.io/v1"


### PR DESCRIPTION
Added _About Installing with Minimal RBAC_ section to the vendor topic about Configuring KOTS RBAC: https://deploy-preview-1460--replicated-docs.netlify.app/vendor/packaging-rbac#about-installing-with-minimal-rbac

Added additional step in the minimal rbac procedure for adding any CRDs to the Role that you create: https://deploy-preview-1460--replicated-docs.netlify.app/enterprise/installing-general-requirements#namespace-scoped