### PR TITLE
add channel archive RBAC resource

### DIFF
--- a/docs/vendor/team-management-rbac-resource-names.md
+++ b/docs/vendor/team-management-rbac-resource-names.md
@@ -34,6 +34,10 @@ Grants the holder the ability to delete the specified linked external docker reg
 
 Grants the holder the ability to create a new channel in the specified application(s).
 
+## kots/app/[:appId]/channel/[:channelId]/archive
+
+Grants the holder permission to archive the specified channel(s) of the specified application(s).
+
 ### kots/app/[:appId]/channel/[:channelId]/promote
 
 Grants the holder the ability to promote a new release to the specified channel(s) of the specified application(s).


### PR DESCRIPTION
Related to [this support issue](https://github.com/replicated-collab/git-guardian-kots/issues/140) - found an RBAC resource we didn't have documented yet for archiving a channel.