### PR TITLE
Add -f to EC curl command

### DIFF
--- a/docs/enterprise/installing-embedded-air-gap.mdx
+++ b/docs/enterprise/installing-embedded-air-gap.mdx
@@ -61,7 +61,7 @@ To install with Embedded Cluster in air gap environments:
 1. Modify the curl command provided in the first step in the **Embedded Cluster installation instructions** dialog by adding the `?airgap=true` query parameter to the end of the `replicated.app` endpoint. For example:
 
     ```bash
-    curl https://replicated.app/embedded/APP_SLUG/CHANNEL_SLUG?airgap=true -H "Authorization: LICENSE_ID" -o 	APP_SLUG-CHANNEL_SLUG.tgz
+    curl -f https://replicated.app/embedded/APP_SLUG/CHANNEL_SLUG?airgap=true -H "Authorization: LICENSE_ID" -o APP_SLUG-CHANNEL_SLUG.tgz
     ```
 
 1. Run the modified curl command on your air gapped VM to download the air gap installation artifacts.

--- a/docs/partials/embedded-cluster/_update-air-gap-admin-console.mdx
+++ b/docs/partials/embedded-cluster/_update-air-gap-admin-console.mdx
@@ -1,7 +1,7 @@
 1. On a machine with browser access (for example, where you accessed the Admin Console to configure the application), download the air gap bundle for the new version using the same curl command that you used to install. For example:
 
    ```bash
-    curl https://replicated.app/embedded/APP_SLUG/CHANNEL_SLUG?airgap=true -H "Authorization: LICENSE_ID" -o 	APP_SLUG-CHANNEL_SLUG.tgz
+    curl -f https://replicated.app/embedded/APP_SLUG/CHANNEL_SLUG?airgap=true -H "Authorization: LICENSE_ID" -o APP_SLUG-CHANNEL_SLUG.tgz
    ```
    For more information, see [Install](/enterprise/installing-embedded-air-gap#install).
 

--- a/docs/partials/embedded-cluster/_update-air-gap-cli.mdx
+++ b/docs/partials/embedded-cluster/_update-air-gap-cli.mdx
@@ -1,7 +1,7 @@
 1. SSH onto a controller node in the cluster and download the air gap bundle for the new version using the same curl command that you used to install. For example:
 
    ```bash
-    curl https://replicated.app/embedded/APP_SLUG/CHANNEL_SLUG?airgap=true -H "Authorization: LICENSE_ID" -o APP_SLUG-CHANNEL_SLUG.tgz
+    curl -f https://replicated.app/embedded/APP_SLUG/CHANNEL_SLUG?airgap=true -H "Authorization: LICENSE_ID" -o APP_SLUG-CHANNEL_SLUG.tgz
    ```
 
    For more information, see [Install](/enterprise/installing-embedded-air-gap#install).


### PR DESCRIPTION
We added `-f` to the command so that it will show the HTTP status code if the command fails.

Could update screenshots but nbd for something like this.