### PR TITLE
Updating EC install experience in Admin Console

### DIFF
--- a/docs/enterprise/installing-embedded-air-gap.mdx
+++ b/docs/enterprise/installing-embedded-air-gap.mdx
@@ -113,29 +113,23 @@ To install with Embedded Cluster in an air gap environment:
     ```
     At this point, the cluster is provisioned and the KOTS Admin Console is deployed, but the application is not yet installed.
 
-1. Bypass the browser TLS warning by clicking **Continue to Setup**.
+1. On the Admin Console landing page, click **Start**.
 
-1. Click **Advanced > Proceed**.
+1. On the **Secure the Admin Console** screen, click **Continue**. In your browser, click **Advanced > Proceed** to bypass the TLS warning.
 
-1. On the HTTPS page, upload your own private key and certificacte or select **Self-signed**.
+1. On the **Certificate type** screen, either select **Self-signed** to continue using the self-signed Admin Console certificate or click **Upload your own** to upload your own private key and certificacte.
 
     By default, a self-signed TLS certificate is used to secure communication between your browser and the Admin Console. You will see a warning in your browser every time you access the Admin Console unless you upload your own certificate.
 
 1. On the login page, enter the Admin Console password that you created during installation and click **Log in**.
 
-1. On the **Nodes** page, you can view details about the machine where you installed, including its node role, status, CPU, and memory. Optionally, add nodes before deploying the application. Click **Continue**.
+1. On the **Configure the cluster** screen, optionally add nodes to the cluster before deploying the application. Click **Continue**.
 
-1. On the config screen, complete the fields for the application configuration options and then click **Continue**.
+1. On the **Configure [App Name]** screen, complete the fields for the application configuration options. Click **Continue**.
 
-1. On the **Preflight checks** page, the application-specific preflight checks run automatically. Preflight checks  are conformance tests that run against the target namespace and cluster to ensure that the environment meets the minimum requirements to support the application. Click **Deploy**.
+1. On the **Validate the environment & deploy [App Name]** screen, address any warnings or failures identified by the preflight checks and then click **Deploy**.
 
-    :::note
-    Replicated recommends that you address any warnings or failures, rather than dismissing them. Preflight checks help ensure that your environment meets the requirements for application deployment.
-    :::
-
-    :::note
-    If the application does not include preflight checks, you need to click **Deploy** then **Yes, Deploy** next to the target version on the Admin Console dashboard to install.
-    :::  
+    Preflight checks are conformance tests that run against the target namespace and cluster to ensure that the environment meets the minimum requirements to support the application.
 
 The Admin Console dashboard opens.
 
@@ -143,7 +137,7 @@ On the Admin Console dashboard, the application status changes from Missing to U
 
 ![Admin console dashboard showing ready status](/images/gitea-ec-ready.png)
 
-[View a larger version of this image](/images/gitea-ec-ready.png) 
+[View a larger version of this image](/images/gitea-ec-ready.png)
 
 ## Add Nodes to Air Gap Clusters
 

--- a/docs/enterprise/installing-embedded-air-gap.mdx
+++ b/docs/enterprise/installing-embedded-air-gap.mdx
@@ -115,7 +115,7 @@ To install with Embedded Cluster in an air gap environment:
 
 1. On the Admin Console landing page, click **Start**.
 
-1. On the **Secure the Admin Console** screen, click **Continue**. In your browser, click **Advanced > Proceed** to bypass the TLS warning.
+1. On the **Secure the Admin Console** screen, review the instructions and click **Continue**. In your browser, follow the instructions that were provided on the **Secure the Admin Console** screen to bypass the warning.
 
 1. On the **Certificate type** screen, either select **Self-signed** to continue using the self-signed Admin Console certificate or click **Upload your own** to upload your own private key and certificacte.
 

--- a/docs/enterprise/installing-embedded-air-gap.mdx
+++ b/docs/enterprise/installing-embedded-air-gap.mdx
@@ -94,24 +94,24 @@ To install with Embedded Cluster in an air gap environment:
 
      The installation command takes a few minutes to complete. During installation, Embedded Cluster completes tasks to prepare the cluster and install KOTS in the cluster. Embedded Cluster also automatically runs a default set of [_host preflight checks_](/vendor/embedded-overview#about-host-preflight-checks) which verify that the environment meets the requirements for the installer.
 
-1. When the installation command completes, go to the URL provided in the output to access the Admin Console.
-     
-    **Example output:** 
+      **Example output:**
 
-    ```bash
-    ✔  Host files materialized
-    ? Enter an Admin Console password: ********
-    ? Confirm password: ********
-    ✔  Host files materialized!
-    ✔  Host preflights succeeded!
-    ✔  Node installation finished!
-    ✔  Storage is ready!
-    ✔  Embedded Cluster Operator is ready!
-    ✔  Admin Console is ready!
-    ✔  Additional components are ready!
-    Visit the admin console to configure and install gitea-kite: http://104.155.145.60:30000
-    ```
-    At this point, the cluster is provisioned and the KOTS Admin Console is deployed, but the application is not yet installed.
+      ```bash
+      ? Enter an Admin Console password: ********
+      ? Confirm password: ********
+      ✔  Host files materialized!
+      ✔  Running host preflights
+      ✔  Node installation finished!
+      ✔  Storage is ready!
+      ✔  Embedded Cluster Operator is ready!
+      ✔  Admin Console is ready!
+      ✔  Additional components are ready!
+      Visit the Admin Console to configure and install gitea-kite: http://104.155.145.60:30000
+      ```
+
+      At this point, the cluster is provisioned and the Admin Console is deployed, but the application is not yet installed.
+
+1. Go to the URL provided in the output to access to the Admin Console.
 
 1. On the Admin Console landing page, click **Start**.
 

--- a/docs/enterprise/installing-embedded.mdx
+++ b/docs/enterprise/installing-embedded.mdx
@@ -77,7 +77,7 @@ To install an application with Embedded Cluster:
 
 1. On the Admin Console landing page, click **Start**.
 
-1. On the **Secure the Admin Console** screen, click **Continue**. In your browser, click **Advanced > Proceed** to bypass the TLS warning.
+1. On the **Secure the Admin Console** screen, review the instructions and click **Continue**. In your browser, follow the instructions that were provided on the **Secure the Admin Console** screen to bypass the warning.
 
 1. On the **Certificate type** screen, either select **Self-signed** to continue using the self-signed Admin Console certificate or click **Upload your own** to upload your own private key and certificacte.
 

--- a/docs/enterprise/installing-embedded.mdx
+++ b/docs/enterprise/installing-embedded.mdx
@@ -89,11 +89,9 @@ To install an application with Embedded Cluster:
 
 1. On the config screen, complete the fields for the application configuration options and then click **Continue**.
 
-1. On the **Validate the environment & deploy** screen, the application-specific preflight checks run automatically. Preflight checks  are conformance tests that run against the target namespace and cluster to ensure that the environment meets the minimum requirements to support the application. Click **Deploy**.
+1. On the **Validate the environment & deploy** screen, address any warnings or failures identified by the preflight checks and then click **Deploy**.
 
-    :::note
-    Replicated recommends that you address any warnings or failures, rather than dismissing them. Preflight checks help ensure that your environment meets the requirements for application deployment.
-    :::
+    The preflight checks on the **Validate the environment & deploy** screen are  application-specific and run automatically. Preflight checks are conformance tests that run against the target namespace and cluster to ensure that the environment meets the minimum requirements to support the application.
 
     :::note
     If the application does not include preflight checks, next to the target version on the dashboard, click **Deploy** then **Yes, Deploy** to install the application.

--- a/docs/enterprise/installing-embedded.mdx
+++ b/docs/enterprise/installing-embedded.mdx
@@ -56,24 +56,24 @@ To install an application with Embedded Cluster:
 
      The installation command takes a few minutes to complete. During installation, Embedded Cluster completes tasks to prepare the cluster and install KOTS in the cluster. Embedded Cluster also automatically runs a default set of [_host preflight checks_](/vendor/embedded-overview#about-host-preflight-checks) which verify that the environment meets the requirements for the installer.
 
-1. When the installation command completes, go to the URL provided in the output to access the Admin Console.
-     
-    **Example output:** 
+      **Example output:**
 
-    ```bash
-    ✔  Host files materialized
-    ? Enter an Admin Console password: ********
-    ? Confirm password: ********
-    ✔  Host files materialized!
-    ✔  Host preflights succeeded!
-    ✔  Node installation finished!
-    ✔  Storage is ready!
-    ✔  Embedded Cluster Operator is ready!
-    ✔  Admin Console is ready!
-    ✔  Additional components are ready!
-    Visit the admin console to configure and install gitea-kite: http://104.155.145.60:30000
-    ```
-    At this point, the cluster is provisioned and the KOTS Admin Console is deployed, but the application is not yet installed.
+      ```bash
+      ? Enter an Admin Console password: ********
+      ? Confirm password: ********
+      ✔  Host files materialized!
+      ✔  Running host preflights
+      ✔  Node installation finished!
+      ✔  Storage is ready!
+      ✔  Embedded Cluster Operator is ready!
+      ✔  Admin Console is ready!
+      ✔  Additional components are ready!
+      Visit the Admin Console to configure and install gitea-kite: http://104.155.145.60:30000
+      ```
+
+      At this point, the cluster is provisioned and the Admin Console is deployed, but the application is not yet installed.
+
+1. Go to the URL provided in the output to access to the Admin Console.
 
 1. On the Admin Console landing page, click **Start**.
 

--- a/docs/enterprise/installing-embedded.mdx
+++ b/docs/enterprise/installing-embedded.mdx
@@ -75,21 +75,21 @@ To install an application with Embedded Cluster:
     ```
     At this point, the cluster is provisioned and the KOTS Admin Console is deployed, but the application is not yet installed.
 
