### PR TITLE
Remove kurl info from installing without object storage topic

### DIFF
--- a/docs/enterprise/installing-general-requirements.mdx
+++ b/docs/enterprise/installing-general-requirements.mdx
@@ -46,7 +46,7 @@ To install KOTS in an existing cluster, your environment must meet the following
     * **4GB for S3-compatible object store**: The Admin Console requires 4GB for an S3-compatible object store to store appplication archives, support bundles, and snapshots that are configured to use a host path and NFS storage destination. By default, KOTS deploys MinIO to satisfy this object storage requirement. During deployment, MinIO is configured with a randomly generated `AccessKeyID` and `SecretAccessKey`, and only exposed as a ClusterIP on the overlay network.
 
       :::note
-      You can optionally install KOTS without MinIO by passing `--with-minio=false` with the `kots install` command. This installs KOTS as a StatefulSet using a persistent volume (PV) for storage. For more information, see [Installing Without Object Storage](/enterprise/installing-stateful-component-requirements).
+      You can optionally install KOTS without MinIO by passing `--with-minio=false` with the `kots install` command. This installs KOTS as a StatefulSet using a persistent volume (PV) for storage. For more information, see [Installing KOTS in Existing Clusters Without Object Storage](/enterprise/installing-stateful-component-requirements).
       :::
 
     * **1GB for rqlite PersistentVolume**: The Admin Console requires 1GB for a rqlite StatefulSet to store version history, application metadata, and other small amounts of data needed to manage the application(s). During deployment, the rqlite component is secured with a randomly generated password, and only exposed as a ClusterIP on the overlay network.  

--- a/docs/enterprise/installing-overview.md
+++ b/docs/enterprise/installing-overview.md
@@ -38,4 +38,4 @@ The KOTS Admin Console requires persistent storage for state. KOTS deploys MinIO
 
 You can optionally install KOTS without object storage. When installed without object storage, KOTS deploys the Admin Console as a StatefulSet with an attached PersistentVolume (PV) instead of as a deployment.
 
-For more information about how to install KOTS without object storage, see [Installing Without Object Storage](/enterprise/installing-stateful-component-requirements).
+For more information about how to install KOTS without object storage, see [Installing KOTS in Existing Clusters Without Object Storage](/enterprise/installing-stateful-component-requirements).

--- a/docs/enterprise/installing-stateful-component-requirements.md
+++ b/docs/enterprise/installing-stateful-component-requirements.md
@@ -1,6 +1,6 @@
-# Installing Without Object Storage
+# Installing KOTS in Existing Clusters Without Object Storage
 
-This topic describes how to install Replicated KOTS without the default object storage, including limitations of installing without object storage.
+This topic describes how to install Replicated KOTS in existing clusters without the default object storage, including limitations of installing without object storage.
 
 ## Overview
 
@@ -11,22 +11,18 @@ The Replicated KOTS Admin Console requires persistent storage for state. By defa
 
 For more information about the Admin Console's persistent storage requirements, see [Minimum System Requirements](/enterprise/installing-general-requirements#minimum-system-requirements) in _Installation Requirements_.
 
