### PR TITLE
Update Velero version compatibility table

### DIFF
--- a/docs/partials/snapshots/_velero-compatibility.mdx
+++ b/docs/partials/snapshots/_velero-compatibility.mdx
@@ -1,0 +1,10 @@
+The following table lists which versions of Velero are compatible with each version of KOTS. For a list of the supported Kubernetes versions for each Velero version, see [Velero compatibility matrix](https://github.com/vmware-tanzu/velero#velero-compatibility-matrix) in the vmware-tanzu/velero repository.
+
+| KOTS version | Velero version |
+|------|-------------|
+| 1.125.2 and later | 1.11.0 to 1.16.2 |
+| 1.125.0 and later | 1.11.0 to 1.16.1 |
+| 1.124.18 and later | 1.11.0 to 1.16.0 |
+| 1.124.0 and later | 1.11.0 to 1.15.2 |
+| 1.123.1 and later | 1.11.0 to 1.15.1 |
+| 1.117.3 and later | 1.11.0 to 1.14.1 |

--- a/docs/release-notes/rn-app-manager.md
+++ b/docs/release-notes/rn-app-manager.md
@@ -5,6 +5,7 @@ pagination_prev: null
 ---
 
 import KubernetesCompatibility from "../partials/install/_kubernetes-compatibility.mdx"
+import VeleroCompatibility from "../partials/snapshots/_velero-compatibility.mdx"
 
 # KOTS Release Notes
 
@@ -15,6 +16,12 @@ This topic contains release notes for the [Replicated KOTS](../intro-kots) insta
 The following table lists the versions of Kubernetes that are compatible with each version of KOTS:
 
 <KubernetesCompatibility/>
+
+## Velero Compatibility
+
+Velero is used to provide backup and restore functionality for the Replicated snapshots feature. For more information, see [About Backup and Restore with Snapshots](/vendor/snapshots-overview).
+
+<VeleroCompatibility/>
 
 <!--RELEASE_NOTES_PLACEHOLDER-->
 

--- a/docs/vendor/snapshots-overview.mdx
+++ b/docs/vendor/snapshots-overview.mdx
@@ -5,6 +5,7 @@ import Dr from "../partials/snapshots/_limitation-dr.mdx"
 import Os from "../partials/snapshots/_limitation-os.mdx"
 import InstallMethod from "../partials/snapshots/_limitation-install-method.mdx"
 import CliRestores from "../partials/snapshots/_limitation-cli-restores.mdx"
+import VeleroCompatibility from "../partials/snapshots/_velero-compatibility.mdx"
 
 # About Backup and Restore with Snapshots
 
@@ -46,13 +47,7 @@ In addition to the default functionality that Velero provides, KOTS exposes hook
 
 ### Velero Version Compatibility
 
-The following table lists which versions of Velero are compatible with each version of KOTS. For more information, see the [Velero documentation](https://velero.io/docs/).
-
-| KOTS version | Velero version |
-|------|-------------|
-| 1.15 to 1.20.2 | 1.2.0 |
-| 1.20.3 to 1.94.0 | 1.5.1 through 1.9.x |
-| 1.94.1 and later | 1.6.x through 1.12.x |
+<VeleroCompatibility/>
 
 ## About Backups
 


### PR DESCRIPTION
Adds velero table as a partial to 
- kots release notes https://deploy-preview-3646--replicated-docs.netlify.app/release-notes/rn-app-manager#velero-compatibility
- snapshots overview https://deploy-preview-3646--replicated-docs.netlify.app/vendor/snapshots-overview#velero-version-compatibility