### PR TITLE
update KOTS release notes workflow for k8s 1.29

### DIFF
--- a/.github/workflows/app-manager-release-notes.yml
+++ b/.github/workflows/app-manager-release-notes.yml
@@ -22,7 +22,7 @@ jobs:
         owner-repo: replicatedhq/kots
         head: $KOTS_VERSION
         title: ${KOTS_VERSION#v}
-        description: 'Support for Kubernetes: 1.26, 1.27, and 1.28'
+        description: 'Support for Kubernetes: 1.26, 1.27, 1.28, and 1.29'
         include-pr-links: false
         github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Updates the KOTS automated release notes workflow to indicate support for Kubernetes 1.29