-1. Bypass the browser TLS warning by clicking **Continue to Setup**.
+1. On the Admin Console landing page, click **Start**.
 
-1. Click **Advanced > Proceed**.
+1. On the **Secure the Admin Console** screen, click **Continue**. In your browser, click **Advanced > Proceed** to bypass the TLS warning.
 
-1. On the HTTPS page, upload your own private key and certificacte or select **Self-signed**.
+1. On the **Certificate type** screen, either select **Self-signed** to continue using the self-signed Admin Console certificate or click **Upload your own** to upload your own private key and certificacte.
 
     By default, a self-signed TLS certificate is used to secure communication between your browser and the Admin Console. You will see a warning in your browser every time you access the Admin Console unless you upload your own certificate.
 
 1. On the login page, enter the Admin Console password that you created during installation and click **Log in**.
 
-1. On the **Nodes** page, you can view details about the VM where you installed, including its node role, status, CPU, and memory. Optionally, add nodes before deploying the application. Click **Continue**.
+1. On the **Configure the cluster** screen, you can view details about the VM where you installed, including its node role, status, CPU, and memory. Optionally, add nodes to the cluster before deploying the application. Click **Continue**.
 
 1. On the config screen, complete the fields for the application configuration options and then click **Continue**.
 
-1. On the **Preflight checks** page, the application-specific preflight checks run automatically. Preflight checks  are conformance tests that run against the target namespace and cluster to ensure that the environment meets the minimum requirements to support the application. Click **Deploy**.
+1. On the **Validate the environment & deploy** screen, the application-specific preflight checks run automatically. Preflight checks  are conformance tests that run against the target namespace and cluster to ensure that the environment meets the minimum requirements to support the application. Click **Deploy**.
 
     :::note
     Replicated recommends that you address any warnings or failures, rather than dismissing them. Preflight checks help ensure that your environment meets the requirements for application deployment.

