### PR TITLE
Bumps the SDK version

### DIFF
--- a/docs/partials/replicated-sdk/_dependency-yaml.mdx
+++ b/docs/partials/replicated-sdk/_dependency-yaml.mdx
@@ -3,7 +3,7 @@
 dependencies:
 - name: replicated
   repository: oci://registry.replicated.com/library
-  version: 1.0.0-beta.29
+  version: 1.0.0-beta.31
 ```
 
 For the latest version information for the Replicated SDK, see the [replicated-sdk repository](https://github.com/replicatedhq/replicated-sdk/tags) in GitHub.


### PR DESCRIPTION
Updates to the latest SDK version to avoid including a critical CVE