### PR TITLE
make EP supported users clearer

### DIFF
--- a/docs/vendor/enterprise-portal-about.mdx
+++ b/docs/vendor/enterprise-portal-about.mdx
@@ -4,8 +4,10 @@ This topic provides an overview of the Replicated Enterprise Portal.
 
 ## Overview
 
-The Enterprise Portal is a customizable, web-based portal that provides a centralized location where your Embedded Cluster and Helm CLI installation method customers can:
-* View application install and update instructions
+The Enterprise Portal is a customizable, web-based portal for customers that install using either Replicated Embedded Cluster or the Helm CLI.
+
+From the Enterprise Portal, your customers can:
+* View application install and update instructions for Embedded Cluster and Helm CLI installations
 * Manage their team members and service accounts
 * Upload support bundles
 * View insights about their active and inactive instances
@@ -35,7 +37,7 @@ For information about using the Enterprise Portal, see [Access and Use the Enter
 
 * The Enterprise Portal is Beta. The features and functionality of the Enterprise Portal are subject to change.
 
-* Installation and upgrade instructions are available only for Embedded Cluster and Helm installations. The Enterprise Portal does not provide instructions for installing and upgrading with KOTS in existing clusters, or with kURL installer clusters.
+* Installation and upgrade instructions are available only for Embedded Cluster and Helm CLI installations. The Enterprise Portal does not provide instructions for installing and upgrading with KOTS in existing clusters or with kURL.
 
 * Air gap instance records do not appear in the Enterprise Portal until the end customer creates an air gap instance record by either uploading a support bundle for that instance or manually entering instance information. For more information, see [View Active and Inactive Instances](/vendor/enterprise-portal-use#view-active-and-inactive-instances) in _Access and Use the Enterprise Portal_.
 
@@ -45,9 +47,11 @@ For information about using the Enterprise Portal, see [Access and Use the Enter
 
 The Enterprise Portal is the next generation version of the Replicated Download Portal. Compared to the Download Portal, the Enterprise Portal not only provides access to installation assets and instructions, but also allows users to track available updates, manage their team and service accounts, view the status of their instances, view license details, and more. These features are designed to make it easier for your customers to manage their instances of your application from a centralized location outside of the installation environment.
 
-You can migrate existing Embedded Cluster and Helm CLI installation method customers from the Download Portal to the Enterprise Portal by enabling the Enterprise Portal for their license. For more information, see [Manage Enterprise Portal Access](enterprise-portal-invite).
+For more information about enabling Enterprise Portal access for your customers that install using either Embedded Cluster or the Helm CLI, see [Manage Enterprise Portal Access](enterprise-portal-invite).
 
-KOTS Existing Cluster and KURL installation method customers should continue to utilize the Download Portal to retrieve needed installation assets. 
+:::note
+The Entprise Portal supports Embedded Cluster and Helm CLI installation methods only. Customers that use KOTS in an existing cluster or kURL can continue to use the Download Portal. 
+:::
 
 For more information about the Download Portal, see [Access a Customer's Download Portal](/vendor/releases-share-download-portal).
 

--- a/docs/vendor/enterprise-portal-invite.mdx
+++ b/docs/vendor/enterprise-portal-invite.mdx
@@ -1,9 +1,5 @@
 # Manage Enterprise Portal Access (Beta)
 
-:::note
-The Entprise Portal currently supports Embedded Cluster and Helm CLI installation methods. If your customer is using KOTS Existing Cluster or kURL installer methods, they should continue to leverage the Replicated Download Portal instead. 
-:::
-
 This topic describes how to enable or disable customer access to the Enterprise Portal. It also describes how to invite users to the Enterprise Portal from the Replicated Vendor Portal.
 
 For information about customizing the invitation email, see [Customize the Enterprise Portal](enterprise-portal-configure).
@@ -11,6 +7,10 @@ For information about customizing the invitation email, see [Customize the Enter
 ## Manage Customer Access to the Enterprise Portal {#manage-ep-access}
 
 You can enable and disable access to the Enterprise Portal for all customers, or on a per-customer basis. When access to the Enterprise Portal is disabled, the customer has access to the Replicated Download Portal instead.
+
+:::note
+The Entprise Portal supports Embedded Cluster and Helm CLI installation methods only. Customers that use KOTS in an existing cluster or kURL can continue to use the Download Portal. 
+:::
 
 To control customer access to the Enterprise Portal:
 


### PR DESCRIPTION
Preview: https://deploy-preview-3629--replicated-docs-upgrade.netlify.app/vendor/enterprise-portal-about

This PR results from a support escalation where a user was confused why EP wasn't working for them once enabled, but they had a kots/kurl install which EP says it doesn't support (but a bit buried in limitations currently). I'll look at adding in-product helper text as well. 