### PR TITLE
Enhancing support bundle content

### DIFF
--- a/docs/vendor/preflight-support-bundle-about.mdx
+++ b/docs/vendor/preflight-support-bundle-about.mdx
@@ -115,23 +115,13 @@ This section provides an overview of support bundles, including how support bund
 
 ### Overview
 
-A support bundle is a valuable diagnostic tool that collects and analyzes key troubleshooting data from the customer deployment to enable the end user to self-diagnose and resolve, and when escalating is necessary, it provides the supoprt teams with key necessary information upfront, reducing overall issue resolution time. Replicated has found that Severity 1 issues are resolved three times faster when a support bundle is provided during an issue escalation. 
+A support bundle is a diagnostic tool that collects and analyzes key troubleshooting data from a customer deployment. Support bundles are designed to help end customers self-diagnose and resolve issues.
 
-The data collected in a support bundle depends on the collectors and redactors defined by the Vendor in the support bundle specification included with the application release. See [Customizing Support Bundles](/vendor/preflight-support-bundle-about#customizing-support-bundles) for more information.
+When it is necessary for the customer to escalate their issue, support bundles provide vendor support teams with the information they need for troubleshooting upfront, reducing overall issue resolution time. Replicated has found that Severity 1 issues are resolved three times faster when a support bundle is provided during an issue escalation. 
 
-When a support bundle is generated the process collects defined data from the cluster, redacts sensitive fields, and then perform analysis on the data to provide remediation steps. The output is a compressed tar.gz file that can be subsequently shared during a support escalation. No data is shared outside the cluster unless the resulting tar.gz file is explicitly shared by the end customer. See [Generating and Sharing Support Bundles](/vendor/preflight-support-bundle-about#generating-and-sharing-support-bundles) for more information.
+The data collected in a support bundle depends on the [collectors](#collect) and [redactors](#redact) defined by the vendor in the support bundle spec included with the application release. For more information about the automatic redactions that are made in support bundles, see [Redact](#redact) above. For more information about customizing the data that is collected in support bundles for your application, see [Customizing the Support Bundle Spec For Your Application](#customize) below.
 
-Support bundles can collect a variety of important cluster-level data from customer environments, such as:
-* Pod logs
-* Node resources and status
-* The status of replicas in a Deployment
-* Cluster information
-* Resources deployed to the cluster
-* The history of Helm releases installed in the cluster
-
-Support bundles can also be used for more advanced use cases, such as checking that a command successfully executes in a pod in the cluster, or that an HTTP request returns a succesful response.
-
-See [Redact](/vendor/preflight-support-bundle-about#redact) for automatic redactions in generated support bundles. 
+When an end customer generates a support bundle, the process uses the vendor-defined spec to collect data from the cluster, redact sensitive fields, and then perform an analysis on the data to provide remediation steps. The output is a compressed `tar.gz` file that can be shared with the vendor as part of a support escalation. No data is shared outside the cluster unless the `tar.gz` support bundle file is explicitly shared by the end customer. For more information, see [How Customers Generate and Share Support Bundles](#generate-share) below.
 
 ### About Host Support Bundles
 
@@ -141,37 +131,61 @@ For Embedded Cluster installations, a default spec can be used to generate suppo
 
 For kURL installations, vendors can customize a host support bundle spec for their application. See [Generate Host Bundles for kURL](/vendor/support-host-support-bundles).
 
-### Customizing Support Bundles
+### Customizing the Support Bundle Spec For Your Application {#customize}
 
-To enable support bundles for your application, add a support bundle YAML specification to a release. An empty support bundle specification automatically includes several default collectors and analzyers. You can also optionally customize the support bundle specification for by adding, removing, or editing collectors and analyzers.
+To enable customers to collect support bundles for your application, add a support bundle YAML specification to an application release. An empty support bundle specification automatically includes default [redactors](#redact), as well as several default [collectors](#collect) and [analzyers](#analyze). You can also optionally customize the support bundle specification by adding, removing, or editing collectors and analyzers.
+
+Support bundles can collect a variety of important cluster-level data from customer environments, such as:
+* Pod logs
+* Node resources and status
+* The status of replicas in a Deployment
+* Cluster information
+* Resources deployed to the cluster
+* The history of Helm releases installed in the cluster
+
+Support bundles can also be used for more advanced use cases, such as checking that a command successfully executes in a pod in the cluster, or that an HTTP request returns a succesful response. 
 
 For more information, see [Add and Customize Support Bundles](support-bundle-customizing).
 
-### Generating and Sharing Support Bundles
+### How Customers Generate and Share Support Bundles {#generate-share}
 
-Users generate support bundles as `tar.gz` files from the command line using the support-bundle kubectl plugin, or via the KOTS Admin Console. Your customers can then share their support bundles with your team by sending you the resulting `tar.gz` file.
+Users generate support bundles as `tar.gz` files from the command line using the support-bundle kubectl plugin. KOTS and Embedded Cluster users can also generate bundles from the Admin Console UI.
 
-Your customer has multiple options to provide you with the generated support bundle. We recommend adivising your customer to use one of the following methods:
-* Directly upload their support bundles via their Enterprise Portal. Using this method additionally gives the customer control to download and delete their own bundles. For more information see [Upload and Manage Support Bundles](/vendor/enterprise-portal-use#collect-upload-and-manage-support-bundles). 
-* KOTS and Embedded Cluster users can also share support bundles from the KOTS Admin Console once generated. For more information, see [Generate Support Bundles](support-bundle-generating).
+Your customers can share their support bundles with your team by sending you the `tar.gz` file. No data is shared outside the cluster unless the `tar.gz` support bundle file is explicitly shared by the end customer.
 
-By providing the support bundle via one of the above methods, the file and its comprehensive analysis results are directly available within the Vendor Portal, saving you the step of of manually uploading the provided file for the purpose of analaysis or sharing with Replicated Support. 
+Replicated recommends that customers share their support bundles with you using one of the following methods:
+* Upload the support bundle in their Enterprise Portal. This allows the customer to download and delete their own support bundles. For more information, see [Collect, Upload, and Manage Support Bundles](/vendor/enterprise-portal-use#collect-upload-and-manage-support-bundles) in _Access and Use the Enterprise Portal_. 
+* KOTS and Embedded Cluster users can also generate and share support bundles from the Admin Console. For more information, see [Generate Support Bundles from the Admin Console](/enterprise/troubleshooting-an-app).
 
-The Support Bundle Analysis page includes:
-* Analysis Overview: Filterable view showing errors, warnings, and insights
-* Instance Reporting Data: Point-in-time information about the instance
-* File Inspector: Directory tree browser for examining collected files
-* Download Option: Ability to download the bundle for offline analysis
+When customers upload their support bundle in the Enterprise Portal or Admin Console, the support bundle and its comprehensive analysis results are automatically made available to you in the Vendor Portal.
 
-Vendors have direct control of uploaded support bundles, including sharing with Replicated or deleting previously uploaded bundles. 
+### Managing and Inspecting Support Bundles in the Vendor Portal {#upload-inspect}
 
-When uploaded to Vendor Portal, support bundles are stored per Replicated's data and security standards. See [Security at Replicated](https://www.replicated.com/security) for more information.
+Support bundles are automatically uploaded to the Vendor Portal when customers share bundles through the Enterprise Portal or Admin Console. You can also manually upload support bundle `.tar.gz` files to the Vendor Portal.
+
+From the Vendor Portal, you have control over uploaded support bundles, including sharing bundles with Replicated or deleting previously uploaded bundles. Support bundles uploaded to the Vendor Portal are stored per Replicated's data and security standards. For more information, see [Security at Replicated](https://www.replicated.com/security).
+
+You can inspect uploaded support bundles on the Vendor Portal **Support bundle analysis** page:
+
+![Support bundle analysis page](/images/support-bundle-analysis-overview.png)
+
+[View a larger version of this image](/images/support-bundle-analysis-overview.png)
+
+As shown in the image above, the **Support bundle analysis** page includes information and features to help you analyze a support bundle, such as:
+* Details about the bundle, including the customer and instance it is associated with, when it was collected and uploaded, and more
+* Any available instance details from the point in time when the bundle was collected
+* An analysis overview that can be filtered to show errors and warnings
+* A file inspector for more detailed analaysis
+
+From the **Support bundle analysis** page, you can also share the bundle with Replicated or download the bundle for offline analysis.
+
+For more information about using the **Support bundle analysis** page, see [Inspect Support Bundles](/vendor/support-inspecting-support-bundles).
 
 ### Sharing Support Bundles with Replicated
 
 Replicated strongly recommends that you always provide a support bundle when you open a new support request, and that you attach new bundles to an existing support issue when conditions change or new problems arise. Sharing an existing support bundle or uploading a new one is secure and provides the Replicated Support team immediate access to necessary diagnostic data, enabling them to provide faster and more informed assistance in troubleshooting your application. 
 
-See [Submit a Support Request](/vendor/support-submit-request) for more information. 
+For more information, see [Submit a Support Request](/vendor/support-submit-request). 
 
 
 


### PR DESCRIPTION
Preview: https://deploy-preview-3658--replicated-docs.netlify.app/vendor/preflight-support-bundle-about#support-bundles 

Keeping various deeper content pieces where they're at now on other linked pages, but extending this overview summary so it covers the full scope of support bundle considerations high-level. 

Based on recent customer feedback that it was too unclear on how to explain everything involved in the support bundle process to others at a high-level ahead of needing to jump into the detailed "how to" pages. 