--- a/docs/enterprise/installing-embedded.mdx
+++ b/docs/enterprise/installing-embedded.mdx
@@ -85,17 +85,13 @@ To install an application with Embedded Cluster:
 
 1. On the login page, enter the Admin Console password that you created during installation and click **Log in**.
 
-1. On the **Configure the cluster** screen, you can view details about the VM where you installed, including its node role, status, CPU, and memory. Optionally, add nodes to the cluster before deploying the application. Click **Continue**.
+1. On the **Configure the cluster** screen, optionally add nodes to the cluster before deploying the application. Click **Continue**.
 
-1. On the config screen, complete the fields for the application configuration options and then click **Continue**.
+1. On the **Configure [App Name]** screen, complete the fields for the application configuration options. Click **Continue**.
 
-1. On the **Validate the environment & deploy** screen, address any warnings or failures identified by the preflight checks and then click **Deploy**.
+1. On the **Validate the environment & deploy [App Name]** screen, address any warnings or failures identified by the preflight checks and then click **Deploy**.
 
-    The preflight checks on the **Validate the environment & deploy** screen are  application-specific and run automatically. Preflight checks are conformance tests that run against the target namespace and cluster to ensure that the environment meets the minimum requirements to support the application.
-
-    :::note
-    If the application does not include preflight checks, next to the target version on the dashboard, click **Deploy** then **Yes, Deploy** to install the application.
-    :::
+    Preflight checks are conformance tests that run against the target namespace and cluster to ensure that the environment meets the minimum requirements to support the application.
 
 The Admin Console dashboard opens.
 

--- a/docs/partials/embedded-cluster/_ec-config.mdx
+++ b/docs/partials/embedded-cluster/_ec-config.mdx
@@ -2,5 +2,5 @@
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
 spec:
-  version: 1.16.0+k8s-1.30
+  version: 1.17.0+k8s-1.30
 ```

--- a/docs/partials/getting-started/_gitea-ec-config.mdx
+++ b/docs/partials/getting-started/_gitea-ec-config.mdx
@@ -2,5 +2,5 @@
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
 spec:
-  version: 1.16.0+k8s-1.30
+  version: 1.17.0+k8s-1.30
 ```

--- a/docs/reference/embedded-config.mdx
+++ b/docs/reference/embedded-config.mdx
@@ -24,7 +24,7 @@ For additional property-specific limitations, see the sections below.
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
 spec:
-  version: 1.16.0+k8s-1.30
+  version: 1.17.0+k8s-1.30
   roles:
     controller:
       name: management

