### PR TITLE
Updates Helm extension example for airgap

### DIFF
--- a/docs/reference/embedded-config.mdx
+++ b/docs/reference/embedded-config.mdx
@@ -45,8 +45,8 @@ spec:
                 nodePorts:
                   http: "80"
                   https: "443"
-              # use image tags only instead of tags + digest 
-              # so the airgap builder grabs single-arch images
+              # Known issue: Use image tags only and set digest to empty string 
+              # to ensure the airgap builder uses single-architecture images
               image:
                 digest: ""
                 digestChroot: ""

--- a/docs/reference/embedded-config.mdx
+++ b/docs/reference/embedded-config.mdx
@@ -45,6 +45,14 @@ spec:
                 nodePorts:
                   http: "80"
                   https: "443"
+              # use image tags only instead of tags + digest 
+              # so the airgap builder grabs single-arch images
+              image:
+                digest: ""
+                digestChroot: ""
+              admissionWebhooks:
+                image:
+                  digest: ""
   unsupportedOverrides:
     k0s: |
       config:


### PR DESCRIPTION
TL;DR
-----

Makes our example Helm extension work with airgap

Details
-------

Adds some values to the example configuration for the NGINX ingress
controller so that it works with our current airgap implementation.
There's a comment on the example to explain why the values need to
be set, which should help since they're set blanks to avoid the
defaults in the NGINX Ingress Controller chart.

I'm not sure the timeline for fixing the limitation of the airgap
builder where it doesn't handle multi-architecture images correctly. We
should coordinate this with @ajp-io to assure the example is updated
when the builder knows what to do with those images.
