### PR TITLE
Update syntax for using kustomize patches

### DIFF
--- a/docs/enterprise/updating-patching-with-kustomize.md
+++ b/docs/enterprise/updating-patching-with-kustomize.md
@@ -176,7 +176,7 @@ To patch your application:
     - ../../midstream
     kind: Kustomization
     patches:
-    - ./FILENAME.yaml
+    - path: ./FILENAME.yaml
    ```
 
 1. Upload your changes to the cluster:


### PR DESCRIPTION
Starting Kustomize 5 (which is the version of Kustomize that recent KOTS versions adopted), there was a breaking change introduced to the use of `patches`. More details: https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.0

> Drop support for a very old, legacy style of patches. patches used to be allowed to be used as an alias for patchesStrategicMerge in kustomize v3. You now have to use patchesStrategicMerge explicitly, or update to the new syntax supported by patches

This PR updates the syntax to accommodate those changes.