### PR TITLE
HOLD FOR RELEASE: document builtInExtensions section for embedded cluster

### DIFF
--- a/docs/reference/embedded-config.mdx
+++ b/docs/reference/embedded-config.mdx
@@ -190,3 +190,36 @@ spec:
 ```
 
 Overrides overwrite the corresponding fields in the k0s configuration. They are not merged into embedded cluster’s default configuration. When using overrides to override a list, for example, ensure that you include other elements in the list that embedded cluster includes by default.
+
+### Overriding The Default Add-On Deployment Values
+
+:::important
+To utilize this feature, please ensure that you are using version v1.2.0 or later. If you are currently running an older version, you must first upgrade to v1.2.0 before proceeding.
+:::
+
+Each add-on deployed by the Embedded Cluster comes with a predefined set of values. In Helm terminology, these values are equivalent to those found in the `values.yaml` file used when deploying a Helm Chart.
+
+To overwrite these default values, you can use the Embedded Cluster configuration by utilizing the `builtInExtensions` property on the `unsupportedOverrides` config section. For example, if you want to override the default values for the OpenEBS add-on, you can create a configuration file like the one shown below:
+
+```yaml
+apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: Config
+metadata:
+  name: my-cluster-config
+spec:
+  version: 1.2.0+k8s-1.29
+  unsupportedOverrides:
+    builtInExtensions:
+    - name: openebs
+      values: |
+        key: value
+```
+
+In this configuration file, the fields specified in the `values` property will be merged with the Embedded Cluster default values for OpenEBS before the cluster is installed or upgraded. The `name` property indicates which add-on the values apply to. The available options for the `name` property are:
+
+- `openebs`
+- `embedded-cluster-operator`
+- `velero`
+- `admin-console`
+
+This feature allows for greater flexibility and customisation of your add-on deployments. By specifying the `builtInExtensions` property, you can ensure that your add-ons are configured exactly as needed for your specific use case.

--- a/docs/reference/embedded-config.mdx
+++ b/docs/reference/embedded-config.mdx
@@ -166,7 +166,7 @@ If an order is not provided, Helm extensions are installed with order 10. Number
 This feature should be used with caution by advanced users who understand the risks and ramifications of changing the default configuration.
 :::
 
-Unsupported overrides allow you to override embedded cluster's default configuration, including the k0s config and the Helm values for extensions like KOTS and OpenEBS. This should be used with caution because changes here are untested and can disrupt or break embedded clusters, leading to a loss of support.
+Unsupported overrides allow you to override embedded cluster's default configuration, including the k0s config and the Helm values for extensions like KOTS and OpenEBS. This should be used with caution because changes here are untested and can disrupt or break embedded clusters. Any issues that are caused by unsupported overrides are not supported.
 
 While they should be used with caution, unsupported overrides are useful if you need to make changes that are not yet otherwise exposed by embedded cluster.
 
@@ -193,13 +193,13 @@ spec:
 
 Overrides overwrite the corresponding fields in the k0s configuration. They are not merged into embedded cluster’s default configuration. When using overrides to override a list, for example, ensure that you include other elements in the list that embedded cluster includes by default.
 
-### Override the Helm Values for Built In Extensions
+### Override the Helm Values for Built-In Extensions
 
 > Introduced in embedded cluster v1.2.0.
 
-Embedded cluster deploys built in extensions like KOTS and OpenEBS to provide capabilities like storage and application management. These extensions are deployed with Helm, and the Helm values for each can be modified if necessary.
+Embedded cluster deploys built-in extensions like KOTS and OpenEBS to provide capabilities like storage and application management. These extensions are deployed with Helm, and the Helm values for each can be modified if necessary.
 
-To modify these values, you can use the `unsupportedOverrides.builtInExtensions` key of the embedded cluster config. Each chart you want to modify is an item in the array. The `name` key identifies the Helm chart that you want to modify, and the `values` key is a string where you specify your modified Helm values. Your modified values will be merged into the values used by embedded cluster.
+To modify these values, you can use the `unsupportedOverrides.builtInExtensions` key of the embedded cluster config. Each chart you want to modify is an item in the array. The `name` key identifies the Helm chart that you want to modify, and the `values` key is a string where you specify your modified Helm values. Your modified values are merged into the values used by embedded cluster.
 
 Example:
 ```yaml
