### PR TITLE
Enhance custom license fields documentation with use cases and examples

### DIFF
--- a/docs/vendor/licenses-about.mdx
+++ b/docs/vendor/licenses-about.mdx
@@ -65,9 +65,9 @@ You can change the type of a license at any time in the Vendor Portal. For examp
 
 Each customer record in the Vendor Portal has built-in fields and also supports custom fields:
 * The built-in fields include values such as the customer name, customer email, and the license expiration date. You can optionally set initial values for the built-in fields so that each new customer created in the Vendor Portal starts with the same set of values.
-* You can also create custom fields to define entitlements for your application. For example, you can create a custom field to set the number of active users permitted.
+* You can also create custom fields to define entitlements for your application. For example, you can create a custom field to set the number of active users permitted, or add metadata like `contract_type`, `renewal_date`, or `account_manager` for reporting purposes.
 
-For more information, see [Manage Customer License Fields](/vendor/licenses-adding-custom-fields).
+For more information, see [Manage Built-In License Fields](/vendor/licenses-adding-custom-fields#manage-built-in-license-fields) and [Manage Custom License Fields](/vendor/licenses-adding-custom-fields#manage-custom-license-fields).
 
 You can make changes to a customer record in the Vendor Portal at any time. The license ID, which is the unique identifier for the customer, never changes. For more information about managing customers in the Vendor Portal, see [Create and Manage Customers](releases-creating-customer).
 

--- a/docs/vendor/licenses-adding-custom-fields.md
+++ b/docs/vendor/licenses-adding-custom-fields.md
@@ -7,20 +7,10 @@ This topic describes how to manage customer license fields in the Replicated Ven
 License fields allow you to control customer entitlements and configure application behavior. The Replicated Vendor Portal includes built-in fields (such as license expiration and install options) and supports custom fields for application-specific requirements.
 
 For information about how to access license field values in your application, see:
-- For Replicated SDK: [Get License Fields with the Replicated SDK API](licenses-reference-sdk)
-- For KOTS installers: [Get License Fields in KOTS Applications](licenses-reference-kots-runtime)
+- For the Replicated SDK: [Get License Fields with the Replicated SDK API](licenses-reference-sdk)
+- For Replicated installers (Embedded Cluster, KOTS, kURL): [Get License Fields in KOTS Applications](licenses-reference-kots-runtime)
 - For Helm installations: [Get License Fields in Helm Installations](licenses-reference-helm)
 - For verification: [Verify Signature and Get License Fields with the SDK API](licenses-verify-fields-sdk-api)
-
-## Common Use Cases for Custom License Fields
-
-Custom license fields allow you to add business-specific data to customer licenses. Common use cases include:
-
-- **Capacity limits**: Control usage with fields like `max_users`, `seats`, `storage_gb`, or `api_calls_per_month`
-- **Feature tiers**: Use fields like `tier` (basic/premium/enterprise) or `support_level` (standard/priority) to enable different features
-- **Configuration**: Store `api_endpoint`, `region`, `data_center`, or `environment` settings
-- **Credentials**: Include `api_key`, `auth_token`, or `encryption_key` (use Password type to mask values in the UI)
-- **Business logic**: Track `contract_type`, `renewal_date`, or `account_manager` for reporting and workflows
 
 ## Manage Built-In License Fields
 
@@ -74,42 +64,17 @@ To lock a built-in license field:
 
 ## Manage Custom License Fields
 
-You can create custom license fields in the Vendor Portal. For example, you can create a custom license field to set the number of active users permitted. Or, you can create a field that sets the number of nodes a customer is permitted on their cluster.
+You can create custom license fields to add business- and application-specific data to customer licenses. The following are some common use cases for custom license fields:
+
+- Set usage or capacity limits with fields like `max_users`, `seats`, `storage_gb`, or `api_calls_per_month`
+- Enable access to certain features or tiers. For example, you could add a `tier` license field with values such as "basic", "premium", or "enterprise". You could also add a `support_level` field with options for "standard" or "priority".
+- Store configuration settings like `api_endpoint`, `region`, `data_center`, or `environment`
+- Include credentials in the license like `api_key`, `auth_token`, or `encryption_key` using the "Password" license field type to mask values in the UI
+- Add metadata such as `contract_type`, `renewal_date`, or `account_manager` for reporting and workflows
 
 The custom license fields that you create are displayed in the Vendor Portal for all new and existing customers. If the custom field is not hidden, it is also displayed to customers under the **Licenses** tab in the Replicated Admin Console and in the **License Details** tab in the Enterprise Portal.
 
 Custom license fields can also be created and managed through the Vendor API v3, which enables automation and integration with your existing systems. For more information, see [Create a custom license field](https://replicated-vendor-api.readme.io/reference/createcustomlicensefield) in the Vendor API v3 documentation.
-
-### How Custom Fields Appear in Licenses
-
-Custom license fields appear in the customer's license YAML under `spec.entitlements`. Your application can read these values to enforce limits or configure behavior.
-
-The following example shows a license with custom fields:
-
-```yaml
-apiVersion: kots.io/v1beta1
-kind: License
-spec:
-  licenseID: "customer-123"
-  customerName: "Acme Corp"
-  entitlements:
-    expires_at:
-      title: Expiration
-      value: "2026-12-31T00:00:00Z"
-      valueType: String
-    seats:
-      title: Maximum Users
-      value: 100
-      valueType: Integer
-    tier:
-      title: Support Tier
-      value: "enterprise"
-      valueType: String
-    premium_support:
-      title: Premium Support Enabled
-      value: true
-      valueType: Boolean
-```
 
 ### Limitation
 
@@ -133,7 +98,7 @@ To create a custom license field:
    |-----------------------|------------------------|
    | Field | The name used to reference the field. This value cannot be changed. |
    | Title| The display name for the field. This is how the field appears in the Vendor Portal and the Admin Console. You can change the title in the Vendor Portal. |
-   | Type| The field type. This value cannot be changed. See [Understanding Custom License Field Types](#understanding-custom-license-field-types) for more information.
+   | Type| The field type. This value cannot be changed. See [Custom License Field Types](#custom-license-field-types).
    | Default | The default value for the field for both existing and new customers. It is a best practice to provide a default value when possible. The maximum size for a license field value is 64KB. |
    | Required | If checked, this prevents the creation of customers unless this field is explicitly defined with a value. |
    | Hidden | If checked, the field is not visible to your customer in the Replicated Admin Console or in their Enterprise Portal. The field is still visible to you in the Vendor Portal. **Note**: The Hidden field is displayed only for vendors with access to the Replicated installers (KOTS, kURL, Embedded Cluster). |
@@ -180,18 +145,49 @@ To delete a custom license field:
 
 Each custom license field has a _type_ that is used to validate its value. The type also determines the widget that you use to set the license field's value on the **Manager customer** page.
 
-| Type | Description | Purpose | When to Use | Widget |
-|------|-------------|---------|-------------|--------|
-| Integer | A whole number numeric value | Capacity limits, quotas, counts | Use for numeric limits like seats, storage amounts, or API call quotas (e.g., `seats: 100`, `max_nodes: 5`) | Text field |
-| String | Short form text that typically fits on a single line | Short identifiers, tier names, regions | Use for short text values like tier levels, regions, or environment names (e.g., `tier: enterprise`, `region: us-west-2`) | Text field |
-| Text | Longer form text that can contain multiple lines | Long configurations, JSON data, descriptions | Use for multi-line content like JSON configurations, certificates, or long descriptions | Text area |
-| Boolean | True or false value | Feature flags, support options | Use for on/off features or capabilities (e.g., `premium_support: true`, `analytics_enabled: false`) | Checkbox |
-| Password | A short string of text that is masked on display | API keys, tokens, credentials | Use for sensitive values that should be masked in the UI. Note: Values are still cleartext in the license file (e.g., `api_key`, `auth_token`) | Password field |
-| Enum | Provides a list of possible values | Limited choices like tier levels or regions | Use when there are predefined options to choose from (e.g., tier with options: basic, premium, enterprise) | Dropdown |
+| Type | Description | Use cases | Widget |
+|------|-------------|-----------|--------|
+| Integer | A whole number numeric value | Use for numeric capacity limits, quotas, or counts. For example, `seats: 100` or `max_nodes: 5`. | Text field |
+| String | Single-line text values | Use for short form text that fits on a single line, like short identifiers or environment names. For example, `account_manager: jeff_noble`. | Text field |
+| Text | Longer form text that can contain multiple lines | Use for multi-line content like JSON configurations, certificates, or long descriptions. | Text area |
+| Boolean | True or false value |  Use for on/off features or capabilities like feature flags and support options. For example, `premium_support: true`, `analytics_enabled: false`. | Checkbox |
+| Password | A short string of text that is masked on display in the UI. Note: Values are cleartext in the license file. | Use for sensitive values that should be masked in the UI like API keys, tokens, or credentials. | Password field |
+| Enum | Provides a list of possible values | Use when there is a set of predefined options for the field. For example, a `tier` field might have options like basic, premium, and enterprise. | Dropdown |
 
 :::note
 String, Text, Password, and Enum types are all represented as strings in the license.
-:::   
+:::
+
+### How Custom Fields Appear in Licenses
+
+Custom license fields appear in the customer's license YAML under `spec.entitlements`. Your application can read these values to enforce limits or configure behavior.
+
+The following example shows a license with custom fields:
+
+```yaml
+apiVersion: kots.io/v1beta1
+kind: License
+spec:
+  licenseID: "customer-123"
+  customerName: "Acme Corp"
+  entitlements:
+    expires_at:
+      title: Expiration
+      value: "2026-12-31T00:00:00Z"
+      valueType: String
+    seats:
+      title: Maximum Users
+      value: 100
+      valueType: Integer
+    tier:
+      title: Support Tier
+      value: "enterprise"
+      valueType: String
+    premium_support:
+      title: Premium Support Enabled
+      value: true
+      valueType: Boolean
+```
 
 ## Set Customer-Specific Values for Custom License Fields
 


### PR DESCRIPTION
## Summary

This PR enhances the custom license fields documentation by adding conceptual guidance and practical examples to complement the existing procedural how-to content.

Preview: https://deploy-preview-3794--replicated-docs.netlify.app/vendor/licenses-adding-custom-fields
Original: https://docs.replicated.com/vendor/licenses-adding-custom-fields#manage-built-in-license-fields 

### Key Changes

**1. Added "About License Fields" section** (May not be necessary but I didn't necessarily recognize that the querying info was a separate page at first) 
- Brief overview of license fields concept
- Cross-links to existing documentation for accessing field values:
  - `licenses-reference-sdk` - For Replicated SDK
  - `licenses-reference-kots-runtime` - For KOTS installers
  - `licenses-reference-helm` - For Helm installations
  - `licenses-verify-fields-sdk-api` - For verification

**2. Added "Common Use Cases for Custom License Fields" section** (I like this section because it helps people understand how they could use these which is a common question) 
Provides concrete examples organized by category:
- **Capacity limits**: `max_users`, `seats`, `storage_gb`, `api_calls_per_month`
- **Feature tiers**: `tier`, `support_level`
- **Configuration**: `api_endpoint`, `region`, `data_center`, `environment`
- **Credentials**: `api_key`, `auth_token`, `encryption_key`
- **Business logic**: `contract_type`, `renewal_date`, `account_manager`

**3. Added "How Custom Fields Appear in Licenses" subsection**
- Shows example license YAML with custom fields in `spec.entitlements`
- Includes realistic examples (seats, tier, premium_support)
- Helps vendors visualize the output of creating custom fields

**4. Enhanced Field Types table**. (goal was to extend the 'how you might use these' examples) 
Added two new columns to the existing table:
- **Purpose**: High-level category for each field type
- **When to Use**: Specific guidance with practical examples

Before:
- Type | Description | Widget

After:
- Type | Description | Purpose | When to Use | Widget

**5. Added Vendor API v3 reference**
- Brief mention of API-based field management
- Link to `createcustomlicensefield` API endpoint

### Benefits

These enhancements provide vendors with:
- Understanding of **when** and **why** to use custom fields (not just how)
- Concrete examples they can adapt for their use cases
- Clear navigation to related documentation for accessing field values
- Better understanding of field type choices through the enhanced table
- Awareness of API-based management options

### What's NOT Changed

This PR preserves all existing content:
- All procedural how-to sections remain unchanged
- Screenshot references intact
- No changes to built-in license fields section
- All existing links and warnings preserved

### Testing Plan

- [ ] Preview documentation build to ensure proper rendering
- [ ] Verify all internal links work correctly (`licenses-reference-sdk`, etc.)
- [ ] Check that the enhanced table renders properly with 5 columns
- [ ] Confirm YAML code block is syntax-highlighted correctly
- [ ] Test that note callouts render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code) + Amber notes/edits