### PR TITLE
Document replicated cluster create --addon flags

### DIFF
--- a/docs/reference/replicated-cli-cluster-create.md
+++ b/docs/reference/replicated-cli-cluster-create.md
@@ -21,12 +21,12 @@ replicated cluster create [flags]
   <tr>
     <td>--addon</td>
     <td>string</td>
-    <td>Addons to install on the cluster (can be specified multiple times)</td>
+    <td>Add-ons to install in the cluster. Can be specified multiple times.</td>
   </tr>
   <tr>
     <td>--bucket-prefix</td>
     <td>string</td>
-    <td>A prefix for the bucket name to be created (required by '--addon object-store')</td>
+    <td>A prefix for the bucket name to be created. Required by `--addon object-store`.</td>
   </tr>
   <tr>
     <td>--disk</td>

--- a/docs/reference/replicated-cli-cluster-create.md
+++ b/docs/reference/replicated-cli-cluster-create.md
@@ -19,6 +19,16 @@ replicated cluster create [flags]
   </tr>
   <Help/>
   <tr>
+    <td>--addon</td>
+    <td>string</td>
+    <td>Addons to install on the cluster (can be specified multiple times)</td>
+  </tr>
+  <tr>
+    <td>--bucket-prefix</td>
+    <td>string</td>
+    <td>A prefix for the bucket name to be created (required by '--addon object-store')</td>
+  </tr>
+  <tr>
     <td>--disk</td>
     <td>integer</td>
     <td>The disk size (GiB) to request per node. <strong>Default:</strong> 50</td>


### PR DESCRIPTION
This PR documents flags associated with the new `--addon` flag within the `replicated cluster create` command https://app.shortcut.com/replicated/story/107825