### PR TITLE
add known SDK limitation for license fields

### DIFF
--- a/docs/vendor/replicated-sdk-overview.md
+++ b/docs/vendor/replicated-sdk-overview.md
@@ -21,6 +21,8 @@ The Replicated SDK has the following limitations:
   * The `/api/v1/app/history` SDK API endpoint always returns an empty array because there is no Helm history in the cluster. See [GET /app/history](/reference/replicated-sdk-apis#get-apphistory) in _Replicated SDK API (Beta)_.
 
   * The SDK does not automatically generate status informers to report status data for installed instances of the application. To get instance status data, you must enable custom status informers by overriding the `replicated.statusInformers` Helm value. See [Enable Application Status Insights](/vendor/insights-app-status#enable-application-status-insights) in _Enabling and Understanding Application Status_.
+ 
+* When installing a KOTS application with the SDK, license field titles with special YAML characters like question marks (`?`) can lead to errors during application release downloads. To avoid this issue, it's best to use only alphanumeric characters in license field titles when including the SDK in a KOTS application.
 
 ## SDK Resiliency
 

--- a/docs/vendor/replicated-sdk-overview.md
+++ b/docs/vendor/replicated-sdk-overview.md
@@ -22,7 +22,7 @@ The Replicated SDK has the following limitations:
 
   * The SDK does not automatically generate status informers to report status data for installed instances of the application. To get instance status data, you must enable custom status informers by overriding the `replicated.statusInformers` Helm value. See [Enable Application Status Insights](/vendor/insights-app-status#enable-application-status-insights) in _Enabling and Understanding Application Status_.
  
-* When installing a KOTS application that includes the SDK, license field titles with special YAML characters like question marks (`?`) can lead to errors during application release downloads. To avoid this issue, it's best to use only alphanumeric characters in license field titles when including the SDK in a KOTS application.
+* When installing a KOTS application that includes the SDK, license field titles with special YAML characters like question marks (`?`) can lead to errors during application release downloads. To avoid this issue, use only alphanumeric characters in license field titles when including the SDK in a KOTS application.
 
 ## SDK Resiliency
 

--- a/docs/vendor/replicated-sdk-overview.md
+++ b/docs/vendor/replicated-sdk-overview.md
@@ -22,7 +22,7 @@ The Replicated SDK has the following limitations:
 
   * The SDK does not automatically generate status informers to report status data for installed instances of the application. To get instance status data, you must enable custom status informers by overriding the `replicated.statusInformers` Helm value. See [Enable Application Status Insights](/vendor/insights-app-status#enable-application-status-insights) in _Enabling and Understanding Application Status_.
  
-* When installing a KOTS application with the SDK, license field titles with special YAML characters like question marks (`?`) can lead to errors during application release downloads. To avoid this issue, it's best to use only alphanumeric characters in license field titles when including the SDK in a KOTS application.
+* When installing a KOTS application that includes the SDK, license field titles with special YAML characters like question marks (`?`) can lead to errors during application release downloads. To avoid this issue, it's best to use only alphanumeric characters in license field titles when including the SDK in a KOTS application.
 
 ## SDK Resiliency
 


### PR DESCRIPTION
This PR adds a known limitation for KOTS applications that include the Replicated SDK.

This is a documentation change ahead of fixing a known issue as part of https://app.shortcut.com/replicated/story/98631/special-yaml-characters-in-license-field-titles-cause-kots-to-fail-when-configuring-the-sdk