### PR TITLE
Remove unsupported multi-channel options from customer CLI docs

### DIFF
--- a/docs/reference/replicated-cli-customer-create.mdx
+++ b/docs/reference/replicated-cli-customer-create.mdx
@@ -7,8 +7,8 @@ Create a new customer for the current application
 Create a new customer for the current application with specified attributes.
 
 This command allows you to create a customer record with various properties such as name,
-custom ID, channels, license type, and feature flags. You can set expiration dates,
-enable or disable specific features, and assign the customer to one or more channels.
+custom ID, channel, license type, and feature flags. You can set expiration dates,
+enable or disable specific features, and assign the customer to a channel.
 
 The --app flag must be set to specify the target application.
 
@@ -22,8 +22,8 @@ replicated customer create [flags]
 # Create a basic customer with a name and assigned to a channel
 replicated customer create --app myapp --name "Acme Inc" --channel stable
 
-# Create a customer with multiple channels and a custom ID
-replicated customer create --app myapp --name "Beta Corp" --custom-id "BETA123" --channel beta --channel stable
+# Create a customer with a custom ID to tie to external systems
+replicated customer create --app myapp --name "Beta Corp" --custom-id "BETA123" --channel stable
 
 # Create a paid customer with specific features enabled
 replicated customer create --app myapp --name "Enterprise Ltd" --type paid --channel enterprise --airgap --snapshot
@@ -33,8 +33,7 @@ replicated customer create --app myapp --name "Trial User" --type trial --channe
 
 # Create a customer with all available options
 replicated customer create --app myapp --name "Full Options Inc" --custom-id "FULL001" \
-	--channel stable --channel beta --default-channel stable --type paid \
-	--email "contact@fulloptions.com" --expires-in 8760h \
+	--channel stable --type paid --email "contact@fulloptions.com" --expires-in 8760h \
 	--airgap --snapshot --kots-install --embedded-cluster-download \
 	--support-bundle-upload --ensure-channel
 ```
@@ -43,9 +42,8 @@ replicated customer create --app myapp --name "Full Options Inc" --custom-id "FU
 
 ```
       --airgap                       If set, the license will allow airgap installs.
-      --channel stringArray          Release channel to which the customer should be assigned (can be specified multiple times)
+      --channel string               Release channel to which the customer should be assigned.
       --custom-id string             Set a custom customer ID to more easily tie this customer record to your external data systems
-      --default-channel string       Which of the specified channels should be the default channel. if not set, the first channel specified will be the default channel.
       --developer-mode               If set, Replicated SDK installed in dev mode will use mock data.
       --email string                 Email address of the customer that is to be created.
       --embedded-cluster-download    If set, the license will allow Embedded Cluster downloads.

--- a/docs/reference/replicated-cli-customer-update.mdx
+++ b/docs/reference/replicated-cli-customer-update.mdx
@@ -7,8 +7,8 @@ Update an existing customer
 Update an existing customer's information and settings.
 
 	This command allows you to modify various attributes of a customer, including their name,
-	custom ID, assigned channels, license type, and feature flags. You can update expiration dates,
-	enable or disable specific features, and change channel assignments.
+	custom ID, assigned channel, license type, and feature flags. You can update expiration dates,
+	enable or disable specific features, and change the channel assignment.
 
 	The --customer flag is required to specify which customer to update.
 
@@ -22,8 +22,8 @@ replicated customer update --customer <id> --name <name> [options] [flags]
 # Update a customer's name
 replicated customer update --customer cus_abcdef123456 --name "New Company Name"
 
-# Change a customer's channel and make it the default
-replicated customer update --customer cus_abcdef123456 --channel stable --default-channel stable
+# Change a customer's channel
+replicated customer update --customer cus_abcdef123456 --channel stable
 
 # Enable airgap installations for a customer
 replicated customer update --customer cus_abcdef123456 --airgap
@@ -42,10 +42,9 @@ replicated customer update --customer cus_abcdef123456 --name "JSON Corp" --outp
 
 ```
       --airgap                       If set, the license will allow airgap installs.
-      --channel stringArray          Release channel to which the customer should be assigned (can be specified multiple times)
+      --channel string               Release channel to which the customer should be assigned.
       --custom-id string             Set a custom customer ID to more easily tie this customer record to your external data systems
       --customer string              The ID of the customer to update
-      --default-channel string       Which of the specified channels should be the default channel. if not set, the first channel specified will be the default channel.
       --developer-mode               If set, Replicated SDK installed in dev mode will use mock data.
       --email string                 Email address of the customer that is to be updated.
       --embedded-cluster-download    If set, the license will allow Embedded Cluster downloads.


### PR DESCRIPTION
Multi-channel licenses are not currently supported. Updated customer create and update docs to reflect single channel assignment.

concerning this ticket: https://app.shortcut.com/replicated/story/133383/hide-multi-channel-licenses-in-cli

regarding this PR: https://github.com/replicatedhq/replicated/pull/668

on the preview pages:
https://deploy-preview-3796--replicated-docs.netlify.app/reference/replicated-cli-customer-create
https://deploy-preview-3796--replicated-docs.netlify.app/reference/replicated-cli-customer-update