### PR TITLE
removes note about unsupported heading config item

### DIFF
--- a/docs/reference/custom-resource-config.mdx
+++ b/docs/reference/custom-resource-config.mdx
@@ -528,8 +528,6 @@ See the [`ConfigOptionData`](template-functions-config-context#configoptiondata)
 The `heading` type allows you to display a group heading as a sub-element within a group.
 This is useful when you would like to use a config group to group items together, but still separate the items visually.
 
-**Note**: The `heading` item type is not supported.
-
 ```yaml
     - name: ldap_settings
       title: LDAP Server Settings


### PR DESCRIPTION
The `heading` config item type works as expected in KOTS. Removing this note as it was carried over from the legacy docs site and doesn't really make sense.

```
    - name: some_heading
      type: heading
      title: Heading Example
```

<img width="597" alt="Screenshot 2024-04-01 at 9 24 03 AM" src="https://github.com/replicatedhq/replicated-docs/assets/17422963/e82eb181-d4a9-4c97-b17e-b8b19d636373">
