### PR TITLE
Don't show Velero in tutorial

### DIFF
--- a/docs/vendor/tutorial-embedded-cluster-install.mdx
+++ b/docs/vendor/tutorial-embedded-cluster-install.mdx
@@ -43,7 +43,6 @@ To install the release with Embedded Cluster:
     ✔  Node installation finished
     ✔  Storage is ready!
     ✔  Embedded Cluster Operator is ready!
-    ✔  Velero is ready!
     ✔  Admin Console is ready!
     ✔  Finished!
     Visit the admin console to configure and install gitea-kite: http://104.155.145.60:30000


### PR DESCRIPTION
We stopped enabling the DR entitlement by default when you enable EC, so Velero won't get deployed in this tutorial now.