### PR TITLE
update velero compatibility

### DIFF
--- a/docs/enterprise/snapshots-troubleshooting-backup-restore.md
+++ b/docs/enterprise/snapshots-troubleshooting-backup-restore.md
@@ -203,4 +203,4 @@ The resource restore priority was changed in Velero 1.10.3 and 1.11.0, which lea
 
 #### Solution
 
-These warnings do not necessarily mean that the restore itself failed. The endpoints likely do exist as they are created by Kubernetes when the related Service resources were restored. However, to prevent encountering these warnings, use Velero version 1.10.2 or earlier.
+These warnings do not necessarily mean that the restore itself failed. The endpoints likely do exist as they are created by Kubernetes when the related Service resources were restored. This issue is resolved in Velero versions 1.11.1 and 1.12.0.

--- a/docs/enterprise/snapshots-troubleshooting-backup-restore.md
+++ b/docs/enterprise/snapshots-troubleshooting-backup-restore.md
@@ -203,4 +203,4 @@ The resource restore priority was changed in Velero 1.10.3 and 1.11.0, which lea
 
 #### Solution
 
-These warnings do not necessarily mean that the restore itself failed. The endpoints likely do exist as they are created by Kubernetes when the related Service resources were restored. This issue is resolved in Velero versions 1.11.1 and 1.12.0.
+These warnings do not necessarily mean that the restore itself failed. The endpoints likely do exist as they are created by Kubernetes when the related Service resources were restored. However, to prevent encountering these warnings, use Velero version 1.11.1 or later.

--- a/docs/enterprise/snapshots-understanding.md
+++ b/docs/enterprise/snapshots-understanding.md
@@ -78,4 +78,4 @@ The following table lists which versions of Velero are compatible with each vers
 |------|-------------|
 | 1.15 to 1.20.2 | 1.2.0 |
 | 1.20.3 to 1.94.0 | 1.5.1 through 1.9.x |
-| 1.94.1 and later | 1.6.x through 1.12.1 |
+| 1.94.1 and later | 1.6.x through 1.12.x |

--- a/docs/enterprise/snapshots-understanding.md
+++ b/docs/enterprise/snapshots-understanding.md
@@ -78,4 +78,4 @@ The following table lists which versions of Velero are compatible with each vers
 |------|-------------|
 | 1.15 to 1.20.2 | 1.2.0 |
 | 1.20.3 and later | 1.5.1 through 1.9.x |
-| 1.94.1 and later | 1.6.x through 1.10.2 |
+| 1.94.1 and later | 1.6.x through 1.12.1 |

--- a/docs/enterprise/snapshots-understanding.md
+++ b/docs/enterprise/snapshots-understanding.md
@@ -77,5 +77,5 @@ The following table lists which versions of Velero are compatible with each vers
 | KOTS version | Velero version |
 |------|-------------|
 | 1.15 to 1.20.2 | 1.2.0 |
-| 1.20.3 and later | 1.5.1 through 1.9.x |
+| 1.20.3 to 1.94.0 | 1.5.1 through 1.9.x |
 | 1.94.1 and later | 1.6.x through 1.12.1 |


### PR DESCRIPTION
Updates Velero version compatibility table to reflect support for the latest version 1.12.1.

Also updates, the troubleshooting topic to indicate that the issue in 1.10.3 and 1.11.0 has been resolved more recent releases.