### PR TITLE
Fixing minor layout glitch

### DIFF
--- a/docs/release-notes/rn-embedded-cluster.md
+++ b/docs/release-notes/rn-embedded-cluster.md
@@ -31,7 +31,7 @@ Released on June 5, 2025
   </tr>
   <tr>
     <th>KOTS Version</th>
-    <td id="center" colspan="2">1.124.17</td>
+    <td id="center" colspan="3">1.124.17</td>
   </tr>
 </table>
 


### PR DESCRIPTION
Since we now support three versions, the version table has three columns and the last row needs to span all three columns

![Screenshot 2025-06-05 at 4 17 14 PM](https://github.com/user-attachments/assets/f94300f3-dec9-4d73-aa66-a4efe9139970)
