### PR TITLE
Refactor Helm template for replicated pull secret

### DIFF
--- a/docs/vendor/helm-image-registry.mdx
+++ b/docs/vendor/helm-image-registry.mdx
@@ -35,7 +35,9 @@ To configure your application to use the proxy registry with Helm CLI installati
    ```yaml
    # templates/replicated-pull-secret.yaml
 
-   {{ if .Values.global.replicated.dockerconfigjson }}
+   {{- $global := default dict .Values.global -}}
+   {{- $replicated := default dict (index $global "replicated") -}}
+   {{- if hasKey $replicated "dockerconfigjson" }}
    apiVersion: v1
    kind: Secret
    metadata:


### PR DESCRIPTION
helm template fails when the .Values.global.replicated dict is empty