### PR TITLE
Update info for CAAs in Configure a Custom Domain section

### DIFF
--- a/docs/vendor/custom-domains-using.md
+++ b/docs/vendor/custom-domains-using.md
@@ -35,7 +35,22 @@ To add and configure a custom domain:
     Your changes can take up to 24 hours to propagate.
 
     :::important
-    If you set up a [CAA record](https://letsencrypt.org/docs/caa/) for this hostname, it might prevent TLS certificate renewal in the future. This can result in downtime for your customers.
+    If you set up a [CAA record](https://letsencrypt.org/docs/caa/) for this hostname you must include all Certificate Authorities (CAs) that Cloudflare partners with. The following CAA records are required to ensure proper certificate issuance and renewal:
+
+    ```dns
+    @ IN CAA 0 issue "letsencrypt.org"
+    @ IN CAA 0 issue "pki.goog; cansignhttpexchanges=yes"
+    @ IN CAA 0 issue "ssl.com"
+    @ IN CAA 0 issue "amazon.com"
+    @ IN CAA 0 issue "cloudflare.com"
+    @ IN CAA 0 issue "google.com"
+    ```
+
+    Failing to include any of these CAs may prevent certificate issuance or renewal, which can result in downtime for your customers. For additional security, you can add an IODEF record to receive notifications about certificate requests:
+
+    ```dns
+    @ IN CAA 0 iodef "mailto:your-security-team@example.com"
+    ```
     :::
 
 1. For **Use Domain**, to set the new domain as the default, click **Yes, set as default**. Otherwise, click **Not now**.

--- a/docs/vendor/custom-domains-using.md
+++ b/docs/vendor/custom-domains-using.md
@@ -34,7 +34,7 @@ To add and configure a custom domain:
 
     Your changes can take up to 24 hours to propagate.
 
-    :::important
+    :::note
     If you set up a [CAA record](https://letsencrypt.org/docs/caa/) for this hostname you must include all Certificate Authorities (CAs) that Cloudflare partners with. The following CAA records are required to ensure proper certificate issuance and renewal:
 
     ```dns

--- a/docs/vendor/custom-domains-using.md
+++ b/docs/vendor/custom-domains-using.md
@@ -35,7 +35,7 @@ To add and configure a custom domain:
     Your changes can take up to 24 hours to propagate.
 
     :::note
-    If you set up a [CAA record](https://letsencrypt.org/docs/caa/) for this hostname you must include all Certificate Authorities (CAs) that Cloudflare partners with. The following CAA records are required to ensure proper certificate issuance and renewal:
+    If you set up a [CAA record](https://letsencrypt.org/docs/caa/) for this hostname, you must include all Certificate Authorities (CAs) that Cloudflare partners with. The following CAA records are required to ensure proper certificate issuance and renewal:
 
     ```dns
     @ IN CAA 0 issue "letsencrypt.org"
@@ -46,7 +46,7 @@ To add and configure a custom domain:
     @ IN CAA 0 issue "google.com"
     ```
 
-    Failing to include any of these CAs may prevent certificate issuance or renewal, which can result in downtime for your customers. For additional security, you can add an IODEF record to receive notifications about certificate requests:
+    Failing to include any of these CAs might prevent certificate issuance or renewal, which can result in downtime for your customers. For additional security, you can add an IODEF record to receive notifications about certificate requests:
 
     ```dns
     @ IN CAA 0 iodef "mailto:your-security-team@example.com"


### PR DESCRIPTION
* Follow-up from [SC-115604](https://app.shortcut.com/replicated/story/115604/support-for-caa-record-in-dns-to-limit-cert-authority)
* Updates notice about CAA records and lists CAs to add
* This method has been tested and appears to work

<img width="895" alt="Screenshot 2025-02-20 at 21 36 31" src="https://github.com/user-attachments/assets/3bbccc2c-1fcc-484c-9088-3e613c715a31" />