-For existing cluster installations, KOTS deploys MinIO for object storage by default. For installations with Replicated kURL, the object storage provider is either MinIO or Rook, depending on which add-on your software vendor included in the kURL installer specification. 
+For existing cluster installations, KOTS deploys MinIO for object storage by default. 
 
 You can optionally install KOTS without object storage. When installed without object storage, KOTS deploys the Admin Console as a Statefulset with an attached PersistentVolume (PV) instead of as a deployment. In this case, support bundles and application archives are stored in the attached PV instead of in object storage. Additionally, for local snapshots storage, KOTS uses the `local-volume-provider` Velero plugin to store backups on local PVs instead of using object storage. The `local-volume-provider` plugin uses the existing Velero service account credentials to mount volumes directly to the Velero node-agent pods. For more information, see [`local-volume-provider`](https://github.com/replicatedhq/local-volume-provider) in GitHub.
 
-## Install Without Object Storage
+## How to Install and Upgrade Without Object Storage
 
-This section describes how to install KOTS without object storage in existing clusters or kURL clusters.
+To install KOTS without object storage in an existing cluster, you can use the `--with-minio=false` flag.
 
-### Existing Clusters
+#### `kots install --with-minio=false`
 
-To install KOTS without object storage in an existing cluster, you can use the `--with-minio=false` flag:
-* When `--with-minio=false` is used with the `kots install` command, KOTS does _not_ deploy MinIO. KOTS deploys the Admin Console as a Statefulset with an attached PV instead of as a deployment. For command usage, see [install](/reference/kots-cli-install/).
-* When `--with-minio=false` is used with the `kots admin-console upgrade` command, KOTS upgrades the existing Admin Console instance to the latest version, replaces the running deployment with a StatefulSet, and removes MinIO after a data migration. This results in temporary downtime for the Admin Console, but deployed applications are unaffected. For command usage, see [admin-console upgrade](/reference/kots-cli-admin-console-upgrade/).
+When `--with-minio=false` is used with the `kots install` command, KOTS does _not_ deploy MinIO. KOTS deploys the Admin Console as a Statefulset with an attached PV instead of as a deployment. For command usage, see [install](/reference/kots-cli-install/).
 
-### kURL Clusters
+#### `kots admin-console upgrade --with-minio=false`
 
-To enable KOTS installations without object storage in kURL clusters, your software vendor must remove the MinIO or Rook object storage add-on from the kURL installer spec and set the `disableS3` flag to `true` in the KOTS add-on.
-
-For more information about the behavior of the `disableS3` flag, see [KOTS Add-on](https://kurl.sh/docs/add-ons/kotsadm) in the open source kURL documentation. For information about migrating a kURL cluster away from object storage, see [Removing Object Storage](https://kurl.sh/docs/install-with-kurl/removing-object-storage) in the kURL documentation.
+When `--with-minio=false` is used with the `kots admin-console upgrade` command, KOTS upgrades the existing Admin Console instance to the latest version, replaces the running deployment with a StatefulSet, and removes MinIO after a data migration. This results in temporary downtime for the Admin Console, but deployed applications are unaffected. For command usage, see [admin-console upgrade](/reference/kots-cli-admin-console-upgrade/).

--- a/docs/vendor/packaging-air-gap-excluding-minio.md
+++ b/docs/vendor/packaging-air-gap-excluding-minio.md
@@ -1,6 +1,6 @@
 # Excluding MinIO from Air Gap Bundles (Beta)
 
-The Replicated Admin Console requires an S3-compatible object store to store application archives and support bundles. By default, Replicated KOTS deploys MinIO during installation to satisfy the object storage requirement. For more information about the options for installing without MinIO in existing cluster or embedded clusters created with Replicated kURL, see [Installing Without Object Storage](/enterprise/installing-stateful-component-requirements).
+The Replicated KOTS Admin Console requires an S3-compatible object store to store application archives and support bundles. By default, KOTS deploys MinIO to satisfy the object storage requirement. For more information about the options for installing without MinIO in existing cluster, see [Installing KOTS in Existing Clusters Without Object Storage](/enterprise/installing-stateful-component-requirements).
 
 As a software vendor, you can exclude MinIO images from all Admin Console air gap distributions (`kotsadm.tar.gz`) in the download portal. Excluding MinIO from the `kotsadm.tar.gz` air gap bundle is useful if you want to prevent MinIO images from appearing in the air gap distribution that your end users download. It also reduces the file size of `kotsadm.tar.gz`.
 


### PR DESCRIPTION
https://deploy-preview-2963--replicated-docs-upgrade.netlify.app/enterprise/installing-stateful-component-requirements

* Removed kurl info from the installing without object storage topic (confirmed that the relevant info for kurl installs is in the kurl "selecting storage add-ons" topic)
* Updated the title to clarify that it's for installing kots in existing clusters
* Updated xrefs accordingly