### PR TITLE
chore(cmx): update support for rke2

### DIFF
--- a/docs/vendor/testing-supported-clusters.md
+++ b/docs/vendor/testing-supported-clusters.md
@@ -123,7 +123,7 @@ Compatibility Matrix supports creating [RKE2](https://docs.rke2.io/) clusters.
   </tr>
   <tr>
     <th>Node Groups</th>
-    <td>Yes</td>
+    <td>No</td>
   </tr>
   <tr>
     <th>Node Auto Scaling</th>
@@ -131,7 +131,7 @@ Compatibility Matrix supports creating [RKE2](https://docs.rke2.io/) clusters.
   </tr>
   <tr>
     <th>Nodes</th>
-    <td>Supports multiple nodes.</td>
+    <td>Supports a single node.</td>
   </tr>
   <tr>
     <th>IP Family</th>


### PR DESCRIPTION
This updates the support for RKE2, as of https://github.com/replicatedhq/vandoor/pull/7552 we are disabling multi-node in RKE2 until VXLAN arrives.  Once that rolls out we can revert this PR.