### PR TITLE
docs: update event notifications for new instance upgrade lifecycle events

### DIFF
--- a/docs/vendor/event-notifications-create.mdx
+++ b/docs/vendor/event-notifications-create.mdx
@@ -77,8 +77,10 @@ To create an event notification subscription:
 Event Notifications (Beta) supports the following event types, organized by category. You can further refine each event type using filters to match your specific needs. You can also select multiple event types in a single subscription.
 
 ### Instance Events
-- **Instance Created**: When a new instance is created
-- **Instance Upgraded**: When an instance upgrades to a new release version
+- **Instance Created**: When a new instance sends its first check-in
+- **Instance Ready**: When a new instance's application status is ready for the first time
+- **Instance Upgrade Started**: When an instance begins upgrading to a new release version. This event fires when the first telemetry with a new version is received, before the application is necessarily ready.
+- **Instance Upgrade Completed**: When an instance's application status is ready after upgrading to a new release version
 - **Instance Version Behind**: When an instance falls behind by a specified number of versions
 - **Instance Inactive**: When an instance has not reported in for 24 hours (declared "Inactive"). Air-gapped instances are excluded from this event type.
 - **Instance State Duration**: When an instance has been in a specific state (such as Unavailable or Degraded) for a specified duration
@@ -191,7 +193,7 @@ You can filter notifications based on your custom license field values. This all
 
 Filtering by custom license fields is supported for the following event types:
 - Customer events (Customer Created, Customer Updated, Customer Archived, Customer Unarchived, Customer License Expiring)
-- Instance events (Instance Created, Instance Upgraded, Instance Version Behind, Instance Inactive, Instance State Duration, Instance State Flapping)
+- Instance events (Instance Created, Instance Ready, Instance Upgrade Started, Instance Upgrade Completed, Instance Version Behind, Instance Inactive, Instance State Duration, Instance State Flapping)
 - Support Bundle events (Support Bundle Uploaded, Support Bundle Analyzed)
 
 License field conditions have a field, an operator, and a value. The available operators depend on the field type:

--- a/docs/vendor/event-notifications-webhooks.mdx
+++ b/docs/vendor/event-notifications-webhooks.mdx
@@ -72,7 +72,7 @@ The following describes the fields in the webhook payload:
   <tr>
     <td>`event`</td>
     <td>string</td>
-    <td>Event type identifier (e.g., "customer.created", "instance.upgraded")</td>
+    <td>Event type identifier (e.g., "customer.created", "instance.upgrade_started")</td>
    </tr>
   <tr>
     <td>`timestamp`</td>


### PR DESCRIPTION
## Summary

Updates the Event Notifications docs to reflect changes from [vandoor PR #9180](https://github.com/replicatedhq/vandoor/pull/9180):

- **Rename** `instance.upgraded` to `instance.upgrade_started` with updated description clarifying it fires on first telemetry with new version, before app is ready
- **Add** new `instance.ready` event (fires once when app status first becomes ready)
- **Add** new `instance.upgrade_completed` event (fires when app is ready after upgrade)
- **Update** `instance.created` description from "when a new instance is created" to "when a new instance sends its first check-in"
- **Update** webhook payload example to use `instance.upgrade_started` instead of `instance.upgraded`
- **Update** license field condition filters list with new event names
- Also updates Alpha -> Beta labeling across event notification pages to match production state

## Files changed

- `event-notifications-create.mdx` - Instance Events list, license field filters, custom metric content
- `event-notifications-webhooks.mdx` - Payload field example
- `event-notifications.mdx` - Alpha -> Beta updates
- `event-notifications-manage.mdx` - Alpha -> Beta updates
- `instance-notifications-config.mdx` - Cross-references updated
- `team-management-slack-config.mdx` - Cross-references updated
- `sidebars.js` - Sidebar label Alpha -> Beta

## Test plan

- [ ] Verify event type names match what ships in vandoor PR #9180
- [ ] Verify descriptions accurately reflect event behavior
- [ ] Review Alpha -> Beta changes are appropriate for current state
- [ ] Check all cross-references and links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)