### PR TITLE
Improve helm air gap instructions

### DIFF
--- a/docs/partials/helm/_helm-install-prereqs.mdx
+++ b/docs/partials/helm/_helm-install-prereqs.mdx
@@ -1,6 +1,6 @@
 * The customer used to install must have a valid email address. This email address is only used as a username for the Replicated registry and is never contacted. For more information about creating and editing customers in the Vendor Portal, see [Creating a Customer](/vendor/releases-creating-customer).
 
-* The customer used to install must have the **Existing Cluster (Helm CLI)** install type enabled. For more information about enabling install types for customers in the Vendor Portal, see [Manage Install Types for a License](licenses-install-types).
+* The customer used to install must have the **Existing Cluster (Helm CLI)** install type enabled. If installing into an air gap environment, additionally enable the **Helm CLI Air Gap Instructions** option for the customer. For more information about enabling install types for customers in the Vendor Portal, see [Manage Install Types for a License](licenses-install-types).
 
 * To ensure that the Replicated proxy registry can be used to grant proxy access to your application images during Helm installations, you must create an image pull secret for the proxy registry and add it to your Helm chart. To do so, follow the steps in [Using the Proxy Registry with Helm Installations](/vendor/helm-image-registry).
 

--- a/docs/vendor/helm-install-airgap.mdx
+++ b/docs/vendor/helm-install-airgap.mdx
@@ -24,8 +24,6 @@ Each method assumes that your customer is familiar with `curl`, `docker`, `helm`
 
 Before you install, complete the following prerequisites:
 
-* Reach out to your account rep to enable the Helm air gap installation feature.
-
 <Prerequisites/>
 
 ## Install


### PR DESCRIPTION
* Removes a reference from back when it was behind a feature flag
* Mentions that the Air Gap option has to be selected as well