### PR TITLE
Revert "ETCD port 2379 must be open between nodes"

### DIFF
--- a/docs/partials/embedded-cluster/_port-reqs.mdx
+++ b/docs/partials/embedded-cluster/_port-reqs.mdx
@@ -4,6 +4,7 @@ This section lists the ports used by Embedded Cluster. These ports must be open 
 
 The following ports must be open and available for use by local processes running on the same node. It is not necessary to create firewall openings for these ports.
 
+* 2379/TCP
 * 7443/TCP
 * 9099/TCP
 * 10248/TCP
@@ -18,7 +19,6 @@ For multi-node installations, create firewall openings between nodes for these p
 
 For single-node installations, ensure that there are no other processes using these ports. Although there is no communication between nodes in single-node installations, these ports are still required.
 
-* 2379/TCP
 * 2380/TCP
 * 4789/UDP
 * 6443/TCP

--- a/static/vendor/embedded-overview.md
+++ b/static/vendor/embedded-overview.md
@@ -146,6 +146,7 @@ This section lists the ports used by Embedded Cluster. These ports must be open 
 
 The following ports must be open and available for use by local processes running on the same node. It is not necessary to create firewall openings for these ports.
 
+* 2379/TCP
 * 7443/TCP
 * 9099/TCP
 * 10248/TCP
@@ -160,7 +161,6 @@ For multi-node installations, create firewall openings between nodes for these p
 
 For single-node installations, ensure that there are no other processes using these ports. Although there is no communication between nodes in single-node installations, these ports are still required.
 
-* 2379/TCP
 * 2380/TCP
 * 4789/UDP
 * 6443/TCP


### PR DESCRIPTION
Reverts replicatedhq/replicated-docs#3287

This is not true for k0s.