### PR TITLE
Update EC version

### DIFF
--- a/docs/reference/embedded-config.mdx
+++ b/docs/reference/embedded-config.mdx
@@ -18,7 +18,7 @@ The embedded cluster config lets you define several aspects of the Kubernetes cl
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
 spec:
-  version: 1.29.2+ec.1
+  version: 1.29.4+ec.3
   roles:
     controller:
       name: management

--- a/docs/vendor/embedded-overview.mdx
+++ b/docs/vendor/embedded-overview.mdx
@@ -69,7 +69,7 @@ You can use the following steps to get started quickly with embedded cluster. Mo
 
 1. Create a new customer or edit an existing customer and select the **Embedded Cluster Enabled (Beta)** license option. Save the customer.
 
-1. Create a new release that includes your application. In that release, create an embedded cluster config that includes, at minimum, the embedded cluster version you want to use.
+1. Create a new release that includes your application. In that release, create an embedded cluster config that includes, at minimum, the embedded cluster version you want to use. See the embedded cluster [GitHub repo](https://github.com/replicatedhq/embedded-cluster/releases) to find the latest version.
 
      Example embedded cluster config:
 
@@ -77,7 +77,7 @@ You can use the following steps to get started quickly with embedded cluster. Mo
      apiVersion: embeddedcluster.replicated.com/v1beta1
      kind: Config
      spec:
-       version: 1.29.2+ec.4
+       version: 1.29.4+ec.3
      ```
 
 1. Save the release and promote it to the channel your customer is assigned to.


### PR DESCRIPTION
I figure we won't always keep these up to date, so I added another note about the EC releases page in GitHub. I just noticed that this is different than the wording used on the EC config page, so we could make those the same if you want. I'm obviously fine if you change the wording or the link formatting.