### PR TITLE
Update ports in systems requirements 

### DIFF
--- a/docs/enterprise/installing-general-requirements.md
+++ b/docs/enterprise/installing-general-requirements.md
@@ -258,7 +258,7 @@ To install KOTS in an embedded cluster created by kURL, your environment must me
 * 4 CPUs or equivalent per machine
 * 8GB of RAM per machine
 * 40GB of disk space per machine
-* TCP ports 2379, 2380, 6443, 6783, 10250, 10251, and 10252 open between cluster nodes
+* TCP ports 2379, 2380, 6443, 6783, 10250, 10257, and 10259 open between cluster nodes
 * UDP port 8472 open between cluster nodes
 
   :::note

--- a/docs/enterprise/installing-general-requirements.md
+++ b/docs/enterprise/installing-general-requirements.md
@@ -258,7 +258,7 @@ To install KOTS in an embedded cluster created by kURL, your environment must me
 * 4 CPUs or equivalent per machine
 * 8GB of RAM per machine
 * 40GB of disk space per machine
-* TCP ports 2379, 2380, 6443, 6783, 10250, 10257, and 10259 open between cluster nodes
+* TCP ports 2379, 2380, 6443, 6783, and 10250 open between cluster nodes
 * UDP port 8472 open between cluster nodes
 
   :::note


### PR DESCRIPTION
Since `1.17`, the ports for the `kube-controller-manager` and `kube-scheduler` have changed. See - https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.17.md#cluster-lifecycle-1

Upstream docs - https://kubernetes.io/docs/reference/networking/ports-and-protocols/