### PR TITLE
Add registry logout step

### DIFF
--- a/docs/partials/replicated-sdk/_401-unauthorized.mdx
+++ b/docs/partials/replicated-sdk/_401-unauthorized.mdx
@@ -1,0 +1,3 @@
+:::note
+If you see a `401 Unauthorized` error message, log out of the Replicated registry by running `helm registry logout registry.replicated.com` and then run `helm package . --dependency-update` again.
+:::

--- a/docs/partials/replicated-sdk/_kots-version-req.mdx
+++ b/docs/partials/replicated-sdk/_kots-version-req.mdx
@@ -1,1 +1,1 @@
-KOTS v1.104.0 or later and the SDK version 1.0.0-beta.12 or later are required to install the SDK with KOTS. You can verify the version of KOTS installed with `kubectl kots version`.
+To install the SDK with KOTS, KOTS v1.104.0 or later and the SDK version 1.0.0-beta.12 or later are required. You can verify the version of KOTS installed with `kubectl kots version`.

--- a/docs/partials/replicated-sdk/_registry-logout.mdx
+++ b/docs/partials/replicated-sdk/_registry-logout.mdx
@@ -1,0 +1,7 @@
+(Recommended) Log out of the Replicated registry:
+
+    ```bash
+    helm registry logout registry.replicated.com
+    ```
+
+    Replicated recommends that you log out of the Replicated registry to avoid errors that can occur when Helm attempts to pull the SDK chart from the registry if you are logged in with a license that has expired. 

--- a/docs/vendor/helm-install-release.md
+++ b/docs/vendor/helm-install-release.md
@@ -8,7 +8,7 @@ This topic describes how to package a Helm chart and the Replicated SDK into a c
 
 To add a Helm chart to a release, you first add the Replicated SDK as a dependency of the Helm chart and then package the chart and its dependencies into a `.tgz` chart archive.
 
-The Replicated SDK is a Helm chart can be installed as a small service alongside your application. The SDK is strongly recommended for applications that will be installed with Helm because it provides access to key Replicated features, such as instance insights and telemetry. For more information, see [About the Replicated SDK](replicated-sdk-overview). 
+The Replicated SDK is a Helm chart can be installed as a small service alongside your application. The SDK is strongly recommended because it provides access to key Replicated features, such as support for collecting custom metrics on application instances. For more information, see [About the Replicated SDK](replicated-sdk-overview). 
 
 ## Chart Version Requirement
 
@@ -22,11 +22,19 @@ This procedure shows how to create a Helm chart archive to add to a release. For
 
 To package a Helm chart so that it can be added to a release:
 
