### PR TITLE
reduce headless EC install docs confusion

### DIFF
--- a/docs/enterprise/installing-embedded-automation.mdx
+++ b/docs/enterprise/installing-embedded-automation.mdx
@@ -19,8 +19,6 @@ The KOTS ConfigValues file includes the fields that are defined in the KOTS Conf
 
 <ConfigValuesExample/>
 
-<ConfigValuesProcedure/>
-
 ## Online (Internet-Connected) Installation
 
 To install with Embedded Cluster in an online environment:


### PR DESCRIPTION
Removed the procedure partial which was causing confusion on this page with both the mention of existing cluster installs and the reference to the kots cli procedure which vendors then expected to work with EC installs. 

I don't think it's really necessary to say how to scrape the UI for config on this page (only used to recreate an existing install). And I'd like to see that improved in EC so it's not UI-based for a headless install. If we find we do need to add that UI procedure back before then, we'll want to add just that relevant part back vs the whole partial previously there. 

related internal slack thread about changing this page: https://replicated.slack.com/archives/C0499EGNPNY/p1753456745585659