@@ -216,7 +216,7 @@ spec:
         key: value
 ```
 
-The following are the built in extensions available for modification:
+The following are the built-in extensions available for modification:
 
 - `openebs`
 - `admin-console`

--- a/docs/reference/embedded-config.mdx
+++ b/docs/reference/embedded-config.mdx
@@ -163,18 +163,20 @@ If an order is not provided, Helm extensions are installed with order 10. Number
 ## Unsupported Overrides
 
 :::important
-This feature should be used with caution by advanced users knowledgeable about k0s.
+This feature should be used with caution by advanced users who understand the risks and ramifications of changing the default configuration.
 :::
 
-Unsupported overrides allow you to override the default k0s config. This should be used with caution because changes here can disrupt or break embedded clusters.
+Unsupported overrides allow you to override embedded cluster's default configuration, including the k0s config and the Helm values for extensions like KOTS and OpenEBS. This should be used with caution because changes here are untested and can disrupt or break embedded clusters, leading to a loss of support.
 
-Though somewhat dangerous, this section is useful if you need to make changes that are not yet otherwise exposed by embedded cluster.
+While they should be used with caution, unsupported overrides are useful if you need to make changes that are not yet otherwise exposed by embedded cluster.
 
-For more information on the k0s config, see [Configuration options](https://docs.k0sproject.io/head/configuration/#full-config-reference) in the k0s documentation.
+### Override the k0s Config
 
-If you need to use unsupported overrides, let Alex Parker know! These overrides are not supported by Replicated, and reasonable modifications to the k0s config will be productized and incorporated directly into the embedded cluster config instead.
+By default, embedded cluster uses a k0s config that is tested and known to work for embedded clusters. In some circumstances, you might want to change the k0s config.
 
-A common use case today is to adjust the default service port range to allow node ports on lower port numbers. This will likely be incorporated into the embedded cluster config in the future, but for now you can set it with unsupported overrides, as shown in the example below:
+For more information on the k0s config, see [Configuration options](https://docs.k0sproject.io/head/configuration/#configuration-file-reference) in the k0s documentation.
+
+A common use case today is to adjust the default service port range to allow node ports on lower port numbers, as shown in the example below:
 
 ```yaml
 apiVersion: embeddedcluster.replicated.com/v1beta1
@@ -191,16 +193,15 @@ spec:
 
 Overrides overwrite the corresponding fields in the k0s configuration. They are not merged into embedded cluster’s default configuration. When using overrides to override a list, for example, ensure that you include other elements in the list that embedded cluster includes by default.
 
-### Overriding The Default Add-On Deployment Values
+### Override the Helm Values for Built In Extensions
 
-:::important
-To utilize this feature, please ensure that you are using version v1.2.0 or later. If you are currently running an older version, you must first upgrade to v1.2.0 before proceeding.
-:::
+> Introduced in embedded cluster v1.2.0.
 
-Each add-on deployed by the Embedded Cluster comes with a predefined set of values. In Helm terminology, these values are equivalent to those found in the `values.yaml` file used when deploying a Helm Chart.
+Embedded cluster deploys built in extensions like KOTS and OpenEBS to provide capabilities like storage and application management. These extensions are deployed with Helm, and the Helm values for each can be modified if necessary.
 
-To overwrite these default values, you can use the Embedded Cluster configuration by utilizing the `builtInExtensions` property on the `unsupportedOverrides` config section. For example, if you want to override the default values for the OpenEBS add-on, you can create a configuration file like the one shown below:
+To modify these values, you can use the `unsupportedOverrides.builtInExtensions` key of the embedded cluster config. Each chart you want to modify is an item in the array. The `name` key identifies the Helm chart that you want to modify, and the `values` key is a string where you specify your modified Helm values. Your modified values will be merged into the values used by embedded cluster.
 
+Example:
 ```yaml
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
@@ -215,11 +216,9 @@ spec:
         key: value
 ```
 
-In this configuration file, the fields specified in the `values` property will be merged with the Embedded Cluster default values for OpenEBS before the cluster is installed or upgraded. The `name` property indicates which add-on the values apply to. The available options for the `name` property are:
+The following are the built in extensions available for modification:
 
 - `openebs`
-- `embedded-cluster-operator`
-- `velero`
 - `admin-console`
-
-This feature allows for greater flexibility and customisation of your add-on deployments. By specifying the `builtInExtensions` property, you can ensure that your add-ons are configured exactly as needed for your specific use case.
+- `velero`
+- `embedded-cluster-operator`

--- a/docs/vendor/embedded-overview.mdx
+++ b/docs/vendor/embedded-overview.mdx
@@ -21,6 +21,7 @@ Embedded cluster has the following requirements:
 
 * Linux operating system
 * x86-64 architecture
+* systemd
 * Embedded cluster is based on k0s, so all k0s system requirements apply. See [System requirements](https://docs.k0sproject.io/head/system-requirements/) in the k0s documentation.
 
 ### Limitations and Known Issues


### PR DESCRIPTION
document the `builtInExtensions` part of the embedded cluster configuration.