### PR TITLE
Update info about installer-only annotation

### DIFF
--- a/docs/partials/helm/_helm-install-prereqs.mdx
+++ b/docs/partials/helm/_helm-install-prereqs.mdx
@@ -1,12 +1,6 @@
-import InstallerOnlyAnnotation from "./_installer-only-annotation.mdx"
-
 * The customer used to install must have a valid email address. This email address is only used as a username for the Replicated registry and is never contacted. For more information about creating and editing customers in the Vendor Portal, see [Creating a Customer](/vendor/releases-creating-customer).
 
 * The customer used to install must have the **Existing Cluster (Helm CLI)** install type enabled. For more information about enabling install types for customers in the Vendor Portal, see [Managing Install Types for a License](licenses-install-types).
-
-* The release that will be installed must include one or more Helm charts. It can also include Replicated custom resources, such as the Embedded Cluster Config custom resource, the KOTS HelmChart, Config, and Application custom resources, or the Troubleshoot Preflight and SupportBundle custom resources.
-
-     <InstallerOnlyAnnotation/> 
 
 * To ensure that the Replicated proxy registry can be used to grant proxy access to your application images during Helm installations, you must create an image pull secret for the proxy registry and add it to your Helm chart. To do so, follow the steps in [Using the Proxy Registry with Helm Installations](/vendor/helm-image-registry).
 

--- a/docs/partials/helm/_helm-install-prereqs.mdx
+++ b/docs/partials/helm/_helm-install-prereqs.mdx
@@ -4,11 +4,9 @@ import InstallerOnlyAnnotation from "./_installer-only-annotation.mdx"
 
 * The customer used to install must have the **Existing Cluster (Helm CLI)** install type enabled. For more information about enabling install types for customers in the Vendor Portal, see [Managing Install Types for a License](licenses-install-types).
 
-* If the release that will be installed includes any Kubernetes resources, add the `kots.io/installer-only` annotation to each resource. It is not necessary to add the `kots.io/installer-only` annotation to any Replicated custom resources, such as the Embedded Cluster Config custom resource, the KOTS HelmChart, Config, or Application custom resources, or the Troubleshoot Preflight or SupportBundle custom resources.
+* The release that will be installed must include one or more Helm charts. It can also include Replicated custom resources, such as the Embedded Cluster Config custom resource, the KOTS HelmChart, Config, and Application custom resources, or the Troubleshoot Preflight and SupportBundle custom resources.
 
      <InstallerOnlyAnnotation/> 
