### PR TITLE
Doc radio and dropdown item types for config

### DIFF
--- a/docs/partials/config/_item-types.mdx
+++ b/docs/partials/config/_item-types.mdx
@@ -1,8 +1,10 @@
 - `bool`
+- `dropdown`
 - `file`
 - `heading`
 - `label`
 - `password`
-- `select_one`
+- `radio`
+- `select_one` (Deprecated)
 - `text`
 - `textarea`

--- a/docs/partials/config/_whenExample.mdx
+++ b/docs/partials/config/_whenExample.mdx
@@ -4,7 +4,7 @@
   items:
   - name: db_type
     title: Database Type
-    type: select_one
+    type: radio
     default: external
     items:
     - name: external

--- a/docs/partials/configValues/_selectOneExample.mdx
+++ b/docs/partials/configValues/_selectOneExample.mdx
@@ -1,4 +1,4 @@
 ```yaml
-select_one_config_field:
+radio_config_field:
   value: option_name
 ```

--- a/docs/partials/template-functions/_ne-comparison.mdx
+++ b/docs/partials/template-functions/_ne-comparison.mdx
@@ -20,7 +20,7 @@ spec:
       title: Ingress Type
       help_text: | 
         Select how traffic will ingress to the appliction.
-      type: select_one
+      type: radio
       items:
       - name: ingress_controller
         title: Ingress Controller
@@ -35,7 +35,7 @@ spec:
     items:
     - name: postgres_type
       help_text: Would you like to use an embedded postgres instance, or connect to an external instance that you manage?
-      type: select_one
+      type: radio
       title: Postgres
       default: embedded_postgres
       items:

--- a/docs/reference/custom-resource-config.mdx
+++ b/docs/reference/custom-resource-config.mdx
@@ -512,6 +512,29 @@ The `bool` input type should use a "0" or "1" to set the value
 
 ![Boolean selector on the configuration screen](../../static/images/config-screen-bool.png)
 
