### PR TITLE
docs: add docs field to HelmChart v1beta2 reference page

### DIFF
--- a/docs/partials/helm/_helm-cr-docs.mdx
+++ b/docs/partials/helm/_helm-cr-docs.mdx
@@ -1,0 +1,47 @@
+The `docs` key is an optional attribute for displaying documentation about the chart to users via the the Replicated Vendor Portal.
+
+The format is a YAML map: keys represent docs section names, and their value is expected to be a YAML multiline markdown block. Section names can be any string, such as `install`, `prerequisites`, and `troubleshooting` in the example below:
+
+```yaml
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: myapp
+spec:
+  chart:
+    name: myapp
+    chartVersion: 3.1.7
+  releaseName: myapp-release
+  docs:
+    install: |
+      # Installation Guide
+
+      This Helm chart deploys MyApp with PostgreSQL support.
+
+      ## Prerequisites
+      - Kubernetes 1.24+
+      - Persistent volume support
+      - 4GB RAM minimum
+
+      ## Installation
+
+      The chart will automatically provision storage and create
+      the necessary services.
+
+    prerequisites: |
+      # Requirements
+
+      Before installing, ensure your cluster has:
+      - A storage class with dynamic provisioning
+      - LoadBalancer support (or NodePort for on-prem)
+      - Network access to container registries
+
+    troubleshooting: |
+      # Common Issues
+
+      **Pods stuck in Pending:**
+      Check storage class availability with kubectl get sc
+
+      **Database connection errors:**
+      Verify the postgresql.host value in your configuration.
+```

--- a/docs/reference/custom-resource-helmchart-v2.mdx
+++ b/docs/reference/custom-resource-helmchart-v2.mdx
@@ -16,6 +16,7 @@ import BuilderAirgapIntro from "../partials/helm/_helm-cr-builder-airgap-intro.m
 import BuilderExample from "../partials/helm/_helm-cr-builder-example.mdx"
 import V2Example from "../partials/helm/_v2-native-helm-cr-example.mdx"
 import KotsHelmCrDescription from "../partials/helm/_kots-helm-cr-description.mdx"
+import Docs from "../partials/helm/_helm-cr-docs.mdx"
 
 # HelmChart v2
 
@@ -111,3 +112,7 @@ The `builder` key is required to support the following installation types:
 #### Example
 
 <BuilderExample/>
+
+## docs
+
+<Docs/>


### PR DESCRIPTION
direct link to the page in PR preview:
https://deploy-preview-3809--replicated-docs-upgrade.netlify.app/reference/custom-resource-helmchart-v2#docs

the YAML example is from a test in Marc's PR: https://github.com/replicatedhq/kotskinds/pull/57

I took a guess at how we use this, so this part may be completely off. Do we display this in Vendor portal and/or Enterprise portal?

> The `docs` key is an optional attribute for displaying documentation about the chart to users via the the Replicated Vendor Portal.

once this is complete,
fixes #3808