### PR TITLE
update kots automated release notes k8s compatibility

### DIFF
--- a/.github/workflows/app-manager-release-notes.yml
+++ b/.github/workflows/app-manager-release-notes.yml
@@ -22,7 +22,7 @@ jobs:
         owner-repo: replicatedhq/kots
         head: $KOTS_VERSION
         title: ${KOTS_VERSION#v}
-        description: 'Support for Kubernetes: 1.26, 1.27, 1.28, and 1.29'
+        description: 'Support for Kubernetes: 1.27, 1.28, 1.29, and 1.30'
         include-pr-links: false
         github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
updates the release notes automation for KOTS to drop stated support for 1.26 and add 1.30