-1. (Recommended) In the Helm chart `Chart.yaml`, add the Replicated SDK as a dependency:
+1. In the Helm chart `Chart.yaml`, add the Replicated SDK as a dependency:
 
     <DependencyYaml/>
     
     For additional guidelines related to adding the SDK as a dependency, see [Install the SDK as a Subchart](replicated-sdk-installing#install-the-sdk-as-a-subchart) in _Installing the Replicated SDK_.
+
+1. (Recommended) Run the following command to log out of the Replicated registry:
+
+    ```bash
+    helm registry logout registry.replicated.com
+    ```
+
+    Replicated recommends that you log out of the Replicated registry to avoid errors that can occur when Helm attempts to pull the SDK chart from the registry if you are logged in with a license that has expired. 
 
 1. Update the `charts/` directory:
 

--- a/docs/vendor/helm-install-release.md
+++ b/docs/vendor/helm-install-release.md
@@ -22,13 +22,7 @@ This procedure shows how to create a Helm chart archive to add to a release. For
 
 To package a Helm chart so that it can be added to a release:
 
-1. In your local directory, `cd` to the location of the `Chart.yaml` file for the Helm chart.
-
-   :::note
-   If the Helm chart that you want to use is available in a chart repository and you do not have access to the source, you can run `helm repo add` and `helm pull` to download a local copy of the chart archive. For more information, see [Helm Repo](https://helm.sh/docs/helm/helm_repo/) and [Helm Pull](https://helm.sh/docs/helm/helm_pull/) in the Helm documentation.
-   :::
-
-1. In the Helm chart `Chart.yaml`, add the Replicated SDK as a dependency:
+1. (Recommended) In the Helm chart `Chart.yaml`, add the Replicated SDK as a dependency:
 
     <DependencyYaml/>
     
@@ -50,4 +44,4 @@ To package a Helm chart so that it can be added to a release:
 
 1. Add the `.tgz` chart archive to a release. See [Managing Releases with the Vendor Portal](releases-creating-releases) or [Managing Releases with the CLI](releases-creating-cli).
 
-  After the release is promoted, your Helm chart is automatically pushed to the Replicated registry. For information about how to install the release in a development environment with Helm, see [Installing with Helm](install-with-helm).  
+  After the release is promoted, your Helm chart is automatically pushed to the Replicated registry. For information about how to install a release with the Helm CLI, see [Installing with Helm](install-with-helm).  

--- a/docs/vendor/helm-install-release.md
+++ b/docs/vendor/helm-install-release.md
@@ -1,4 +1,5 @@
 import DependencyYaml from "../partials/replicated-sdk/_dependency-yaml.mdx"
+import RegistryLogout from "../partials/replicated-sdk/_registry-logout.mdx"
 
 # Packaging a Helm Chart for a Release
 
@@ -28,13 +29,7 @@ To package a Helm chart so that it can be added to a release:
     
     For additional guidelines related to adding the SDK as a dependency, see [Install the SDK as a Subchart](replicated-sdk-installing#install-the-sdk-as-a-subchart) in _Installing the Replicated SDK_.
 
-1. (Recommended) Run the following command to log out of the Replicated registry:
-
-    ```bash
-    helm registry logout registry.replicated.com
-    ```
-
-    Replicated recommends that you log out of the Replicated registry to avoid errors that can occur when Helm attempts to pull the SDK chart from the registry if you are logged in with a license that has expired. 
+1. <RegistryLogout/> 
 
 1. Update the `charts/` directory:
 

--- a/docs/vendor/replicated-sdk-installing.md
+++ b/docs/vendor/replicated-sdk-installing.md
@@ -29,7 +29,7 @@ To add and install the SDK as a subchart:
     helm registry logout registry.replicated.com
     ```
 
-    Replicated recommends that you log out of the Replicated registry to avoid errors that can occur when Helm attempts to pull the SDK chart from the registry if you are logged in to the registry with a license that has expired. 
+    Replicated recommends that you log out of the Replicated registry to avoid errors that can occur when Helm attempts to pull the SDK chart from the registry if you are logged in with a license that has expired. 
 
 1. Update the `charts/` directory:
 
@@ -102,7 +102,7 @@ To add the SDK Helm chart to a release for a standard manifest-based application
 
 1. If one was not created automatically, add a Replicated HelmChart custom resource to the release. HelmChart custom resources have `apiVersion: kots.io/v1beta2` and `kind: HelmChart`. 
 
-  **Example:**
+     **Example:**
   
     ```yaml
     apiVersion: kots.io/v1beta2
@@ -119,11 +119,11 @@ To add the SDK Helm chart to a release for a standard manifest-based application
         chartVersion: 1.0.0-beta.13
     ```
 
-    As shown in the example above, the HelmChart custom resource requires the name and version of the SDK Helm chart that you added to the release:
-    * **`chart.name`**: The name of the SDK Helm chart is `replicated`. You can find the chart name in the `name` field of the SDK Helm chart `Chart.yaml` file.
-    * **`chart.chartVersion`**: The chart version varies depending on the version of the SDK that you pulled and added to the release. You can find the chart version in the `version` field of SDK Helm chart `Chart.yaml` file.
+     As shown in the example above, the HelmChart custom resource requires the name and version of the SDK Helm chart that you added to the release:
+     * **`chart.name`**: The name of the SDK Helm chart is `replicated`. You can find the chart name in the `name` field of the SDK Helm chart `Chart.yaml` file.
+     * **`chart.chartVersion`**: The chart version varies depending on the version of the SDK that you pulled and added to the release. You can find the chart version in the `version` field of SDK Helm chart `Chart.yaml` file.
 
-    For more information about configuring the HelmChart custom resource to support KOTS installations, see [About Distributing Helm Charts with KOTS](/vendor/helm-native-about) and [HelmChart v2](/reference/custom-resource-helmchart-v2).
+     For more information about configuring the HelmChart custom resource to support KOTS installations, see [About Distributing Helm Charts with KOTS](/vendor/helm-native-about) and [HelmChart v2](/reference/custom-resource-helmchart-v2).
 
 1. Save and promote the release to an internal-only channel used for testing, such as the default Unstable channel.
 

--- a/docs/vendor/replicated-sdk-installing.md
+++ b/docs/vendor/replicated-sdk-installing.md
@@ -7,27 +7,41 @@ This topic describes the methods for distributing and installing the Replicated 
 
 It includes information about how to install the SDK alongside Helm chart- or standard manifest-based applications using the Helm CLI or Replicated KOTS. It also includes information about installing the SDK separately from an application as a standalone component in integration mode.
 
-## Install the SDK as a Subchart
-
-You can include the SDK as a dependency of your application Helm chart. When included as a dependency, the SDK is installed as a subchart alongside your application in customer environments.
-
-The SDK can be installed as a subchart using the Helm CLI or Replicated KOTS.
+## Requirement
 
 <KotsVerReq/>
 
-To install the SDK as a subchart alongside an application Helm chart:
+## Install the SDK as a Subchart
+
+You can include the SDK as a dependency of your application Helm chart. When included as a dependency, the SDK is installed as a subchart alongside your application in customer environments. The SDK can be installed as a subchart using the Helm CLI or Replicated KOTS.
+
+To add and install the SDK as a subchart:
 
 1. In your application Helm chart `Chart.yaml` file, declare the SDK as a dependency:
 
-  <DependencyYaml/>
+   <DependencyYaml/>
 
-  Replicated recommends that your application is installed as a single chart that includes all necessary charts as dependencies. However, if your application is installed as multiple charts, declare the SDK as a dependency of the chart that customers install first.
+   Replicated recommends that your application is installed as a single chart that includes all necessary charts as dependencies. However, if your application is installed as multiple charts, declare the SDK as a dependency of the chart that customers install first.
 
-1. Update dependencies and package the Helm chart to a `.tgz` chart archive:
+1. (Recommended) Run the following command to log out of the Replicated registry:
 
-  ```
-  helm package . --dependency-update
-  ```
+    ```bash
+    helm registry logout registry.replicated.com
+    ```
+
+    Replicated recommends that you log out of the Replicated registry to avoid errors that can occur when Helm attempts to pull the SDK chart from the registry if you are logged in to the registry with a license that has expired. 
+
+1. Update the `charts/` directory:
+
+    ```
+    helm dependency update
+    ```
+    
+1. Package the Helm chart into a `.tgz` archive:
+
+   ```
+   helm package .
+   ```  
 
 1. Add the chart archive to a new release. For more information, see [Managing Releases with the CLI](/vendor/releases-creating-cli) or [Managing Releases with the Vendor Portal](/vendor/releases-creating-releases).
 
@@ -39,18 +53,18 @@ To install the SDK as a subchart alongside an application Helm chart:
 
 1. Confirm that the SDK was installed by seeing that the `replicated` Deployment was created:
 
-  ```
-  kubectl get deploy --namespace NAMESPACE
-  ```
-  Where `NAMESPACE` is the namespace in the cluster where the application and the SDK are installed. 
+    ```
+    kubectl get deploy --namespace NAMESPACE
+    ```
+    Where `NAMESPACE` is the namespace in the cluster where the application and the SDK are installed. 
 
-  **Example output**:
+    **Example output**:
 
-  ```
-  NAME         READY   UP-TO-DATE   AVAILABLE   AGE
-  my-app       1/1     1            1           35s
-  replicated   1/1     1            1           35s
-  ```
+    ```
+    NAME         READY   UP-TO-DATE   AVAILABLE   AGE
+    my-app       1/1     1            1           35s
+    replicated   1/1     1            1           35s
+    ```
 
 ## Install the SDK Alongside a Standard Manifest-Based Application
 
@@ -62,54 +76,54 @@ To add the SDK Helm chart to a release for a standard manifest-based application
 
 1. Install the Helm CLI using Homebrew:
 
-  ```
-  brew install helm
-  ```
-  For more information, including alternative installation options, see [Install Helm](https://helm.sh/docs/intro/install/) in the Helm documentation.
+    ```
+    brew install helm
+    ```
+    For more information, including alternative installation options, see [Install Helm](https://helm.sh/docs/intro/install/) in the Helm documentation.
 
 1. Download the `.tgz` chart archive for the SDK Helm chart:
 
-  ```
-  helm pull oci://registry.replicated.com/library/replicated --version SDK_VERSION
-  ```
-  Where `SDK_VERSION` is the version of the SDK to install. For a list of available SDK versions, see the [replicated-sdk repository](https://github.com/replicatedhq/replicated-sdk/tags) in GitHub.
+    ```
+    helm pull oci://registry.replicated.com/library/replicated --version SDK_VERSION
+    ```
+    Where `SDK_VERSION` is the version of the SDK to install. For a list of available SDK versions, see the [replicated-sdk repository](https://github.com/replicatedhq/replicated-sdk/tags) in GitHub.
 
-  The output of this command is a `.tgz` file with the naming convention `CHART_NAME-CHART_VERSION.tgz`. For example, `replicated-1.0.0-beta.13.tgz`.
+    The output of this command is a `.tgz` file with the naming convention `CHART_NAME-CHART_VERSION.tgz`. For example, `replicated-1.0.0-beta.13.tgz`.
 
-  For more information and additional options, see [Helm Pull](https://helm.sh/docs/helm/helm_pull/) in the Helm documentation.
+    For more information and additional options, see [Helm Pull](https://helm.sh/docs/helm/helm_pull/) in the Helm documentation.
 
 1. Add the SDK `.tgz` chart archive to a new release. For more information, see [Managing Releases with the CLI](/vendor/releases-creating-cli) or [Managing Releases with the Vendor Portal](/vendor/releases-creating-releases).
 
-  The following shows an example of the SDK Helm chart added to a draft release for a standard manifest-based application:
+    The following shows an example of the SDK Helm chart added to a draft release for a standard manifest-based application:
 
-  ![SDK Helm chart in a draft release](/images/sdk-kots-release.png)
-  
-  [View a larger version of this image](/images/sdk-kots-release.png)
+    ![SDK Helm chart in a draft release](/images/sdk-kots-release.png)
+    
+    [View a larger version of this image](/images/sdk-kots-release.png)
 
 1. If one was not created automatically, add a Replicated HelmChart custom resource to the release. HelmChart custom resources have `apiVersion: kots.io/v1beta2` and `kind: HelmChart`. 
 
   **Example:**
   
-  ```yaml
-  apiVersion: kots.io/v1beta2
-  kind: HelmChart
-  metadata:
-    name: replicated
-  spec:
-  # chart identifies a matching chart from a .tgz
-    chart:
-      # for name, enter replicated
+    ```yaml
+    apiVersion: kots.io/v1beta2
+    kind: HelmChart
+    metadata:
       name: replicated
-      # for chartversion, enter the version of the
-      # SDK Helm chart in the release
-      chartVersion: 1.0.0-beta.13
-  ```
+    spec:
+    # chart identifies a matching chart from a .tgz
+      chart:
+        # for name, enter replicated
+        name: replicated
+        # for chartversion, enter the version of the
+        # SDK Helm chart in the release
+        chartVersion: 1.0.0-beta.13
+    ```
 
-  As shown in the example above, the HelmChart custom resource requires the name and version of the SDK Helm chart that you added to the release:
-   * **`chart.name`**: The name of the SDK Helm chart is `replicated`. You can find the chart name in the `name` field of the SDK Helm chart `Chart.yaml` file.
-   * **`chart.chartVersion`**: The chart version varies depending on the version of the SDK that you pulled and added to the release. You can find the chart version in the `version` field of SDK Helm chart `Chart.yaml` file.
+    As shown in the example above, the HelmChart custom resource requires the name and version of the SDK Helm chart that you added to the release:
+    * **`chart.name`**: The name of the SDK Helm chart is `replicated`. You can find the chart name in the `name` field of the SDK Helm chart `Chart.yaml` file.
+    * **`chart.chartVersion`**: The chart version varies depending on the version of the SDK that you pulled and added to the release. You can find the chart version in the `version` field of SDK Helm chart `Chart.yaml` file.
 
-  For more information about configuring the HelmChart custom resource to support KOTS installations, see [About Distributing Helm Charts with KOTS](/vendor/helm-native-about) and [HelmChart v2](/reference/custom-resource-helmchart-v2).
+    For more information about configuring the HelmChart custom resource to support KOTS installations, see [About Distributing Helm Charts with KOTS](/vendor/helm-native-about) and [HelmChart v2](/reference/custom-resource-helmchart-v2).
 
 1. Save and promote the release to an internal-only channel used for testing, such as the default Unstable channel.
 
@@ -117,19 +131,19 @@ To add the SDK Helm chart to a release for a standard manifest-based application
 
 1. Confirm that the SDK was installed by seeing that the `replicated` Deployment was created:
 
-  ```
-  kubectl get deploy --namespace NAMESPACE
-  ```
-  Where `NAMESPACE` is the namespace in the cluster where the application, the admin console, and the SDK are installed. 
+    ```
+    kubectl get deploy --namespace NAMESPACE
+    ```
+    Where `NAMESPACE` is the namespace in the cluster where the application, the admin console, and the SDK are installed. 
 
-  **Example output**:
+    **Example output**:
 
-  ```
-  NAME         READY   UP-TO-DATE   AVAILABLE   AGE
-  kotsadm      1/1     1            1           112s
-  my-app       1/1     1            1           28s
-  replicated   1/1     1            1           27s
-  ```
+    ```
+    NAME         READY   UP-TO-DATE   AVAILABLE   AGE
+    kotsadm      1/1     1            1           112s
+    my-app       1/1     1            1           28s
+    replicated   1/1     1            1           27s
+    ```
 
 ## Install the SDK in Integration Mode
 

--- a/docs/vendor/replicated-sdk-installing.md
+++ b/docs/vendor/replicated-sdk-installing.md
@@ -1,5 +1,6 @@
 import DependencyYaml from "../partials/replicated-sdk/_dependency-yaml.mdx"
 import KotsVerReq from "../partials/replicated-sdk/_kots-version-req.mdx"
+import RegistryLogout from "../partials/replicated-sdk/_registry-logout.mdx"
 
 # Installing the Replicated SDK (Beta)
 
@@ -23,13 +24,7 @@ To add and install the SDK as a subchart:
 
    Replicated recommends that your application is installed as a single chart that includes all necessary charts as dependencies. However, if your application is installed as multiple charts, declare the SDK as a dependency of the chart that customers install first.
 
-1. (Recommended) Run the following command to log out of the Replicated registry:
-
-    ```bash
-    helm registry logout registry.replicated.com
-    ```
-
-    Replicated recommends that you log out of the Replicated registry to avoid errors that can occur when Helm attempts to pull the SDK chart from the registry if you are logged in with a license that has expired. 
+1. <RegistryLogout/> 
 
 1. Update the `charts/` directory:
 

--- a/docs/vendor/tutorial-config-package-chart.md
+++ b/docs/vendor/tutorial-config-package-chart.md
@@ -1,4 +1,5 @@
 import DependencyYaml from "../partials/replicated-sdk/_dependency-yaml.mdx"
+import UnauthorizedError from "../partials/replicated-sdk/_401-unauthorized.mdx"
 
 # Step 3: Package the Helm Chart
 
@@ -17,6 +18,7 @@ To add the Replicated SDK and package the Helm chart:
    ```bash
    helm package . --dependency-update
    ```
+   <UnauthorizedError/>
 
 ## Next Step
 

--- a/docs/vendor/tutorial-kots-helm-package-chart.md
+++ b/docs/vendor/tutorial-kots-helm-package-chart.md
@@ -1,4 +1,5 @@
 import DependencyYaml from "../partials/replicated-sdk/_dependency-yaml.mdx"
+import UnauthorizedError from "../partials/replicated-sdk/_401-unauthorized.mdx"
 
 # Step 3: Package the Helm Chart
 
@@ -19,6 +20,7 @@ To add the Replicated SDK and package the Helm chart:
    ```bash
    helm package . --dependency-update
    ```
+   <UnauthorizedError/>
 
 ## Next Step
 


### PR DESCRIPTION
Added a registry logout step to:
* Installing the SDK: https://deploy-preview-2002--replicated-docs.netlify.app/vendor/replicated-sdk-installing#install-the-sdk-as-a-subchart
* Packaging a Helm Chart: https://deploy-preview-2002--replicated-docs.netlify.app/vendor/helm-install-release#release

Also added a note to a couple tutorials that ask users to package a Helm chart w/ the SDK in case they run into the 401 error there. Example: https://deploy-preview-2002--replicated-docs.netlify.app/vendor/tutorial-kots-helm-package-chart