### PR TITLE
Update algolia crawl workflow

### DIFF
--- a/.github/workflows/algolia-crawl.yml
+++ b/.github/workflows/algolia-crawl.yml
@@ -1,23 +1,20 @@
 name: Algolia Crawler
 
+concurrency: algolia-crawl
+
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
-  algolia_crawl:
-    name: Algolia Recrawl
+  trigger_crawl:
+    name: Trigger Algolia Crawl
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-
-      - name: Algolia crawler creation and crawl
-        uses: algolia/algoliasearch-crawler-github-actions@v1.1.13
-        id: algolia_crawler
-        with:
-          crawler-user-id: ${{ secrets.CRAWLER_USER_ID }}
-          crawler-api-key: ${{ secrets.CRAWLER_API_KEY }}
-          algolia-app-id: ${{ secrets.ALGOLIA_APP_ID }}
-          algolia-api-key: ${{ secrets.ALGOLIA_API_KEY }}
-          site-url: 'https://docs.replicated.com/'
+      - name: Trigger Algolia Crawler
+        run: |
+          curl -X POST \
+            'https://crawler.algolia.com/api/1/crawlers/${{ secrets.CRAWLER_ID }}/reindex' \
+            -H 'Content-Type: application/json' \
+            --user '${{ secrets.CRAWLER_USER_ID }}:${{ secrets.CRAWLER_API_KEY }}'


### PR DESCRIPTION
The existing scrape job has been broken since we switched to the new Algolia DocSearch program for our search. Note that the old DocSearch scraper that we were using is now deprecated: https://github.com/algolia/docsearch-scraper

This PR adds a new github action that would crawl the site each time a PR is merged to main

As part of this change, new secrets are added to this github repo:
- CRAWLER_ID: from Data Sources > Crawler > Crawers tab > Replicated Docs > Configuration > Settings
- CRAWLER_API_KEY: from Data Sources > Crawler > Settings tab