### PR TITLE
Fix Linux install commands

### DIFF
--- a/docs/partials/replicated-cli/_install-linux.mdx
+++ b/docs/partials/replicated-cli/_install-linux.mdx
@@ -1,10 +1,11 @@
 Run the following command:
 
     ```shell
-    curl -Ls $(curl -s https://api.github.com/repos/replicatedhq/replicated/releases/latest \
-      | grep "browser_download_url.*linux_amd64.tar.gz" \
-      | cut -d : -f 2,3 \
-      | tr -d \") -o replicated.tar.gz
+    version=$(curl -s https://api.github.com/repos/replicatedhq/replicated/releases/latest \
+      | grep -m1 -Po '"tag_name":\s*"v\K[^"]+')
+    curl -Ls \
+      "https://github.com/replicatedhq/replicated/releases/download/v${version}/replicated_${version}_linux_amd64.tar.gz" \
+      -o replicated.tar.gz
     tar xf replicated.tar.gz replicated && rm replicated.tar.gz
     mv replicated /usr/local/bin/replicated
     ```


### PR DESCRIPTION
The Linux install commands relied on grepping for
`browser_download_url` in the latest release JSON. Unfortunately there are more than one occurrence of that string, and it produces an incorrect download URL.

Modify the Linux install commands to instead grep for the latest version, and then explicitly generate the download URL based on that.