### PR TITLE
Add troubleshooting info for helm dependency update 401 errors

### DIFF
--- a/docs/partials/replicated-sdk/_registry-logout.mdx
+++ b/docs/partials/replicated-sdk/_registry-logout.mdx
@@ -1,7 +1,7 @@
-(Recommended) Log out of the Replicated registry:
+If you see a 401 Unauthorized error after running `helm dependency update`, run the following command to remove credentials from the Replicated registry, then re-run `helm dependency update`:
 
-    ```bash
-    helm registry logout registry.replicated.com
-    ```
+```bash
+helm registry logout registry.replicated.com
+```
 
-    Replicated recommends that you log out of the Replicated registry to avoid errors that can occur when Helm attempts to pull the SDK chart from the registry if you are logged in with a license that has expired. 
+For more information, see [401 Unauthorized Error When Updating Helm Dependencies](replicated-sdk-installing#401).

--- a/docs/vendor/helm-install-release.md
+++ b/docs/vendor/helm-install-release.md
@@ -28,13 +28,15 @@ To package a Helm chart so that it can be added to a release:
 
     <DependencyYaml/>
     
-    For additional guidelines related to adding the SDK as a dependency, see [Install the SDK as a Subchart](replicated-sdk-installing#install-the-sdk-as-a-subchart) in _Installing the Replicated SDK_.
-
-1. <RegistryLogout/> 
+    For additional guidelines related to adding the SDK as a dependency, see [Install the SDK as a Subchart](replicated-sdk-installing#install-the-sdk-as-a-subchart) in _Installing the Replicated SDK_. 
 
 1. Update dependencies and package the chart as a `.tgz` file:
 
     <HelmPackage/>
+
+    :::note
+    <RegistryLogout/>
+    :::
 
 1. Add the `.tgz` file to a release. For more information, see [Managing Releases with the Vendor Portal](releases-creating-releases) or [Managing Releases with the CLI](releases-creating-cli).
 

--- a/docs/vendor/replicated-sdk-installing.mdx
+++ b/docs/vendor/replicated-sdk-installing.mdx
@@ -25,13 +25,14 @@ To install the SDK as a subchart:
 
      <DependencyYaml/>
 
-1. <RegistryLogout/> 
-
 1. Update the `charts/` directory:
 
     ```
     helm dependency update
     ```
+    :::note
+    <RegistryLogout/> 
+    :::
     
 1. Package the Helm chart into a `.tgz` archive:
 
@@ -151,3 +152,31 @@ To add the SDK Helm chart to a release for a Kubernetes manifest-based applicati
 ## Install the SDK in Integration Mode
 
 <IntegrationMode/>
+
+## Troubleshoot
+
+### 401 Unauthorized Error When Updating Helm Dependencies {#401}
+
+#### Symptom
+
+You see an error message similar to the following after adding the Replicated SDK as a dependency in your Helm chart then running `helm dependency update`:
+
+```
+Error: could not download oci://registry.replicated.com/library/replicated-sdk: failed to authorize: failed to fetch oauth token: unexpected status from GET request to https://registry.replicated.com/v2/token?scope=repository%3Alibrary%2Freplicated-sdk%3Apull&service=registry.replicated.com: 401 Unauthorized
+```
+
+#### Cause
+
+When you run `helm dependency update`, Helm attempts to pull the Replicated SDK chart from the Replicated registry. An error can occur if you are already logged in to the Replicated registry with a license that has expired, such as when testing application releases.
+
+#### Solution
+
+To solve this issue:
+
+1. Run the following command to remove login credentials for the Replicated registry:
+
+    ```
+    helm registry logout registry.replicated.com
+    ```
+
+1. Re-run `helm dependency update` for your Helm chart.    


### PR DESCRIPTION
Added a new Troubleshoot section in the installing the SDK topic to explain the helm dependency update error: https://deploy-preview-2918--replicated-docs.netlify.app/vendor/replicated-sdk-installing#troubleshoot

<img width="1312" alt="Screenshot 2024-12-23 at 2 14 00 PM" src="https://github.com/user-attachments/assets/af22cfb5-dc3c-4d81-b83d-9c0e0205a178" />

Also reformatted the info about `helm registry logout` info in the procedures themselves so that it's a note rather than a step:

<img width="958" alt="Screenshot 2024-12-23 at 2 13 47 PM" src="https://github.com/user-attachments/assets/bca75c25-b73f-4c75-89a7-c7dd0234b132" />
