### PR TITLE
Fixing a dead link in the SDK values page

### DIFF
--- a/docs/partials/replicated-sdk/_sdk-values.mdx
+++ b/docs/partials/replicated-sdk/_sdk-values.mdx
@@ -24,6 +24,6 @@ replicated:
 
 These `replicated` values can be referenced by the application or set during installation as needed. For example, if users need to add labels or annotations to everything that runs in their cluster, then they can pass the labels or annotations to the relevant value in the SDK subchart.
 
-For the default Replicated SDK Helm chart values file, see [values.yaml.tmpl](https://github.com/replicatedhq/replicated-sdk/blob/main/chart/values.yaml.tmpl) in the [replicated-sdk](https://github.com/replicatedhq/replicated-sdk) repository in GitHub.
+For the default Replicated SDK Helm chart values file, see [values.yaml](https://github.com/replicatedhq/replicated-sdk/blob/main/chart/values.yaml) in the [replicated-sdk](https://github.com/replicatedhq/replicated-sdk) repository in GitHub.
 
 The SDK Helm values also include a `replicated.license` field, which is a string that contains the YAML representation of the customer license. For more information about the built-in fields in customer licenses, see [Built-In License Fields](licenses-using-builtin-fields).


### PR DESCRIPTION
Fixing a dead link to https://github.com/replicatedhq/replicated-sdk/blob/main/chart/values.yaml