### PR TITLE
Update replicated-cli-cluster-addon-create.md

### DIFF
--- a/docs/reference/replicated-cli-cluster-addon-create.md
+++ b/docs/reference/replicated-cli-cluster-addon-create.md
@@ -18,7 +18,7 @@ The following `cluster addon create` commands are supported:
   <th width="50%">Description</th>
 </tr>
   <tr>
-    <td><a href="replicated-cli-addon-create-object-store"><code>replicated cluster addon create object-store</code></a></td>
+    <td><code>replicated cluster addon create object-store</code></td>
     <td>Create an object store bucket for a cluster.</td>
   </tr>
 </table>


### PR DESCRIPTION
Removes link that shouldn't be a link. Reported in https://github.com/replicatedhq/replicated-docs/issues/2891