### PR TITLE
docs: add SDK 1.19.1 release notes

### DIFF
--- a/docs/partials/replicated-sdk/_dependency-yaml.mdx
+++ b/docs/partials/replicated-sdk/_dependency-yaml.mdx
@@ -3,7 +3,7 @@
 dependencies:
 - name: replicated
   repository: oci://registry.replicated.com/library
-  version: 1.18.2
+  version: 1.19.1
 ```
 
 For the latest version information for the Replicated SDK, see the [replicated-sdk repository](https://github.com/replicatedhq/replicated-sdk/releases) in GitHub.

--- a/docs/release-notes/rn-replicated-sdk.md
+++ b/docs/release-notes/rn-replicated-sdk.md
@@ -8,6 +8,17 @@ pagination_prev: null
 
 This topic contains release notes for the [Replicated SDK](/vendor/replicated-sdk-overview). The release notes list new features, improvements, bug fixes, known issues, and breaking changes.
 
+## 1.19.1
+
+Released on April 7, 2026
+
+### Bug fixes {#bug-fixes-1-19-1}
+* Fixes an issue where the "Enable mock data for development" checkbox in the Vendor Portal did not reliably disable mock mode for development licenses. The SDK now defaults mock mode to OFF when the `integration-enabled` key is absent from the replicated secret. The Helm chart template now always writes the `integration-enabled` key explicitly.
+
+### Improvements {#improvements-1-19-1}
+* Switches to the GA `discovery.k8s.io/v1` EndpointSlice API for service status discovery, replacing the legacy Endpoints API.
+* Adds support for specifying the replicated-sdk image by digest.
+
 ## 1.19.0
 
 Released on April 2, 2026

--- a/docs/release-notes/rn-replicated-sdk.md
+++ b/docs/release-notes/rn-replicated-sdk.md
@@ -13,7 +13,7 @@ This topic contains release notes for the [Replicated SDK](/vendor/replicated-sd
 Released on April 7, 2026
 
 ### Bug fixes {#bug-fixes-1-19-1}
-* Fixes an issue where the "Enable mock data for development" checkbox in the Vendor Portal did not reliably disable mock mode for development licenses. The SDK now defaults mock mode to OFF when the `integration-enabled` key is absent from the replicated secret. The Helm chart template now always writes the `integration-enabled` key explicitly.
+* Fixes an issue where the "Enable mock data for development" checkbox in the Vendor Portal did not reliably disable mock mode for development licenses. By default, the SDK now disables mock data when the `integration-enabled` key is absent from the `replicated` secret. Also, the Helm chart template now always writes the `integration-enabled` key explicitly.
 
 ### Improvements {#improvements-1-19-1}
 * Switches to the GA `discovery.k8s.io/v1` EndpointSlice API for service status discovery, replacing the legacy Endpoints API.


### PR DESCRIPTION
## Summary
- Adds release notes for Replicated SDK 1.19.1
- Bug fix: mock mode default changed to OFF for development licenses
- Improvement: migrated to GA `discovery.k8s.io/v1` EndpointSlice API
- Improvement: support for specifying SDK image by digest