### PR TITLE
Add missing RBAC resource names to documentation

### DIFF
--- a/docs/vendor/team-management-rbac-resource-names.md
+++ b/docs/vendor/team-management-rbac-resource-names.md
@@ -512,10 +512,6 @@ Grants the holder permission to delete the addon for a vm.
 
 Grants the holder permission to view team details and settings.
 
-### team/activity-stream/read
-
-Grants the holder permission to view the team activity stream.
-
 ### team/auditlog/read
 
 Grants the holder permission to view the audit log for the team.


### PR DESCRIPTION
Preview link: https://deploy-preview-3827--replicated-docs.netlify.app/vendor/team-management-rbac-resource-names

## Summary
- Adds RBAC resource names that are enforced in the codebase but were missing from the [RBAC Resource Names](https://docs.replicated.com/vendor/team-management-rbac-resource-names) docs page. These can be corrected now ahead of any additional code changes
- Adds a new **Notifications** section with 8 resource names for notification subscriptions, types, and event history. Note: I'm good with these being included since this is so close to being more broadly available to users

## Test plan
- [ ] Verify the docs site builds without errors
- [ ] Review each new resource name and description for accuracy against the codebase (`pkg/policy/resources.go`)
- [ ] Confirm all resource names match the exact strings used in `CheckAccessOrAbort` / `CheckAccess` calls
