### PR TITLE
Update kURL to clarify version expectation

### DIFF
--- a/docs/vendor/testing-supported-clusters.md
+++ b/docs/vendor/testing-supported-clusters.md
@@ -267,7 +267,7 @@ Compatibility Matrix supports creating [kURL](https://kurl.sh) clusters.
   </tr>
   <tr>
     <th>Supported kURL Versions</th>
-    <td>Any promoted kURL installer. For an installer version other than "latest", the installer version ID for previously released installers can be found on the kURL Installer history page under Channels.</td>
+    <td>Any promoted kURL installer. For an installer version other than "latest", you can find the ID for previously promoted installers on the **Channels > kURL Installer history** page in the Vendor Portal. For more information about viewing the history of kURL installers promoted to a channel, see [Installer History](/vendor/installer-history).</td>
   </tr>
   <tr>
     <th>Supported Instance Types</th>

--- a/docs/vendor/testing-supported-clusters.md
+++ b/docs/vendor/testing-supported-clusters.md
@@ -267,7 +267,7 @@ Compatibility Matrix supports creating [kURL](https://kurl.sh) clusters.
   </tr>
   <tr>
     <th>Supported kURL Versions</th>
-    <td>Any kURL installer ID. For more information, see <a href="/vendor/packaging-embedded-kubernetes">Creating a kURL installer</a>.</td>
+    <td>Any promoted kURL installer. For an installer version other than "latest", the installer version ID for previously released installers can be found on the kURL Installer history page under Channels.</td>
   </tr>
   <tr>
     <th>Supported Instance Types</th>

--- a/docs/vendor/testing-supported-clusters.md
+++ b/docs/vendor/testing-supported-clusters.md
@@ -267,7 +267,7 @@ Compatibility Matrix supports creating [kURL](https://kurl.sh) clusters.
   </tr>
   <tr>
     <th>Supported kURL Versions</th>
-    <td>Any promoted kURL installer. For an installer version other than "latest", you can find the ID for previously promoted installers on the **Channels > kURL Installer history** page in the Vendor Portal. For more information about viewing the history of kURL installers promoted to a channel, see [Installer History](/vendor/installer-history).</td>
+    <td>Any promoted kURL installer. For an installer version other than "latest", you can find the ID for previously promoted installers on the **Channels > kURL Installer History** page in the Vendor Portal. For more information about viewing the history of kURL installers promoted to a channel, see [Installer History](/vendor/installer-history).</td>
   </tr>
   <tr>
     <th>Supported Instance Types</th>


### PR DESCRIPTION
The current link to "creating a kURL installer" doesn't actually help me find the info I need. I need the kURL installer ID slug. Outside of trying to use kURL.sh to get this ID, I need to go find it in my installers history. Still not the easiest to discover ,but a small improvement towards pointing me in the right direction. 

I'm not sure if this page is deep linkable or not since it's context specific, but this is an example of what the URL for the right page looks like https://vendor.replicated.com/apps/{app-id}/channels/{channel-id)/kubernetes-installers?page=0