### PR TITLE
Add repository dispatch for EC release notes

### DIFF
--- a/.github/workflows/embedded-cluster-release-notes.yml
+++ b/.github/workflows/embedded-cluster-release-notes.yml
@@ -85,11 +85,11 @@ jobs:
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
 
-      #- name: Slack Notification
-      #  uses: slackapi/slack-github-action@v2.0.0
-      #  with:
-      #    webhook: ${{ secrets.EMBEDDED_CLUSTER_RELEASE_NOTES_SLACK_WEBHOOK }}
-      #    webhook-type: webhook-trigger
-      #    payload: |
-      #      version: "${{ github.event.client_payload.version }}"
-      #      pull_request_url: "${{steps.cpr.outputs.pull-request-url}}"
+      - name: Slack Notification
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.EMBEDDED_CLUSTER_RELEASE_NOTES_SLACK_WEBHOOK }}
+          webhook-type: webhook-trigger
+          payload: |
+            version: "${{ github.event.client_payload.version }}"
+            pull_request_url: "${{steps.cpr.outputs.pull-request-url}}"

--- a/.github/workflows/embedded-cluster-release-notes.yml
+++ b/.github/workflows/embedded-cluster-release-notes.yml
@@ -85,11 +85,11 @@ jobs:
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
 
-      - name: Slack Notification
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.EMBEDDED_CLUSTER_RELEASE_NOTES_SLACK_WEBHOOK }}
-          webhook-type: webhook-trigger
-          payload: |
-            version: "${{ github.event.client_payload.version }}"
-            pull_request_url: "${{steps.cpr.outputs.pull-request-url}}"
+      #- name: Slack Notification
+      #  uses: slackapi/slack-github-action@v2.0.0
+      #  with:
+      #    webhook: ${{ secrets.EMBEDDED_CLUSTER_RELEASE_NOTES_SLACK_WEBHOOK }}
+      #    webhook-type: webhook-trigger
+      #    payload: |
+      #      version: "${{ github.event.client_payload.version }}"
+      #      pull_request_url: "${{steps.cpr.outputs.pull-request-url}}"

--- a/.github/workflows/embedded-cluster-release-notes.yml
+++ b/.github/workflows/embedded-cluster-release-notes.yml
@@ -1,0 +1,95 @@
+name: embedded-cluster-release-notes
+on:
+  repository_dispatch:
+    types: [embedded-cluster-release-notes]
+    inputs:
+      version:
+        description: Embedded Cluster version
+        required: true
+
+jobs:
+  generate-release-notes-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate Release Notes
+        id: release-notes
+        env:
+          EC_VERSION: ${{ github.event.client_payload.version }}
+        uses: replicatedhq/release-notes-generator@main
+        with:
+          owner-repo: replicatedhq/embedded-cluster
+          head: $EC_VERSION
+          title: ${EC_VERSION#v}
+          description: ''
+          include-pr-links: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Release Notes
+        env:
+          PATTERN: ".+RELEASE_NOTES_PLACEHOLDER.+"
+          EC_VERSION: ${{ github.event.client_payload.version }}
+        run: |
+          # Extract EC version without v prefix if it exists
+          EC_VERSION_CLEAN=${EC_VERSION#v}
+          
+          # Create the full release notes content
+          cat > /tmp/release-notes.txt << EOF
+          
+          ## ${EC_VERSION_CLEAN}
+          
+          Released on $(date +'%B %-d, %Y')
+          
+          <!-- VERSION TABLE PLACEHOLDER
+          Please manually replace this placeholder with a version table in the format:
+          
+          <table>
+            <tr>
+              <th>Version</th>
+              <td id="center">X.Y.Z+k8s-1.XX</td>
+              <td id="center">X.Y.Z+k8s-1.XX</td>
+            </tr>
+            <tr>
+              <th>Kubernetes Version</th>
+              <td id="center">1.XX.Y</td>
+              <td id="center">1.XX.Y</td>
+            </tr>
+            <tr>
+              <th>KOTS Version</th>
+              <td id="center" colspan="2">1.XXX.Y</td>
+            </tr>
+          </table>
+          -->
+          
+          ${{ steps.release-notes.outputs.release-notes }}
+          EOF
+          
+          sed -i -E "/$PATTERN/r /tmp/release-notes.txt" docs/release-notes/rn-embedded-cluster.md
+          rm -f /tmp/release-notes.txt
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        id: cpr
+        with:
+          token: ${{ secrets.REPLICATED_GH_PAT }}
+          commit-message: Embedded Cluster ${{ github.event.client_payload.version }} release notes
+          title: Embedded Cluster ${{ github.event.client_payload.version }} release notes
+          branch: automation/embedded-cluster-release-notes-${{ github.event.client_payload.version }}
+          delete-branch: true
+          base: "main"
+          body: "Automated changes by the [embedded-cluster-release-notes](https://github.com/replicatedhq/replicated-docs/blob/main/.github/workflows/embedded-cluster-release-notes.yml) GitHub action. Please manually replace the version table placeholder."
+
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+
+      - name: Slack Notification
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.EMBEDDED_CLUSTER_RELEASE_NOTES_SLACK_WEBHOOK }}
+          webhook-type: webhook-trigger
+          payload: |
+            version: "${{ github.event.client_payload.version }}"
+            pull_request_url: "${{steps.cpr.outputs.pull-request-url}}"

--- a/docs/release-notes/rn-embedded-cluster.md
+++ b/docs/release-notes/rn-embedded-cluster.md
@@ -10,6 +10,8 @@ This topic contains release notes for the [Replicated Embedded Cluster](/vendor/
 
 Additionally, these release notes list the versions of Kubernetes and Replicated KOTS that are available with each version of Embedded Cluster.
 
+<!--RELEASE_NOTES_PLACEHOLDER-->
+
 ## 2.4.0
 
 Released on May 6, 2025


### PR DESCRIPTION
Example PR that's generated when this dispatch is triggered: https://github.com/replicatedhq/replicated-docs/pull/3246. I believe there are no release notes as the release notes generator does a diff between the current version and the last release version. 

The above PR was tested manually with a workflow dispatch on the `diamonwiggins/test-workflow-dispatch` branch with:

```
curl -X POST \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer $GITHUB_TOKEN" \
  https://api.github.com/repos/replicatedhq/replicated-docs/actions/workflows/embedded-cluster-release-notes.yml/dispatches \
  -d '{
    "ref": "diamonwiggins/test-workflow-dispatch",
    "inputs": {
      "version": "2.4.0+k8s-1.30" 
    }
  }'
```

https://github.com/replicatedhq/replicated-docs/blob/diamonwiggins/test-workflow-dispatch/.github/workflows/embedded-cluster-release-notes.yml