### PR TITLE
Removing an old alpha reference on EC doc

### DIFF
--- a/docs/vendor/embedded-using.mdx
+++ b/docs/vendor/embedded-using.mdx
@@ -153,11 +153,11 @@ Users can add nodes to a cluster with Embedded Cluster from the Admin Console. T
 
 For more information, see [Manage Multi-Node Clusters with Embedded Cluster](/enterprise/embedded-manage-nodes).
 
-### High Availability for Multi-Node Clusters (Alpha)
+### High Availability for Multi-Node Clusters
 
 Multi-node clusters are not highly available by default. Enabling high availability (HA) requires that at least three controller nodes are present in the cluster. Users can enable HA when joining the third node.
 
-For more information about creating HA multi-node clusters with Embedded Cluster, see [Enable High Availability for Multi-Node Clusters (Alpha)](/enterprise/embedded-manage-nodes#ha) in _Managing Multi-Node Clusters with Embedded Cluster_.
+For more information about creating HA multi-node clusters with Embedded Cluster, see [Enable High Availability for Multi-Node Clusters](/enterprise/embedded-manage-nodes#ha) in _Managing Multi-Node Clusters with Embedded Cluster_.
 
 ## About Performing Updates with Embedded Cluster
 


### PR DESCRIPTION
Still said alpha in this section of the docs, but has been GA since 2.4.0 https://docs.replicated.com/release-notes/rn-embedded-cluster#240