+### `dropdown`
+
+The `dropdown` item type includes one or more nested items that are displayed in a dropdown on the Admin Console config screen. Compared to displaying radio buttons with the [`radio`](#radio) item type, dropdowns are useful for long lists of options.
+
+To set a default value for `dropdown` items, set the `default` field to the name of the target nested item.
+
+```yaml
+spec:
+  groups:
+  - name: example_settings
+    title: My Example Config
+    items:
+    - name: version
+      title: Version
+      default: version_latest
+      type: dropdown
+      items:
+      - name: version_latest
+        title: latest
+      - name: version_123
+        title: 1.2.3
+```
+
 ### `file`
 A `file` is a special type of form field that renders an [`<input type="file" />`](https://www.w3schools.com/tags/tag_input.asp) HTML element.
 Only the contents of the file, not the name, are captured.
@@ -575,7 +598,34 @@ The `password` type is a text field that hides the character input.
 
 ![Password text field on the configuration screen](../../static/images/config-screen-password.png)
 
-### `select_one`
+### `radio`
+
+The `radio` item type includes one or more nested items that are displayed as radio buttons on the Admin Console config screen. Compared to displaying dropdowns with the [`dropdown`](#dropdown) item type, radio buttons are useful for short lists of options.
+
+To set a default value for `radio` items, set the `default` field to the name of the target nested item.
+
+```yaml
+spec:
+  groups:
+  - name: example_settings
+    title: My Example Config
+    items:
+    - name: authentication_type
+      title: Authentication Type
+      default: authentication_type_anonymous
+      type: radio
+      items:
+      - name: authentication_type_anonymous
+        title: Anonymous
+      - name: authentication_type_password
+        title: Password
+```
+
+### `select_one` (Deprecated)
+
+:::important
+The `select_one` item type is deprecated and is not recommended for use. To display config items with multiple options, use the [`radio`](#radio) or [`dropdown`](#dropdown) item types instead.
+:::
 
 `select_one` items must contain nested items. The nested items are displayed as radio buttons in the Admin Console.
 

--- a/docs/reference/custom-resource-config.mdx
+++ b/docs/reference/custom-resource-config.mdx
@@ -514,7 +514,7 @@ The `bool` input type should use a "0" or "1" to set the value
 
 ### `dropdown`
 
-The `dropdown` item type includes one or more nested items that are displayed in a dropdown on the Admin Console config screen. Compared to displaying radio buttons with the [`radio`](#radio) item type, dropdowns are useful for long lists of options.
+The `dropdown` item type includes one or more nested items that are displayed in a dropdown on the Admin Console config screen. Dropdowns are especially useful for displaying long lists of options. You can also use the [`radio`](#radio) item type to display radio buttons for items with shorter lists of options.
 
 To set a default value for `dropdown` items, set the `default` field to the name of the target nested item.
 
@@ -600,7 +600,7 @@ The `password` type is a text field that hides the character input.
 
 ### `radio`
 
-The `radio` item type includes one or more nested items that are displayed as radio buttons on the Admin Console config screen. Compared to displaying dropdowns with the [`dropdown`](#dropdown) item type, radio buttons are useful for short lists of options.
+The `radio` item type includes one or more nested items that are displayed as radio buttons on the Admin Console config screen. Radio buttons are especially useful for displaying short lists of options. You can also use the [`dropdown`](#dropdown) item type for items with longer lists of options.
 
 To set a default value for `radio` items, set the `default` field to the name of the target nested item.
 

--- a/docs/reference/custom-resource-config.mdx
+++ b/docs/reference/custom-resource-config.mdx
@@ -514,6 +514,8 @@ The `bool` input type should use a "0" or "1" to set the value
 
 ### `dropdown`
 
+> Introduced in KOTS v1.114.0
+
 The `dropdown` item type includes one or more nested items that are displayed in a dropdown on the Admin Console config screen. Dropdowns are especially useful for displaying long lists of options. You can also use the [`radio`](#radio) item type to display radio buttons for items with shorter lists of options.
 
 To set a default value for `dropdown` items, set the `default` field to the name of the target nested item.
@@ -533,6 +535,10 @@ spec:
         title: latest
       - name: version_123
         title: 1.2.3
+      - name: version_124
+        title: 1.2.4
+      - name: version_125
+        title: 1.2.5    
 ```
 
 ### `file`
@@ -599,6 +605,8 @@ The `password` type is a text field that hides the character input.
 ![Password text field on the configuration screen](../../static/images/config-screen-password.png)
 
 ### `radio`
+
+> Introduced in KOTS v1.114.0
 
 The `radio` item type includes one or more nested items that are displayed as radio buttons on the Admin Console config screen. Radio buttons are especially useful for displaying short lists of options. You can also use the [`dropdown`](#dropdown) item type for items with longer lists of options.
 

--- a/docs/reference/template-functions-examples.mdx
+++ b/docs/reference/template-functions-examples.mdx
@@ -39,9 +39,9 @@ spec:
   - name: example_group
     title: Example Config
     items:
-    - name: select_one_example
+    - name: radio_example
       title: Select One
-      type: select_one
+      type: radio
       items:
       - name: option_one
         title: Option One
@@ -52,7 +52,7 @@ spec:
       type: text
       # Display this item only when the customer enables the option_one config field *and*
       # has the feature-1 entitlement in their license
-      when: repl{{ and (LicenseFieldValue "feature-1" | ParseBool) (ConfigOptionEquals "select_one_example" "option_one")}}  
+      when: repl{{ and (LicenseFieldValue "feature-1" | ParseBool) (ConfigOptionEquals "radio_example" "option_one")}}  
 ```
 
 This example uses the following KOTS template functions:
@@ -102,9 +102,9 @@ spec:
   - name: example_group
     title: Example Config
     items:
-    - name: select_one_example
+    - name: radio_example
       title: Select One Example
-      type: select_one
+      type: radio
       items:
       - name: option_one
         title: Option One
@@ -118,7 +118,7 @@ spec:
       title: Conditional Item
       type: text
       # Display this item only when *both* specified config options are enabled
-      when: repl{{ and (ConfigOptionEquals "select_one_example" "option_one") (ConfigOptionEquals "boolean_example" "1")}}
+      when: repl{{ and (ConfigOptionEquals "radio_example" "option_one") (ConfigOptionEquals "boolean_example" "1")}}
 ```
 
 As shown below, when both `Option One` and `Boolean Example` are selected, the conditional statement evaluates to true and the `Conditional Item` field is displayed:

--- a/docs/vendor/config-screen-conditional.mdx
+++ b/docs/vendor/config-screen-conditional.mdx
@@ -131,7 +131,7 @@ spec:
     items:
     - name: db_type
       title: Database Type
-      type: select_one
+      type: radio
       default: external
       items:
       - name: external
@@ -178,7 +178,7 @@ spec:
       title: Ingress Type
       help_text: | 
         Select how traffic will ingress to the appliction.
-      type: select_one
+      type: radio
       items:
       - name: ingress_controller
         title: Ingress Controller
@@ -201,7 +201,7 @@ spec:
       when: 'repl{{ and (not IsKurl) (ConfigOptionEquals "ingress_type" "ingress_controller") }}'
     - name: ingress_tls_type
       title: Ingress TLS Type
-      type: select_one
+      type: radio
       items:
       - name: self_signed
         title: Self Signed (Generate Self Signed Certificate)

--- a/docs/vendor/helm-optional-charts.md
+++ b/docs/vendor/helm-optional-charts.md
@@ -41,7 +41,7 @@ To start, define the Admin Console Config page that gives the user a choice of "
           description: Database Options
           items:
             - name: postgres_type
-              type: select_one
+              type: radio
               title: Postgres
               default: embedded_postgres
               items:
@@ -61,7 +61,7 @@ To start, define the Admin Console Config page that gives the user a choice of "
     ```
 
     The YAML above does the following:
-    * Creates a `select_one` field with "Embedded Postgres" or "External Postgres" options
+    * Creates a field with "Embedded Postgres" or "External Postgres" radio buttons
     * Uses the Replicated RandomString template function to generate a unique default password for the embedded Postgres instance at installation time
     * Creates fields for the Postgres password and connection string, if the user selects the External Postgres option
 

--- a/docs/vendor/releases-configvalues.md
+++ b/docs/vendor/releases-configvalues.md
@@ -52,7 +52,7 @@ After you get the ConfigValues file for your application using the `kots get con
 
    * Write comments in the file or provide supplementary documentation to describe the following:
       * The fields that are required and optional. For any required configuration fields that do not have a default value, users must provide a value in the ConfigValues file to install the application.
-      * The supported values for each configuration field. For example, for `select_one` fields, document each of the possible values that users can provide.
+      * The supported values for each configuration field. For example, for `radio` or `dropdown` fields, document each of the possible values that users can provide.
       * The supported YAML format for each value. The following table describes the supported value format for each configuration field type:
 
         <table>
@@ -60,7 +60,7 @@ After you get the ConfigValues file for your application using the `kots get con
           <tr><td><code>bool</code></td><td><p><code>"1"</code> specifies true and <code>"0"</code> specifies false.</p><BoolExample/></td></tr>
           <tr><td><code>file</code></td><td><p>A <code>filename</code> field and a Base64 encoded string of the contents of the file in the <code>value</code> field.</p><FileExample/></td></tr>
           <tr><td><code>password</code></td><td><p>A <code>valuePlaintext</code> field that contains the password in plain text. KOTS encrypts any values in <code>valuePlaintext</code> fields during installation.</p><PasswordExample/></td></tr>
-          <tr><td><code>select_one</code></td><td><p>The <code>value</code> must match the name of one of the options for the <code>select_one</code> field as defined in the Config custom resource manifest.</p><SelectOneExample/></td></tr>
+          <tr><td><code>radio</code> and <code>dropdown</code></td><td><p>The <code>value</code> must match the name of one of the nested items for the <code>select_one</code> field as defined in the Config custom resource manifest.</p><SelectOneExample/></td></tr>
           <tr><td><code>text</code></td><td><p>Plain text in the <code>value</code> field.</p><TextExample/></td></tr>
           <tr><td><code>textarea</code></td><td><p>Plain text in the <code>value</code> field.</p><TextAreaExample/></td></tr>
         </table>

--- a/docs/vendor/tutorial-adding-db-config.md
+++ b/docs/vendor/tutorial-adding-db-config.md
@@ -182,7 +182,7 @@ spec:
       items:
         - name: postgres_type
           help_text: Would you like to use an embedded postgres instance, or connect to an external instance that you manage?
-          type: select_one
+          type: radio
           title: Postgres
           default: embedded_postgres
           items:
@@ -486,7 +486,7 @@ spec:
       items:
         - name: postgres_type
           help_text: Would you like to use an embedded postgres instance, or connect to an external instance that you manage?
-          type: select_one
+          type: radio
           title: Postgres
           default: embedded_postgres
           items:


### PR DESCRIPTION
- [dropdown](https://deploy-preview-2564--replicated-docs-upgrade.netlify.app/reference/custom-resource-config#dropdown)
- [radio](https://deploy-preview-2564--replicated-docs-upgrade.netlify.app/reference/custom-resource-config#radio)
- Marked select_one as deprecated: https://deploy-preview-2564--replicated-docs-upgrade.netlify.app/reference/custom-resource-config#select_one-deprecated
- Updated various examples to use radio instead of select_one. For example: https://deploy-preview-2564--replicated-docs-upgrade.netlify.app/vendor/config-screen-conditional#embedded-cluster-distribution-check and https://deploy-preview-2564--replicated-docs-upgrade.netlify.app/reference/template-functions-examples#boolean-comparison