### PR TITLE
Add Google Artifact Registry and custom-id

### DIFF
--- a/docs/reference/replicated-cli-customer-create.md
+++ b/docs/reference/replicated-cli-customer-create.md
@@ -38,6 +38,11 @@ replicated customer create [Flags]
     <td>duration</td>
     <td>If set, license will expire a specified number of units from the current time. For example, <code>2h</code> or <code>1h60m</code> or <code>120m</code> are all the same duration.</td>
   </tr>
+  <tr>
+    <td><code>--custom-id</code></td>
+    <td>string</td>
+    <td>If set, this custom alphanumeric ID is associated with this customer to more easily tie this record to your external data systems (i.e. Salesforce, Hubspot, etc.) </td>
+  </tr>
   <Help/>
   <App/>
   <Token/>
@@ -45,7 +50,10 @@ replicated customer create [Flags]
 
 ## Examples
 ```bash
-replicated customer create --channel Megacorp_Beta --name "Megacorp" --ensure-channel --expires-in "8760h"
-ID                                  NAME        CHANNELS         EXPIRES                          TYPE
-2u4KGXSY65SAUW0ltG_pPhxBGPJ4XNSS    Megacorp    Megacorp_Beta    2021-01-20 00:17:38 +0000 UTC    dev
+replicated customer create --channel Megacorp_Beta --name "Megacorp" --ensure-channel --expires-in "8760h" --custom-id "salesforceid-123"
+```
+
+```bash
+ID                                  NAME        CHANNELS         EXPIRES                          TYPE    CUSTOM_ID
+2u4KGXSY65SAUW0ltG_pPhxBGPJ4XNSS    Megacorp    Megacorp_Beta    2021-01-20 00:17:38 +0000 UTC    dev     salesforceid-123
 ```

--- a/docs/reference/replicated-cli-customer-ls.md
+++ b/docs/reference/replicated-cli-customer-ls.md
@@ -29,9 +29,9 @@ List all customers:
 
 ```bash
 replicated customer ls
-ID                                  NAME                            CHANNELS         EXPIRES    TYPE
-iEgJuVDHy2pi-AqOjLXbZCTX9bqlV6YH    John Smith                      Unstable         Never      
-YAg7ripYbK0tM5MVn_81nMy0YrhBsHrm    Megacorp                        Megacorp_Beta    Never      
+ID                                  NAME                            CHANNELS         EXPIRES    TYPE    CUSTOM_ID
+iEgJuVDHy2pi-AqOjLXbZCTX9bqlV6YH    John Smith                      Unstable         Never              Not Set
+YAg7ripYbK0tM5MVn_81nMy0YrhBsHrm    Megacorp                        Megacorp_Beta    Never              salesforceid-123
 ```
 
 List customers and their instances for a specific application version:

--- a/docs/reference/replicated-cli-registry-add-gar.mdx
+++ b/docs/reference/replicated-cli-registry-add-gar.mdx
@@ -1,0 +1,47 @@
+import App from "../partials/replicated-cli/_app.mdx"
+import SkipValidation from "../partials/replicated-cli/_skip-validation.mdx"
+import Token from "../partials/replicated-cli/_token.mdx"
+import Help from "../partials/replicated-cli/_help.mdx"
+
+# registry add gar
+
+Adds a Google Artifact Registry (GAR) using a service account key or token.
+
+## Usage
+
+```bash
+replicated registry add gar [flags]
+```
+
+The following flags are supported:
+
+<table>
+  <tr>
+    <th width="30%">Flag</th>
+    <th width="20%">Type (if applicable)</th>
+    <th width="50%">Description</th>
+  </tr>
+  <App/>
+  <Help/>
+  <tr>
+    <td><code>--serviceaccountkey</code></td>
+    <td>string</td>
+    <td>The service account key to use when authenticating to the registry.</td>
+  </tr>
+  <tr>
+    <td><code>--serviceaccountkey-stdin</code></td>
+    <td></td>
+    <td>Take the service account key from stdin.</td>
+  </tr>
+  <tr>
+    <td><code>--token</code></td>
+    <td>string</td>
+    <td>The Google Cloud OAuth token to use when authenticating to the registry.</td>
+  </tr>
+  <tr>
+    <td><code>--token-stdin</code></td>
+    <td></td>
+    <td>Takes the Google Cloud OAuth token from stdin.</td>
+  </tr>
+  <SkipValidation/>
+</table>

--- a/docs/reference/replicated-cli-registry-add.mdx
+++ b/docs/reference/replicated-cli-registry-add.mdx
@@ -29,6 +29,10 @@ The following `registry add` commands are supported:
     <td>Adds an Amazon Elastic Container Registry (ECR).</td>
   </tr>
   <tr>
+    <td><a href="replicated-cli-registry-add-gar"><code>replicated registry add gar</code></a></td>
+    <td>Adds a Google Artifact Registry (GAR).</td>
+  </tr>
+  <tr>
     <td><a href="replicated-cli-registry-add-gcr"><code>replicated registry add gcr</code></a></td>
     <td>Adds a Google Container Registry (GCR).</td>
   </tr>

--- a/sidebars.js
+++ b/sidebars.js
@@ -726,6 +726,7 @@ const sidebars = {
         'reference/replicated-cli-registry-add',
         'reference/replicated-cli-registry-add-dockerhub',
         'reference/replicated-cli-registry-add-ecr',
+        'reference/replicated-cli-registry-add-gar',
         'reference/replicated-cli-registry-add-gcr',
         'reference/replicated-cli-registry-add-ghcr',
         'reference/replicated-cli-registry-add-other',


### PR DESCRIPTION
* Add Google Artifact Registry to `replicated registry add` command
    - Google Artifact Registry supports both service account and OAuth  token based authentication
    
* Updated docs for creating new customers with `--custom-id my-salesforce-id` parameter
    - Updates `replicated customer ls` to display new `CUSTOM_ID` column