--- a/docs/vendor/quick-start.mdx
+++ b/docs/vendor/quick-start.mdx
@@ -244,7 +244,7 @@ Before you begin, ensure that you have access to a VM that meets the requirement
    
    1. On the Admin Console landing page, click **Start**.
 
-   1. On the **Secure the Admin Console** screen, click **Continue**. In your browser, click **Advanced > Proceed** to bypass the TLS warning.
+   1. On the **Secure the Admin Console** screen, review the instructions and click **Continue**. In your browser, follow the instructions that were provided on the **Secure the Admin Console** screen to bypass the warning.
 
    1. On the **Certificate type** screen, either select **Self-signed** to continue using the self-signed Admin Console certificate or click **Upload your own** to upload your own private key and certificacte.
 

--- a/docs/vendor/quick-start.mdx
+++ b/docs/vendor/quick-start.mdx
@@ -254,7 +254,11 @@ Before you begin, ensure that you have access to a VM that meets the requirement
 
    1. On the **Configure the cluster** screen, you can view details about the VM where you installed, including its node role, status, CPU, and memory. Users can also optionally add additional nodes on this page before deploying the application. Click **Continue**. 
 
-      On the Admin Console dashboard, the application status changes from Missing to Unavailable while the `gitea` Deployment is being created.
+       The Admin Console dashboard opens.
+
+   1. On the Admin Console dashboard, next to the version, click **Deploy** and then **Yes, Deploy**. 
+
+      The application status changes from Missing to Unavailable while the `gitea` Deployment is being created.
 
    1. After a few minutes when the application status is Ready, click **Open App** to view the Gitea application in a browser.
    

--- a/docs/vendor/quick-start.mdx
+++ b/docs/vendor/quick-start.mdx
@@ -242,21 +242,19 @@ Before you begin, ensure that you have access to a VM that meets the requirement
 
    1. Go to the URL provided in the output to access to the Admin Console.
    
-   1. Bypass the browser TLS warning by clicking **Continue to Setup**.
+   1. On the Admin Console landing page, click **Start**.
 
-   1. Click **Advanced > Proceed**.
+   1. On the **Secure the Admin Console** screen, click **Continue**. In your browser, click **Advanced > Proceed** to bypass the TLS warning.
 
-   1. On the **HTTPS for the Gitea Admin Console** page, select **Self-signed** and click **Continue**.
+   1. On the **Certificate type** screen, either select **Self-signed** to continue using the self-signed Admin Console certificate or click **Upload your own** to upload your own private key and certificacte.
 
-   1. On the login page, enter the Admin Console password that you created during installation and click **Log In**.
+    By default, a self-signed TLS certificate is used to secure communication between your browser and the Admin Console. You will see a warning in your browser every time you access the Admin Console unless you upload your own certificate.
 
-   1. On the **Nodes** page, you can view details about the VM where you installed, including its node role, status, CPU, and memory. Users can also optionally add additional nodes on this page before deploying the application. Click **Continue**. 
+   1. On the login page, enter the Admin Console password that you created during installation and click **Log in**.
 
-      The Admin Console dashboard opens.
-      
-   1. In the **Version** section, next to the new version, click **Deploy** and then **Yes, Deploy**. 
+   1. On the **Configure the cluster** screen, you can view details about the VM where you installed, including its node role, status, CPU, and memory. Users can also optionally add additional nodes on this page before deploying the application. Click **Continue**. 
 
-      The application status changes from Missing to Unavailable while the `gitea` Deployment is being created.
+      On the Admin Console dashboard, the application status changes from Missing to Unavailable while the `gitea` Deployment is being created.
 
    1. After a few minutes when the application status is Ready, click **Open App** to view the Gitea application in a browser.
    

--- a/docs/vendor/quick-start.mdx
+++ b/docs/vendor/quick-start.mdx
@@ -248,7 +248,7 @@ Before you begin, ensure that you have access to a VM that meets the requirement
 
    1. On the **Certificate type** screen, either select **Self-signed** to continue using the self-signed Admin Console certificate or click **Upload your own** to upload your own private key and certificacte.
 
-    By default, a self-signed TLS certificate is used to secure communication between your browser and the Admin Console. You will see a warning in your browser every time you access the Admin Console unless you upload your own certificate.
+       By default, a self-signed TLS certificate is used to secure communication between your browser and the Admin Console. You will see a warning in your browser every time you access the Admin Console unless you upload your own certificate.
 
    1. On the login page, enter the Admin Console password that you created during installation and click **Log in**.
 


### PR DESCRIPTION
Updated install instructions: https://deploy-preview-2809--replicated-docs-upgrade.netlify.app/enterprise/installing-embedded#install (also copied the same steps to the air gap install topic)

Updated the quick start flow (note that the sample app does not have a config nor preflights): https://deploy-preview-2809--replicated-docs.netlify.app/vendor/quick-start#quick-start