### PR TITLE
Documents limitation on policy enforcement

### DIFF
--- a/docs/vendor/embedded-overview.mdx
+++ b/docs/vendor/embedded-overview.mdx
@@ -75,7 +75,7 @@ Embedded Cluster has the following limitations:
 
 * **Templating not supported in Embedded Cluster Config**: The [Embedded Cluster Config](/reference/embedded-config) resource does not support the use of Go template functions, including [KOTS template functions](/reference/template-functions-about).
 
-* **Policy enforcement on Embedded Cluster workloads is not supported**: The Embedded Cluster runs workloads that require higher levels of privilege. If your application installs a policy enforcement engine such as Gatekeeper or Kyverno, ensure that your application does not enforce the policy in the namespaces used by Embedded Cluster.
+* **Policy enforcement on Embedded Cluster workloads is not supported**: The Embedded Cluster runs workloads that require higher levels of privilege. If your application installs a policy enforcement engine such as Gatekeeper or Kyverno, ensure that the policy is not enforced in the namespaces used by Embedded Cluster.
 
 ## Quick Start
 

--- a/docs/vendor/embedded-overview.mdx
+++ b/docs/vendor/embedded-overview.mdx
@@ -75,7 +75,7 @@ Embedded Cluster has the following limitations:
 
 * **Templating not supported in Embedded Cluster Config**: The [Embedded Cluster Config](/reference/embedded-config) resource does not support the use of Go template functions, including [KOTS template functions](/reference/template-functions-about).
 
-* **Policy enforcement on Embedded Cluster workloads is not supported**: The Embedded Cluster runs workloads that require higher levels of privilege. If your application installs a policy enforcement engine such as Gatekeeper or Kyverno, ensure that the policy is not enforced in the namespaces used by Embedded Cluster.
+* **Policy enforcement on Embedded Cluster workloads is not supported**: The Embedded Cluster runs workloads that require higher levels of privilege. If your application installs a policy enforcement engine such as Gatekeeper or Kyverno, ensure that its policies are not enforced in the namespaces used by Embedded Cluster.
 
 ## Quick Start
 

--- a/docs/vendor/embedded-overview.mdx
+++ b/docs/vendor/embedded-overview.mdx
@@ -75,7 +75,7 @@ Embedded Cluster has the following limitations:
 
 * **Templating not supported in Embedded Cluster Config**: The [Embedded Cluster Config](/reference/embedded-config) resource does not support the use of Go template functions, including [KOTS template functions](/reference/template-functions-about).
 
-* **Policy enforcement on Embedded Cluster workloads is not supported**: The Embedded Cluster runs workloads that required higher levels of privilege. If you application installs a policy enforcement engine such as Gatekeeper or Kyverno it should not enforce policy in the namespaces used by the embedded cluster.
+* **Policy enforcement on Embedded Cluster workloads is not supported**: The Embedded Cluster runs workloads that require higher levels of privilege. If your application installs a policy enforcement engine such as Gatekeeper or Kyverno, ensure that your application does not enforce the policy in the namespaces used by Embedded Cluster.
 
 ## Quick Start
 

--- a/docs/vendor/embedded-overview.mdx
+++ b/docs/vendor/embedded-overview.mdx
@@ -75,6 +75,8 @@ Embedded Cluster has the following limitations:
 
 * **Templating not supported in Embedded Cluster Config**: The [Embedded Cluster Config](/reference/embedded-config) resource does not support the use of Go template functions, including [KOTS template functions](/reference/template-functions-about).
 
+* **Policy enforcement on Embedded Cluster workloads is not supported**: The Embedded Cluster runs workloads that required higher levels of privilege. If you application installs a policy enforcement engine such as Gatekeeper or Kyverno it should not enforce policy in the namespaces used by the embedded cluster.
+
 ## Quick Start
 
 You can use the following steps to get started quickly with Embedded Cluster. More detailed documentation is available below.


### PR DESCRIPTION
TL;DR
-----

Documents limitation on policy enforcement

Details
-------

This change documents that Embedded Cluster does not support enforcing policy on the workloads run by the embedded cluster. This may not be a common use case, so it may not make sense to add this change. I'm suggesting it and asking @ajp-io and @chris-sanders to take a look.