### PR TITLE
Fix syntax error in an example

### DIFF
--- a/docs/reference/replicated-sdk-apis.md
+++ b/docs/reference/replicated-sdk-apis.md
@@ -117,7 +117,7 @@ Request:
       "name": "my-instance-name",
       "preExistingKey": "will-not-be-overwritten",
       "cpuCores": "10",
-      "supportTier": "basic",
+      "supportTier": "basic"
     }
   }
 }


### PR DESCRIPTION
A stray comma makes JSON invalid.