### PR TITLE
bump sdk version to 1.0.0-beta.13

### DIFF
--- a/docs/partials/replicated-sdk/_dependency-yaml.mdx
+++ b/docs/partials/replicated-sdk/_dependency-yaml.mdx
@@ -3,7 +3,7 @@
 dependencies:
 - name: replicated
   repository: oci://registry.replicated.com/library
-  version: 1.0.0-beta.12
+  version: 1.0.0-beta.13
 ```
 
 For the latest version information for the Replicated SDK, see the [replicated-sdk repository](https://github.com/replicatedhq/replicated-sdk/tags) in GitHub.


### PR DESCRIPTION
bumps SDK version in the docs to the latest `1.0.0-beta.13`