### PR TITLE
add `cluster shell` doc page

### DIFF
--- a/docs/reference/replicated-cli-cluster-shell.mdx
+++ b/docs/reference/replicated-cli-cluster-shell.mdx
@@ -1,0 +1,45 @@
+# cluster shell
+
+Opens a new shell session with the kubeconfig configured for the specified cluster. This allows you to have immediate kubectl access to the cluster within the shell environment.
+
+You can either specify the cluster ID directly or provide the cluster name to resolve the corresponding cluster ID. The shell will inherit your existing environment and add the necessary kubeconfig context for interacting with the Kubernetes cluster.
+
+Once inside the shell, you can use 'kubectl' to interact with the cluster. To exit the shell, press Ctrl-D or type 'exit'. When the shell closes, the kubeconfig will be reset back to your default configuration.
+
+## Usage
+
+```bash
+replicated cluster shell [ID] [flags]
+```
+
+<table>
+  <tr>
+    <th width="30%">Flag</th>
+    <th width="20%">Type (if applicable)</th>
+    <th width="50%">Description</th>
+  </tr>
+  <Help/>
+  <tr>
+    <td>--id</td>
+    <td>string</td>
+    <td>ID of the cluster to have kubectl access to (when name is not provided)</td>
+  </tr>
+  <tr>
+    <td>--name</td>
+    <td>string</td>
+    <td>Name of the cluster to have kubectl access to.</td>
+  </tr>
+</table>
+
+## Examples
+
+Example:
+```bash
+# Open a shell for a cluster by ID
+replicated cluster shell CLUSTER_ID
+```
+
+```bash
+# Open a shell for a cluster by name
+replicated cluster shell --name "My Cluster"
+```

--- a/docs/reference/replicated-cli-cluster-shell.mdx
+++ b/docs/reference/replicated-cli-cluster-shell.mdx
@@ -38,7 +38,7 @@ replicated cluster shell [ID] [flags]
 Example:
 ```bash
 # Open a shell for a cluster by ID
-replicated cluster shell CLUSTER_ID
+replicated cluster shell 89be02de
 ```
 
 ```bash

--- a/docs/reference/replicated-cli-cluster-shell.mdx
+++ b/docs/reference/replicated-cli-cluster-shell.mdx
@@ -35,7 +35,6 @@ replicated cluster shell [ID] [flags]
 
 ## Examples
 
-Example:
 ```bash
 # Open a shell for a cluster by ID
 replicated cluster shell 89be02de

--- a/docs/reference/replicated-cli-cluster-shell.mdx
+++ b/docs/reference/replicated-cli-cluster-shell.mdx
@@ -1,3 +1,5 @@
+import Help from "../partials/replicated-cli/_help.mdx"
+
 # cluster shell
 
 Opens a new shell session with the kubeconfig configured for the specified cluster. This allows you to have immediate kubectl access to the cluster within the shell environment.

--- a/docs/vendor/testing-how-to.md
+++ b/docs/vendor/testing-how-to.md
@@ -206,18 +206,22 @@ To access a cluster from the command line:
    ```
    In the output of the command, verify that the `STATUS` for the target cluster is `running`. For command usage, see [cluster ls](/reference/replicated-cli-cluster-ls).
 
-1. Run the following command to download the kubeconfig for the cluster and update Kubernetes context:
+1. Run the following command to open a new shell session with the kubeconfig configured for the specified cluster:
 
    ```bash
-   replicated cluster kubeconfig CLUSTER_ID
-   ```
-   When the command completes, a `Updated kubernetes context` message is displayed. For command usage, see [cluster kubeconfig](/reference/replicated-cli-cluster-kubeconfig).
+   replicated cluster shell CLUSTER_ID
+   ``` 
+   Where CLUSTER_ID is the unique ID for the cluster.
+
+   For command usage, see [cluster shell](/reference/replicated-cli-cluster-shell).
 
 1. Verify that you can interact with the cluster through kubectl by running a command. For example:
 
    ```bash
    kubectl get ns
    ```
+
+1. Press Ctrl-D or type `exit` when done to end the shell and the connection to the server.
 
 ### Upgrade Clusters (kURL Only)
 

--- a/docs/vendor/testing-how-to.md
+++ b/docs/vendor/testing-how-to.md
@@ -212,7 +212,7 @@ To access a cluster from the command line:
    ```bash
    replicated cluster shell CLUSTER_ID
    ``` 
-   Where CLUSTER_ID is the unique ID for the running cluster that you want to access.
+   Where `CLUSTER_ID` is the unique ID for the running cluster that you want to access.
 
    For command usage, see [cluster shell](/reference/replicated-cli-cluster-shell).
 

--- a/docs/vendor/testing-how-to.md
+++ b/docs/vendor/testing-how-to.md
@@ -193,6 +193,7 @@ The `cluster prepare` command requires either a Helm chart archive or a director
     ```
 
 For command usage, including additional options, see [cluster prepare](/reference/replicated-cli-cluster-prepare).
+
 ### Access Clusters
 
 Compatibility Matrix provides the kubeconfig for clusters so that you can access clusters with the kubectl command line tool. For more information, see [Command line tool (kubectl)](https://kubernetes.io/docs/reference/kubectl/) in the Kubernetes documentation.
@@ -206,12 +207,12 @@ To access a cluster from the command line:
    ```
    In the output of the command, verify that the `STATUS` for the target cluster is `running`. For command usage, see [cluster ls](/reference/replicated-cli-cluster-ls).
 
-1. Run the following command to open a new shell session with the kubeconfig configured for the specified cluster:
+1. Run the following command to open a new shell session with the kubeconfig configured for the cluster:
 
    ```bash
    replicated cluster shell CLUSTER_ID
    ``` 
-   Where CLUSTER_ID is the unique ID for the cluster.
+   Where CLUSTER_ID is the unique ID for the running cluster that you want to access.
 
    For command usage, see [cluster shell](/reference/replicated-cli-cluster-shell).
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -661,6 +661,7 @@ const sidebars = {
       'reference/replicated-cli-cluster-port-ls',
       'reference/replicated-cli-cluster-port-rm',
       'reference/replicated-cli-cluster-rm',
+      'reference/replicated-cli-cluster-shell',
       'reference/replicated-cli-cluster-update-ttl',
       'reference/replicated-cli-cluster-upgrade',
       'reference/replicated-cli-cluster-versions',


### PR DESCRIPTION
New `cluster shell` reference topic: https://deploy-preview-2784--replicated-docs-upgrade.netlify.app/reference/replicated-cli-cluster-shell

Updated the "Access Cluster" steps to describe using `cluster shell` instead of `cluster kubeconfig`: https://deploy-preview-2784--replicated-docs-upgrade.netlify.app/vendor/testing-how-to#access-clusters

Note: The `cluster kubeconfig` method of accessing clusters is still referenced in the CI/CD topics: https://docs.replicated.com/vendor/ci-workflows

