### PR TITLE
update static context description

### DIFF
--- a/docs/reference/template-functions-about.mdx
+++ b/docs/reference/template-functions-about.mdx
@@ -102,7 +102,7 @@ KOTS template functions are grouped into different contexts, depending on the ph
 
 ### Static Context
 
-You can use template functions in the static context in any manifest file at any time.
+The context necessary to render the Static template functions is always available.
 
 The static context also includes the Masterminds Sprig function library. For more information, see [Sprig Function Documentation](http://masterminds.github.io/sprig/) on the sprig website.
 

--- a/docs/reference/template-functions-about.mdx
+++ b/docs/reference/template-functions-about.mdx
@@ -104,7 +104,7 @@ KOTS template functions are grouped into different contexts, depending on the ph
 
 The context necessary to render the static template functions is always available.
 
-The static context includes the Masterminds Sprig function library. For more information, see [Sprig Function Documentation](http://masterminds.github.io/sprig/) on the sprig website.
+The static context also includes the Masterminds Sprig function library. For more information, see [Sprig Function Documentation](http://masterminds.github.io/sprig/) on the sprig website.
 
 For a list of all KOTS template functions available in the static context, see [Static context](template-functions-static-context).
 

--- a/docs/reference/template-functions-about.mdx
+++ b/docs/reference/template-functions-about.mdx
@@ -102,9 +102,9 @@ KOTS template functions are grouped into different contexts, depending on the ph
 
 ### Static Context
 
-The context necessary to render the Static template functions is always available.
+The context necessary to render the static template functions is always available.
 
-The static context also includes the Masterminds Sprig function library. For more information, see [Sprig Function Documentation](http://masterminds.github.io/sprig/) on the sprig website.
+The static context includes the Masterminds Sprig function library. For more information, see [Sprig Function Documentation](http://masterminds.github.io/sprig/) on the sprig website.
 
 For a list of all KOTS template functions available in the static context, see [Static context](template-functions-static-context).
 


### PR DESCRIPTION
Updates the Static Context description to be more clear about when in the application lifecycle they are available. In the case of Static template functions, they are _always_ available. The previous wording made it sound like they could be _used_ anywhere, which is not accurate since certain fields of KOTS custom resources do not support template functions.