### PR TITLE
adds new RBAC routes for restricted EP Invite domains

### DIFF
--- a/docs/vendor/team-management-rbac-resource-names.md
+++ b/docs/vendor/team-management-rbac-resource-names.md
@@ -202,6 +202,18 @@ Grants the holder permission to create Enterprise Portal customer users for the 
 
 Grants the holder permission to delete Enterprise Portal customer users for the specified application.
 
+### kots/app/[:appId]/enterprise-portal/customer-allowed-domains/read
+
+Grants the holder permission to view Enterprise Portal customer allowed domains for the specified application.
+
+### kots/app/[:appId]/enterprise-portal/customer-allowed-domains/create
+
+Grants the holder permission to create and manage Enterprise Portal customer allowed domains for the specified application.
+
+### kots/app/[:appId]/enterprise-portal/customer-allowed-domains/delete
+
+Grants the holder permission to delete Enterprise Portal customer allowed domains for the specified application.
+
 ### kots/app/[:appId]/enterprise-portal/documentation/read
 
 Grants the holder permission to view Enterprise Portal documentation settings for the specified application.


### PR DESCRIPTION
Adds new RBAC Routes for restricted Enterprise Portal Invite domains. 

https://app.shortcut.com/replicated/story/122863/ep-customer-access-restrict-email-invites-to-specific-domains