### PR TITLE
Update testing-supported-clusters.md

### DIFF
--- a/docs/vendor/testing-supported-clusters.md
+++ b/docs/vendor/testing-supported-clusters.md
@@ -402,7 +402,7 @@ Compatibility Matrix supports creating [Azure AKS](https://azure.microsoft.com/e
   </tr>
   <tr>
     <th>Supported Kubernetes Versions</th>
-    <td>1.28, 1.29, 1.30</td>
+    <td>1.28, 1.29, 1.30, 1.31</td>
   </tr>
   <tr>
     <th>Supported Instance Types</th>


### PR DESCRIPTION
Add AKS 1.31 to CMX versions.  Merge after https://github.com/replicatedhq/reliability-matrix/pull/1145 is released.