### PR TITLE
remove references to obsolete support email

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This repository has been made public so that vendors and the open-source communi
 
 - **Submit a PR** You can submit a PR directly from a specific topic in the documentation by clicking the **Create pull request or raise issue on GitHub** at the bottom of the page. This method lets you edit the content directly and commit your changes on a new branch. After submitting your proposed changes, the Replicated team will verify the accuracy of the changes and perform an editorial review. If the PR is approved, it will be merged directly into the main branch.
 
-- **Open a Github Issue** - To open a GitHub issue for this repository, click the Issues tab and click **New Issue**. This method may be more useful when you want to report a bug specifically for the documentation. If you are having an issue with the product itself, we encourage you to report it to us in a support issue raised via Vendor Portal.
+- **Open a Github Issue** - To open a GitHub issue for this repository, click the Issues tab and click **New Issue**. This method may be more useful when you want to report a bug specifically for the documentation. If you are having an issue with the product itself, we encourage you to report it to us in a support issue submitted in the vendor portal.
 
 ## Setting Up Local WYSIWYG Previews
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This repository has been made public so that vendors and the open-source communi
 
 - **Submit a PR** You can submit a PR directly from a specific topic in the documentation by clicking the **Create pull request or raise issue on GitHub** at the bottom of the page. This method lets you edit the content directly and commit your changes on a new branch. After submitting your proposed changes, the Replicated team will verify the accuracy of the changes and perform an editorial review. If the PR is approved, it will be merged directly into the main branch.
 
-- **Open a Github Issue** - To open a GitHub issue for this repository, click the Issues tab and click **New Issue**. This method may be more useful when you want to report a bug specifically for the documentation. If you are having an issue with the product itself, we encourage you to report it to us in a Zendesk ticket, Slack message, or by emailing support@replicated.com.
+- **Open a Github Issue** - To open a GitHub issue for this repository, click the Issues tab and click **New Issue**. This method may be more useful when you want to report a bug specifically for the documentation. If you are having an issue with the product itself, we encourage you to report it to us in a support issue raised via Vendor Portal.
 
 ## Setting Up Local WYSIWYG Previews
 

--- a/docs/vendor/policies-vulnerability-patch.md
+++ b/docs/vendor/policies-vulnerability-patch.md
@@ -12,7 +12,7 @@ Our build pipeline uses [Trivy](https://www.aquasec.com/products/trivy/) to scan
 It’s possible that other security scanners will detect a different set of results.
 We commit to patching vulnerabilities according to the timeline below based on the results of our internal scans.
 
-If you or your customer detects a different vulnerability using a different scanner, we encourage you to report it to us in a GitHub issue, Slack message, or emailing support@replicated.com.
+If you or your customer detects a different vulnerability using a different scanner, we encourage you to report it to us in a GitHub issue, Slack message, or opening a support issue in Vendor Portal.
 Our team will evaluate the vulnerability and determine the best course of action.
 
 ## Base Images

--- a/docs/vendor/policies-vulnerability-patch.md
+++ b/docs/vendor/policies-vulnerability-patch.md
@@ -12,7 +12,7 @@ Our build pipeline uses [Trivy](https://www.aquasec.com/products/trivy/) to scan
 It’s possible that other security scanners will detect a different set of results.
 We commit to patching vulnerabilities according to the timeline below based on the results of our internal scans.
 
-If you or your customer detects a different vulnerability using a different scanner, we encourage you to report it to us in a GitHub issue, Slack message, or opening a support issue in Vendor Portal.
+If you or your customer detects a different vulnerability using a different scanner, we encourage you to report it to us in a GitHub issue, Slack message, or opening a support issue in the vendor portal.
 Our team will evaluate the vulnerability and determine the best course of action.
 
 ## Base Images


### PR DESCRIPTION
The email address support@replicated.com, and Zendesk, have been unavailable and unmonitored for over a year.  This change removes references to those.