### PR TITLE
Add qualified scripts

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -54,6 +54,19 @@ const config = {
     ],
   ],
 
+  scripts: [
+    {
+      src:
+        '/js/qualified.js',
+      async: false,
+    },
+    {
+      src:
+        'https://js.qualified.com/qualified.js?token=Fj948QvXpLAwjfVs',
+      async: true,
+    },
+  ],
+  
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({

--- a/static/js/qualified.js
+++ b/static/js/qualified.js
@@ -1,0 +1,1 @@
+(function(w,q){w['QualifiedObject']=q;w[q]=w[q]||function(){(w[q].q=w[q].q||[]).push(arguments)};})(window,'qualified')


### PR DESCRIPTION
Docusaurus docs on the scripts property: https://docusaurus.io/docs/api/docusaurus-config#scripts

Related stackoverflow: https://stackoverflow.com/questions/57859350/how-can-i-add-custom-scripts-in-index-htmls-head-part-in-docusaurus-v2

Here's where the feature was added in docusauurs v2: https://github.com/facebook/docusaurus/pull/1831