-
-     For more information, see [Understand Install Types](/vendor/licenses-install-types#install-types) in _Managing Install Types for a License_. 
 
 * To ensure that the Replicated proxy registry can be used to grant proxy access to your application images during Helm installations, you must create an image pull secret for the proxy registry and add it to your Helm chart. To do so, follow the steps in [Using the Proxy Registry with Helm Installations](/vendor/helm-image-registry).
 

--- a/docs/partials/helm/_helm-install-prereqs.mdx
+++ b/docs/partials/helm/_helm-install-prereqs.mdx
@@ -1,5 +1,15 @@
-* You must have a customer in the Replicated Vendor Portal with a valid email address. This email address is only used as a username for the Replicated registry and is never contacted. For more information about creating and editing customers in the Vendor Portal, see [Creating a Customer](/vendor/releases-creating-customer).
+import InstallerOnlyAnnotation from "./_installer-only-annotation.mdx"
+
+* The customer used to install must have a valid email address. This email address is only used as a username for the Replicated registry and is never contacted. For more information about creating and editing customers in the Vendor Portal, see [Creating a Customer](/vendor/releases-creating-customer).
+
+* The customer used to install must have the **Existing Cluster (Helm CLI)** install type enabled. For more information about enabling install types for customers in the Vendor Portal, see [Managing Install Types for a License](licenses-install-types).
+
+* If the release that will be installed includes any Kubernetes resources, add the `kots.io/installer-only` annotation to each resource. It is not necessary to add the `kots.io/installer-only` annotation to any Replicated custom resources, such as the Embedded Cluster Config custom resource, the KOTS HelmChart, Config, or Application custom resources, or the Troubleshoot Preflight or SupportBundle custom resources.
+
+     <InstallerOnlyAnnotation/> 
+
+     For more information, see [Understand Install Types](/vendor/licenses-install-types#install-types) in _Managing Install Types for a License_. 
 
 * To ensure that the Replicated proxy registry can be used to grant proxy access to your application images during Helm installations, you must create an image pull secret for the proxy registry and add it to your Helm chart. To do so, follow the steps in [Using the Proxy Registry with Helm Installations](/vendor/helm-image-registry).
 
-* (Recommended) To install the Replicated SDK alongside the application, declare the SDK as a dependency. For more information, see [Install the SDK as a Subchart](replicated-sdk-installing#install-the-sdk-as-a-subchart) in _Installing the Replicated SDK_.
+* Declare the SDK as a dependency in your Helm chart. For more information, see [Install the SDK as a Subchart](replicated-sdk-installing#install-the-sdk-as-a-subchart) in _Installing the Replicated SDK_.

--- a/docs/partials/helm/_installer-only-annotation.mdx
+++ b/docs/partials/helm/_installer-only-annotation.mdx
@@ -1,3 +1,5 @@
+Any other Kubernetes resources in the release (such as Kubernetes Deployments or Services) must include the `kots.io/installer-only` annotation.
+
 The `kots.io/installer-only` annotation indicates that the Kubernetes resource is used only by the Replicated installers (Embedded Cluster, KOTS, and kURL).
 
 Example:

--- a/docs/partials/helm/_installer-only-annotation.mdx
+++ b/docs/partials/helm/_installer-only-annotation.mdx
@@ -1,0 +1,11 @@
+The `kots.io/installer-only` annotation indicates that the Kubernetes resource is used only by the Replicated installers (Embedded Cluster, KOTS, and kURL).
+
+Example:
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  annotations:
+    kots.io/installer-only: "true"
+```

--- a/docs/vendor/licenses-install-types.mdx
+++ b/docs/vendor/licenses-install-types.mdx
@@ -1,3 +1,5 @@
+import InstallerOnlyAnnotation from "../partials/helm/_installer-only-annotation.mdx"
+
 # Managing Install Types for a License (Beta)
 
 This topic describes how to manage which installation types and options are enabled for a license.
@@ -34,13 +36,17 @@ The following describes each installation type available, as well as the require
 <table>
      <tr>
           <th width="30%">Install Type</th>
-          <th>Description</th>
+          <th width="35%">Description</th>
           <th>Requirements</th>
      </tr>
      <tr>
           <th>Existing Cluster (Helm CLI)</th>
-          <td><p>The customer does not have access to the Replicated installers.</p><p>When the <strong>Helm CLI Air Gap Instructions (Helm CLI only)</strong> install option is also enabled, the Download Portal displays instructions on how to pull Helm installable images into a local repository. See <a href="#install-options">Understanding Additional Install Options</a> below.</p></td>
-          <td>The latest release promoted to the channel where the customer is assigned must contain only Helm charts and Replicated Custom Resources. Any other Kubernetes resources must include the `kots.io/installer-only` annotation. See <a href="#installer-only-annotation">kots.io/installer-only Annotation</a> below.</td>
+          <td><p>Allows the customer to install with Helm in an existing cluster. The customer does not have access to the Replicated installers (Embedded Cluster, KOTS, and kURL).</p><p>When the <strong>Helm CLI Air Gap Instructions (Helm CLI only)</strong> install option is also enabled, the Download Portal displays instructions on how to pull Helm installable images into a local repository. See <a href="#install-options">Understanding Additional Install Options</a> below.</p></td>
+          <td>
+            <p>The latest release promoted to the channel where the customer is assigned must contain one or more Helm charts. The release can also optionally include Replicated custom resources (such as Embedded Cluster Config and KOTS HelmChart, Config, and Application).</p>
+            <p>Any other Kubernetes resources in the release (such as Kubernetes Deployments or Services) must include the `kots.io/installer-only` annotation.</p>
+            <InstallerOnlyAnnotation/>
+          </td>
      </tr>
      <tr>
        <th>Existing Cluster (KOTS install)</th>
@@ -48,7 +54,7 @@ The following describes each installation type available, as well as the require
        <td>
           <ul>
             <li>Your Vendor Portal team must have the KOTS entitlement</li>
-            <li>The latest release promoted to the channel where the customer is assigned must contain KOTS custom resources</li>
+            <li>The latest release promoted to the channel where the customer is assigned must contain KOTS custom resources, such as the KOTS HelmChart, Config, and Application custom resources. For more information, see [About Custom Resources](/reference/custom-resource-about).</li>
           </ul> 
        </td>   
      </tr>
@@ -76,20 +82,6 @@ The following describes each installation type available, as well as the require
        </td>   
      </tr>
 </table>
-
-### `kots.io/installer-only` Annotation {#installer-only-annotation}
-
-The `kots.io/installer-only` annotation indicates that the Kubernetes resource is only used by the Replicated installers (Embedded Cluster, KOTS, or kURL). This annotation is required for releases that support the `Existing Cluster (Helm CLI)` install type and include resources other than Helm charts.
-
-Example:
-```yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: my-service
-  annotations:
-    kots.io/installer-only: "true"
-```
 
 ## Understanding Additional Install Options {#install-options}
 

--- a/docs/vendor/licenses-install-types.mdx
+++ b/docs/vendor/licenses-install-types.mdx
@@ -43,8 +43,7 @@ The following describes each installation type available, as well as the require
           <th>Existing Cluster (Helm CLI)</th>
           <td><p>Allows the customer to install with Helm in an existing cluster. The customer does not have access to the Replicated installers (Embedded Cluster, KOTS, and kURL).</p><p>When the <strong>Helm CLI Air Gap Instructions (Helm CLI only)</strong> install option is also enabled, the Download Portal displays instructions on how to pull Helm installable images into a local repository. See <a href="#install-options">Understanding Additional Install Options</a> below.</p></td>
           <td>
-            <p>The latest release promoted to the channel where the customer is assigned must contain one or more Helm charts. The release can also optionally include Replicated custom resources (such as Embedded Cluster Config and KOTS HelmChart, Config, and Application).</p>
-            <p>Any other Kubernetes resources in the release (such as Kubernetes Deployments or Services) must include the `kots.io/installer-only` annotation.</p>
+            <p>The latest release promoted to the channel where the customer is assigned must contain one or more Helm charts. It can also include Replicated custom resources, such as the Embedded Cluster Config custom resource, the KOTS HelmChart, Config, and Application custom resources, or the Troubleshoot Preflight and SupportBundle custom resources.</p>
             <InstallerOnlyAnnotation/>
           </td>
      </tr>


### PR DESCRIPTION
Updated the requirements for the Helm install type to include the annotation YAML sample in the cell of the table: https://deploy-preview-2869--replicated-docs.netlify.app/vendor/licenses-install-types#install-types