### PR TITLE
HOLD FOR RELEASE: Replicated SDK no longer uses v to prefix versions

### DIFF
--- a/.github/workflows/replicated-sdk-release-notes.yml
+++ b/.github/workflows/replicated-sdk-release-notes.yml
@@ -24,8 +24,8 @@ jobs:
       uses: replicatedhq/release-notes-generator@main
       with:
         owner-repo: replicatedhq/replicated-sdk
-        base: v$PREV_REPLICATED_SDK_VERSION
-        head: v$REPLICATED_SDK_VERSION
+        base: $PREV_REPLICATED_SDK_VERSION
+        head: $REPLICATED_SDK_VERSION
         title: $REPLICATED_SDK_VERSION
         include-pr-links: false
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/reference/template-functions-examples.mdx
+++ b/docs/reference/template-functions-examples.mdx
@@ -209,9 +209,9 @@ spec:
     images:
       replicated-sdk: >-
         {{repl if HasLocalRegistry -}}
-          {{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/replicated-sdk:v1.0.0-beta.22
+          {{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/replicated-sdk:1.0.0-beta.29
         {{repl else -}}
-          docker.io/replicated/replicated-sdk:v1.0.0-beta.22
+          docker.io/replicated/replicated-sdk:1.0.0-beta.29
         {{repl end}}
 ```
 
@@ -221,7 +221,7 @@ Given the example above, if the user is _not_ using a local registry, then the `
 # Helm chart values file
 
 images:
-  replicated-sdk: 'docker.io/replicated/replicated-sdk:v1.0.0-beta.22'
+  replicated-sdk: 'docker.io/replicated/replicated-sdk:1.0.0-beta.29'
 ```
 
 #### Multi-Line in Secret Object


### PR DESCRIPTION
Replicated SDK releases will no longer use `v` prefix in version tags