### PR TITLE
Update CMX history info to discuss Queued Timeout status

### DIFF
--- a/docs/vendor/compatibility-matrix-usage.md
+++ b/docs/vendor/compatibility-matrix-usage.md
@@ -9,11 +9,17 @@ historical information about both clusters and VMs, as shown below:
 ![Compatibility Matrix History Page](/images/compatibility-matrix-history.png)
 [View a larger version of this image](/images/compatibility-matrix-history.png)
 
-Only _terminated_ clusters and VMs that have been deleted or errored are displayed on the **History** page.
+The **History** page displays clusters and VMs that have either been
+_terminated_ or remained _queued_ for greater than 24 hours and have been
+removed.  If a cluster or VM has been removed after sitting in _queued_ state
+for greater than 24 hours, it will be displayed as "Queued Timeout" within the
+status column.
 
-The top of the **History** page displays the total number of terminated clusters and VMs
-in the selected time period as well as the total cost and usage time for
-the terminated resources.
+The top of the **History** page displays the total number of non-running clusters
+and VMs in the selected time period as well as the total cost and usage time
+for the non-running resources.  The total cost is calculated at termination and
+is based on the time the resource was running.  Clusters and VMs that never
+entered _running_ state are not included in the total cost and usage time.
 
 The table includes cluster and VM entries with the following columns:
 - **Name:** The name of the cluster or VM.

--- a/docs/vendor/compatibility-matrix-usage.md
+++ b/docs/vendor/compatibility-matrix-usage.md
@@ -9,17 +9,16 @@ historical information about both clusters and VMs, as shown below:
 ![Compatibility Matrix History Page](/images/compatibility-matrix-history.png)
 [View a larger version of this image](/images/compatibility-matrix-history.png)
 
-The **History** page displays clusters and VMs that have either been
-_terminated_ or remained _queued_ for greater than 24 hours and have been
-removed.  If a cluster or VM has been removed after sitting in _queued_ state
-for greater than 24 hours, it will be displayed as "Queued Timeout" within the
-status column.
+The **History** page displays clusters and VMs with one of the following statuses:
+* Terminated
+* Error
+* Queued Timeout. A Queued Timeout status indicates that the cluster or VM was automatically removed after being in a _queued_ state for more than 24 hours.
 
 The top of the **History** page displays the total number of non-running clusters
 and VMs in the selected time period as well as the total cost and usage time
 for the non-running resources.  The total cost is calculated at termination and
 is based on the time the resource was running.  Clusters and VMs that never
-entered _running_ state are not included in the total cost and usage time.
+entered the _running_ state are not included in the total cost and usage time.
 
 The table includes cluster and VM entries with the following columns:
 - **Name:** The name of the cluster or VM.


### PR DESCRIPTION
After changes in https://github.com/replicatedhq/vandoor/pull/7513, the CMX history page can now show a `"Queued Timeout"` status, this provides documentation around this new status and how the CMX history page has been changed to now show clusters and VMs that may have this status in addition to `terminated`.