### PR TITLE
Moves Intel instructions under Apple Silicon instructions

### DIFF
--- a/docs/vendor/environment-setup.mdx
+++ b/docs/vendor/environment-setup.mdx
@@ -188,20 +188,19 @@ For more information, see the [sbctl](https://github.com/replicatedhq/sbctl) rep
 
 To install sbctl, run one of the following commands:
 
+* macOS Apple Silicon:
+    ```bash
+    curl -LO https://github.com/replicatedhq/sbctl/releases/latest/download/sbctl_darwin_arm64.tar.gz
+    tar -xzf sbctl_darwin_arm64.tar.gz -C /tmp sbctl
+    rm -f sbctl_darwin_arm64.tar.gz
+    sudo mv /tmp/sbctl /usr/local/bin/
+    ```
 * macOS Intel systems:
 
     ```bash
     curl -LO https://github.com/replicatedhq/sbctl/releases/latest/download/sbctl_darwin_amd64.tar.gz
     tar -xzf sbctl_darwin_amd64.tar.gz -C /tmp sbctl
     rm -f sbctl_darwin_amd64.tar.gz
-    sudo mv /tmp/sbctl /usr/local/bin/
-    ```
-
-* macOS Apple Silicon:
-    ```bash
-    curl -LO https://github.com/replicatedhq/sbctl/releases/latest/download/sbctl_darwin_arm64.tar.gz
-    tar -xzf sbctl_darwin_arm64.tar.gz -C /tmp sbctl
-    rm -f sbctl_darwin_arm64.tar.gz
     sudo mv /tmp/sbctl /usr/local/bin/
     ```
 


### PR DESCRIPTION
Update the `sbctl` install instructions so that Apple Silicon is first for Macs since people are more likely to be running Apple Silicon and more likely to pick the first option.