### PR TITLE
Chore: CMX - add note about dockerhub pull secret requirement

### DIFF
--- a/docs/vendor/testing-supported-clusters.md
+++ b/docs/vendor/testing-supported-clusters.md
@@ -102,7 +102,7 @@ The compatibility matrix supports creating [Red Hat OpenShift OKD](https://www.o
     <td>
       <ul>
         <li>OpenShift does not support r1.small instance types.</li>
-        <li>Openshift versions prior to 4.13-okd do not have a registry mirror and so may be subject to rate limiting from Dockerhub. We recommend implementing an image pull secret to pull images as an authenticated Dockerhub user.</li>
+        <li>OpenShift versions prior to 4.13-okd do not have a registry mirror and so may be subject to [rate limiting from Docker Hub](https://docs.docker.com/docker-hub/download-rate-limit/). We recommend configuring an [image pull secret](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) to pull public Docker Hub images as an authenticated user in order to increase limits.</li>
         <li><p>OpenShift builds take approximately 17 minutes.</p>
             <p><Pool/></p>
           </li>

--- a/docs/vendor/testing-supported-clusters.md
+++ b/docs/vendor/testing-supported-clusters.md
@@ -102,7 +102,7 @@ The compatibility matrix supports creating [Red Hat OpenShift OKD](https://www.o
     <td>
       <ul>
         <li>OpenShift does not support r1.small instance types.</li>
-        <li>OpenShift versions prior to 4.13-okd do not have a registry mirror and so may be subject to [rate limiting from Docker Hub](https://docs.docker.com/docker-hub/download-rate-limit/). We recommend configuring an [image pull secret](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) to pull public Docker Hub images as an authenticated user in order to increase limits.</li>
+        <li>OpenShift versions earlier than 4.13-okd do not have a registry mirror and so may be subject to rate limiting from Docker Hub. For information about Docker Hub rate limiting, see <a href="https://docs.docker.com/docker-hub/download-rate-limit/">Docker Hub rate limit</a>. To increase limits, Replicated recommends that you configure an image pull secret to pull public Docker Hub images as an authenticated user. For more information about how to configure image pull secrets, see <a href="https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/">Pull an Image from a Private Registry</a> in the Kubernetes documentation.</li>
         <li><p>OpenShift builds take approximately 17 minutes.</p>
             <p><Pool/></p>
           </li>

--- a/docs/vendor/testing-supported-clusters.md
+++ b/docs/vendor/testing-supported-clusters.md
@@ -102,6 +102,7 @@ The compatibility matrix supports creating [Red Hat OpenShift OKD](https://www.o
     <td>
       <ul>
         <li>OpenShift does not support r1.small instance types.</li>
+        <li>Openshift versions prior to 4.13-okd do not have a registry mirror and so may be subject to rate limiting from Dockerhub. We recommend implementing an image pull secret to pull images as an authenticated Dockerhub user.</li>
         <li><p>OpenShift builds take approximately 17 minutes.</p>
             <p><Pool/></p>
           </li>


### PR DESCRIPTION
OpenShift prior to 4.13 does not implement a registry mirror, this change adds a note to limitations to highlight that the vendor needs to implement an image pull secret to overcome rate limiting from Dockerhub.