### PR TITLE
chore: remove eks 1.28 and move 1.31 to extended support

### DIFF
--- a/docs/vendor/testing-supported-clusters.md
+++ b/docs/vendor/testing-supported-clusters.md
@@ -318,7 +318,7 @@ CMX supports creating [AWS EKS](https://aws.amazon.com/eks/?nc2=type_a) clusters
   </tr>
   <tr>
     <th>Supported Kubernetes Versions</th>
-    <td><p>{/* START_eks_VERSIONS */}1.28, 1.29, 1.30, 1.31, 1.32, 1.33, 1.34{/* END_eks_VERSIONS */}</p><p>Extended Support Versions: 1.28, 1.29, 1.30</p></td>
+    <td><p>{/* START_eks_VERSIONS */}1.29, 1.30, 1.31, 1.32, 1.33, 1.34{/* END_eks_VERSIONS */}</p><p>Extended Support Versions: 1.29, 1.30, 1.31</p></td>
   </tr>
   <tr>
     <th>Supported Instance Types</th>


### PR DESCRIPTION
EKS dropped 1.28 from extended support and moved 1.31 to extended support on Nov 25. 