### PR TITLE
docs: simplify EC v3 image template functions

### DIFF
--- a/docs/reference/template-functions-about.mdx
+++ b/docs/reference/template-functions-about.mdx
@@ -51,7 +51,7 @@ For the [Config](/reference/custom-resource-config) custom resource, KOTS templa
   * LocalRegistryNamespace
   * LocalImageName
 
-  These template functions are typically used to conditionally rewrite image references in air gap installations to reference the local image registry. For Embedded Cluster v3 installations, use the ReplicatedImageName, ReplicatedImageName, and ReplicatedImageName template functions instead. For more information, see [Template Functions for Embedded Cluster (Beta)](/embedded-cluster/v3/template-functions).
+  These template functions are typically used to conditionally rewrite image references in air gap installations to reference the local image registry. For Embedded Cluster v3 installations, use the ReplicatedImageName and ReplicatedImageRegistry template functions instead. For more information, see [Template Functions for Embedded Cluster (Beta)](/embedded-cluster/v3/template-functions).
 
 ## Syntax {#syntax}
 

--- a/embedded-cluster/embedded-using.mdx
+++ b/embedded-cluster/embedded-using.mdx
@@ -56,7 +56,7 @@ To support air gap installations:
 
 1. Configure each HelmChart custom resource's `builder` key. This ensures that all the required and optional images for your application are available in environments without internet access. See [`builder`](/reference/custom-resource-helmchart-v2#builder) in _HelmChart v2_.
 
-1. Configure each HelmChart custom resource to ensure that all image reference resolve correctly in online and air gap installations. You do this in the HelmChart custom resource's [`values`](/reference/custom-resource-helmchart-v2#values) key using the [ReplicatedImageName](template-functions#replicatedimagename), [ReplicatedImageRegistry](template-functions#replicatedimageregistry), and [ReplicatedImageRepository](template-functions#replicatedimagerepository) template functions. See the following examples for more information:
+1. Configure each HelmChart custom resource to ensure that all image references resolve correctly in online and air gap installations. You do this in the HelmChart custom resource's [`values`](/reference/custom-resource-helmchart-v2#values) key using the [ReplicatedImageName](template-functions#replicatedimagename) and [ReplicatedImageRegistry](template-functions#replicatedimageregistry) template functions. See the following examples for more information:
 
     <details>
 
@@ -85,7 +85,7 @@ To support air gap installations:
 
     <summary>Example (Separate values for image registry and repository)</summary>
 
-    If a chart uses separate registry and repository fields for image references, use the [ReplicatedImageRegistry](template-functions#replicatedimageregistry) and [ReplicatedImageRepository](template-functions#replicatedimagerepository) template functions in the HelmChart custom resource:
+    If a chart uses separate registry and repository fields for image references, use the [ReplicatedImageRegistry](template-functions#replicatedimageregistry) template function to rewrite only the `registry` field. The `repository` field does not need to be templated — it passes through from `values.yaml` unchanged.
 
     ```yaml
     # values.yaml
@@ -103,9 +103,7 @@ To support air gap installations:
       values:
         image:
           registry: '{{repl ReplicatedImageRegistry (HelmValue ".image.registry") }}'
-          repository: '{{repl ReplicatedImageRepository (HelmValue ".image.repository") true }}'
     ```
-    ReplicatedImageRepository sets `noProxy` to `true` because the repository value in `values.yaml` already contains the proxy path prefix (`proxy/my-app/...`). ReplicatedImageRegistry omits `noProxy` so the function returns the correct proxy domain for the installation, including any [custom domain](/vendor/custom-domains) configuration.
     </details>
 
     <details>
@@ -128,7 +126,7 @@ To support air gap installations:
     ```
     </details>
 
-1. In the HelmChart resource that corresponds to the chart where you included the Replicated SDK as a dependency, rewrite the Replicated SDK image reference using the [ReplicatedImageRegistry](template-functions#replicatedimageregistry) and [ReplicatedImageRepository](template-functions#replicatedimagerepository) template functions:
+1. In the HelmChart resource that corresponds to the chart where you included the Replicated SDK as a dependency, rewrite the Replicated SDK image registry using the [ReplicatedImageRegistry](template-functions#replicatedimageregistry) template function:
 
     ```yaml
     # HelmChart custom resource
@@ -139,12 +137,9 @@ To support air gap installations:
         replicated:
           image:
             registry: '{{repl ReplicatedImageRegistry (HelmValue ".replicated.image.registry") }}'
-            # The default location for the SDK image is
-            # proxy.replicated.com/library/replicated-sdk-image
-            repository: '{{repl ReplicatedImageRepository (HelmValue ".replicated.image.repository") true }}'
     ```
 
-1. If you added any Helm chart `extensions` in the Embedded Cluster Config, rewrite image references in each extension using either the [ReplicatedImageName](template-functions#replicatedimagename) template function (if the chart uses a single field for the full image reference) or the [ReplicatedImageRegistry](template-functions#replicatedimageregistry) and [ReplicatedImageRepository](template-functions#replicatedimagerepository) template functions (if the chart uses separate fields for the image registry and repository values). 
+1. If you added any Helm chart `extensions` in the Embedded Cluster Config, rewrite image references in each extension using either the [ReplicatedImageName](template-functions#replicatedimagename) template function (if the chart uses a single field for the full image reference) or the [ReplicatedImageRegistry](template-functions#replicatedimageregistry) template function (if the chart uses separate fields for registry and repository).
 
     <details>
     <summary>Example (Extension for a Helm chart that you own)</summary>
@@ -165,7 +160,6 @@ To support air gap installations:
               controller:
                 image:
                   registry: 'repl{{ ReplicatedImageRegistry (HelmValue ".controller.image.registry") }}'
-                  repository: 'repl{{ ReplicatedImageRepository (HelmValue ".controller.image.repository") true }}'
     ```
     </details>
 
@@ -188,11 +182,8 @@ To support air gap installations:
               controller:
                 image:
                   registry: 'repl{{ ReplicatedImageRegistry "registry.k8s.io" }}'
-                  repository: 'repl{{ ReplicatedImageRepository "registry.k8s.io/ingress-nginx/controller" }}'
     ```
     The template functions will add the proxy prefix in online installations and rewrite to the local registry in air gap installations.
-
-    ReplicatedImageRepository requires the full upstream image path including the registry (for example, `registry.k8s.io/ingress-nginx/controller`), not just the repository.
     </details>
 
 

--- a/embedded-cluster/embedded-using.mdx
+++ b/embedded-cluster/embedded-using.mdx
@@ -85,7 +85,7 @@ To support air gap installations:
 
     <summary>Example (Separate values for image registry and repository)</summary>
 
-    If a chart uses separate registry and repository fields for image references, use the [ReplicatedImageRegistry](template-functions#replicatedimageregistry) template function to rewrite only the `registry` field. The `repository` field does not need to be templated — it passes through from `values.yaml` unchanged.
+    If a chart uses separate registry and repository fields for image references, use the [ReplicatedImageRegistry](template-functions#replicatedimageregistry) template function to rewrite the `registry` field. The `repository` field does not need to be templated.
 
     ```yaml
     # values.yaml
@@ -109,7 +109,7 @@ To support air gap installations:
     <details>
     <summary>Example (References to public images)</summary>
 
-    For public images that don't go through the Replicated proxy registry, set the upstream reference directly in the chart's `values.yaml`. Use `noProxy` so the reference remains unchanged in online installations but is still rewritten for air gap.
+    For public images that don't go through the Replicated proxy registry, set the upstream reference directly in the chart's `values.yaml`. Use `noProxy` so that ReplicatedImageName leaves the reference unchanged in online installations. When you include `noProxy`, ReplicatedImageName still rewrites the image to the local registry in air gap installations.
 
     ```yaml
     # values.yaml
@@ -183,7 +183,7 @@ To support air gap installations:
                 image:
                   registry: 'repl{{ ReplicatedImageRegistry "registry.k8s.io" }}'
     ```
-    The template functions will add the proxy prefix in online installations and rewrite to the local registry in air gap installations.
+    The template functions add the proxy prefix in online installations and rewrite to the local registry in air gap installations.
     </details>
 
 

--- a/embedded-cluster/embedded-v3-migrate.mdx
+++ b/embedded-cluster/embedded-v3-migrate.mdx
@@ -54,7 +54,7 @@ To update a release from Embedded Cluster v2 to v3:
 
 1. If you use the Replicated proxy registry, update your release to remove the ImagePullSecretName template function from your HelmChart `values` key. Embedded Cluster v3 configures the cluster to automatically authenticate to the proxy registry for all pods, so you don't need to manually inject a pull secret. See the _Embedded Cluster v3_ steps in [Configure your application to use the proxy registry](/vendor/private-images-kots#configure-v3).
 
-1. If you support air gap installations, update your image references to use the Embedded Cluster ReplicatedImageName, ReplicatedImageRegistry, and ReplicatedImageRepository template functions. This ensures that image references resolve correctly in both online and air gap installations. See [Add support for air gap installations](embedded-using#local-image-registry).
+1. If you support air gap installations, update your image references to use the Embedded Cluster ReplicatedImageName and ReplicatedImageRegistry template functions. This ensures that image references resolve correctly in both online and air gap installations. See [Add support for air gap installations](embedded-using#local-image-registry).
 
     :::note
     In Embedded Cluster v3, these template functions replace the [LocalImageName](/reference/template-functions-config-context#localimagename), [LocalRegistryHost](/reference/template-functions-config-context#localregistryhost), and [LocalRegistryNamespace](/reference/template-functions-config-context#localregistrynamespace) template functions.

--- a/embedded-cluster/template-functions.mdx
+++ b/embedded-cluster/template-functions.mdx
@@ -12,7 +12,7 @@ This topic lists the Replicated template functions for Embedded Cluster. For mor
 func HelmValue(path string) string
 ```
 
-Returns the value from the chart's `values.yaml` at the given dotted path. Use this to read the chart's default image values and pass them to the [ReplicatedImageName](#replicatedimagename), [ReplicatedImageRegistry](#replicatedimagerepository), or [ReplicatedImageRegistry](#replicatedimageregistry) template functions.
+Returns the value from the chart's `values.yaml` at the given dotted path. Use this to read the chart's default image values and pass them to the [ReplicatedImageName](#replicatedimagename) or [ReplicatedImageRegistry](#replicatedimageregistry) template functions.
 
 ### Examples
 
@@ -32,7 +32,6 @@ values:
   my-subchart:
     image:
       registry: '{{repl ReplicatedImageRegistry (HelmValue ".my-subchart.image.registry") }}'
-      repository: '{{repl ReplicatedImageRepository (HelmValue ".my-subchart.image.repository") true }}'
 ```
 
 ## ReplicatedImageName
@@ -58,9 +57,9 @@ The following table describes the value returned by ReplicatedImageName in onlin
 
 | Install type | noProxy | Result |
 |------|---------|--------|
-| Online | Omitted | Returns the proxy registry URL for the image in the format: `proxy.replicated.com/proxy/<app-slug>/<image>`, where `app-slug` is the unique application slug |
+| Online | Omitted | Returns the proxy registry URL for the image in the format: `proxy.replicated.com/proxy/<app-slug>/<image>` (or your [custom domain](/vendor/custom-domains-using)). Images already using the proxy domain are returned unchanged. |
 | Online | `true` | Returns the image reference with no changes |
-| Air gap | `true` or omitted | Returns the location of the image at the local image registry in the format: `<local-registry>/<app-slug>/<name>:<tag>` |
+| Air gap | `true` or omitted | Returns the location of the image at the local image registry in the format: `<local-registry>/<repo-path>:<tag>` |
 
 ### Examples
 
@@ -89,25 +88,25 @@ spec:
 func ReplicatedImageRegistry(registry string, noProxy ...bool) string
 ```
 
-Returns the registry host.
+Returns the registry host with the proxy path included.
 
-Use this with the ReplicatedImageRepository template function when the image reference in the Helm chart uses separate `registry` and `repository` fields.
+Use this when the image reference in the Helm chart uses separate `registry` and `repository` fields. Only the `registry` field needs to be templated — the repository passes through from `values.yaml` unchanged.
 
 ### Parameters
 
-#### image
+#### registry
 
-The image reference to rewrite.
+The registry host to rewrite (for example, `ghcr.io` or `docker.io`).
 Use the [HelmValue](#helmvalue-func) function to return the value from the chart's `values.yaml` at the given dotted path.
 
 #### noProxy
 
-The following table describes the value returned by ReplicatedImageName in online or air gap installations when the `noProxy` field is omitted or set to `true`:
+The following table describes the value returned by ReplicatedImageRegistry in online or air gap installations when the `noProxy` field is omitted or set to `true`:
 
 | Install type | noProxy | Result |
 |------|---------|--------|
-| Online | Omitted | Returns the proxy registry domain (either `proxy.replicated.com` or your [custom domain](/vendor/custom-domains-using)) |
-| Online | `true` | Returns the image registry value with no changes |
+| Online | Omitted | Returns the proxy registry path in the format: `proxy.replicated.com/proxy/<app-slug>/<registry>` (or your [custom domain](/vendor/custom-domains-using)). Registries already using the proxy domain are returned unchanged. |
+| Online | `true` | Returns the registry value with no changes |
 | Air gap | `true` or omitted | Returns the local registry address |
 
 ### Examples
@@ -122,8 +121,9 @@ spec:
   values:
     image:
       registry: '{{repl ReplicatedImageRegistry (HelmValue ".image.registry") }}'
-      repository: '{{repl ReplicatedImageRepository (HelmValue ".image.repository") true }}'
 ```
+
+The `repository` field does not need to be templated. It passes through from the chart's `values.yaml` unchanged.
 
 #### Rewrite upstream image references for third-party Helm extensions
 
@@ -140,65 +140,4 @@ extensions:
         controller:
           image:
             registry: 'repl{{ ReplicatedImageRegistry "registry.k8s.io" }}'
-            repository: 'repl{{ ReplicatedImageRepository "registry.k8s.io/ingress-nginx/controller" }}'
-```
-
-## ReplicatedImageRepository
-
-```go
-func ReplicatedImageRepository(repository string, noProxy ...bool) string
-```
-
-Returns the repository path.
-
-Use this with the ReplicatedImageRegistry template function when the image reference in the Helm chart uses separate `registry` and `repository` fields.
-
-### Parameters
-
-#### image
-
-The image reference to rewrite.
-Use the [HelmValue](#helmvalue-func) function to return the value from the chart's `values.yaml` at the given dotted path.
-
-#### noProxy
-
-The following table describes the value returned by ReplicatedImageName in online or air gap installations, when the `noProxy` field is omitted or set to `true`:
-
-| Install type | noProxy | Result |
-|------|---------|--------|
-| Online | Omitted | Returns the proxy registry image repository in the format: `proxy/<app-slug>/<repository>`, where `app_slug` is the unique application slug |
-| Online | `true` | Returns the image repository value with no changes |
-| Air gap | `true` or omitted | Returns the local image repository in the format: `<app-slug>/<name>` |
-
-### Examples
-
-#### Rewrite image references using HelmValues
-
-```yaml
-# HelmChart custom resource
-apiVersion: kots.io/v1beta2
-kind: HelmChart
-spec:
-  values:
-    image:
-      registry: '{{repl ReplicatedImageRegistry (HelmValue ".image.registry") }}'
-      repository: '{{repl ReplicatedImageRepository (HelmValue ".image.repository") true }}'
-```
-
-#### Rewrite upstream image references for third-party Helm extensions
-
-```yaml
-# Embedded Cluster Config
-extensions:
-  helmCharts:
-    - chart:
-        name: ingress-nginx
-        chartVersion: "4.11.3"
-      releaseName: ingress-nginx
-      namespace: ingress-nginx
-      values: |
-        controller:
-          image:
-            registry: 'repl{{ ReplicatedImageRegistry "registry.k8s.io" }}'
-            repository: 'repl{{ ReplicatedImageRepository "registry.k8s.io/ingress-nginx/controller" }}'
 ```

--- a/embedded-cluster/template-functions.mdx
+++ b/embedded-cluster/template-functions.mdx
@@ -42,7 +42,7 @@ func ReplicatedImageName(image string, noProxy ...bool) string
 
 Returns a full image reference, including the registry, repository, and any tags.
 
-Use this when a chart expects the entire image reference in a single field.
+Use this when a chart expects the entire image reference in a single field. For more information, see [Add support for air gap installations](embedded-using#local-image-registry) in _Configure Embedded Cluster_.
 
 ### Parameters
 
@@ -57,7 +57,7 @@ The following table describes the value returned by ReplicatedImageName in onlin
 
 | Install type | noProxy | Result |
 |------|---------|--------|
-| Online | Omitted | Returns the proxy registry URL for the image in the format: `proxy.replicated.com/proxy/<app-slug>/<image>` (or your [custom domain](/vendor/custom-domains-using)). Images already using the proxy domain are returned unchanged. |
+| Online | Omitted | Returns the proxy registry URL for the image in the format: `<proxy-registry-domain>/proxy/<app-slug>/<image>`. The proxy registry domain is either `proxy.replicated.com` or your [custom domain](/vendor/custom-domains-using). If the image is already using the proxy registry URL, then ReplicatedImageName returns the image value unchanged. |
 | Online | `true` | Returns the image reference with no changes |
 | Air gap | `true` or omitted | Returns the location of the image at the local image registry in the format: `<local-registry>/<repo-path>:<tag>` |
 
@@ -88,9 +88,13 @@ spec:
 func ReplicatedImageRegistry(registry string, noProxy ...bool) string
 ```
 
-Returns the registry host with the proxy path included.
+Returns the registry host with the Replicated proxy registry path included. The proxy registry path has this format: `proxy.replicated.com/proxy/<app-slug>/<registry>`.
 
-Use this when the image reference in the Helm chart uses separate `registry` and `repository` fields. Only the `registry` field needs to be templated — the repository passes through from `values.yaml` unchanged.
+Use this when the image reference in the Helm chart uses separate `registry` and `repository` fields. For more information, see [Add support for air gap installations](embedded-using#local-image-registry) in _Configure Embedded Cluster_.
+
+:::note
+You do not need to template the `repository` field. When you template the `registry` field, ReplicatedImageRegistry returns the full proxy registry path required to pull the image through the proxy registry.
+:::
 
 ### Parameters
 
@@ -105,7 +109,7 @@ The following table describes the value returned by ReplicatedImageRegistry in o
 
 | Install type | noProxy | Result |
 |------|---------|--------|
-| Online | Omitted | Returns the proxy registry path in the format: `proxy.replicated.com/proxy/<app-slug>/<registry>` (or your [custom domain](/vendor/custom-domains-using)). Registries already using the proxy domain are returned unchanged. |
+| Online | Omitted | Returns the proxy registry path in the format: `<proxy-registry-domain>/proxy/<app-slug>/<image>`. The proxy registry domain is either `proxy.replicated.com` or your [custom domain](/vendor/custom-domains-using). If the registry is already using the proxy registry URL, then ReplicatedImageRegistry returns the registry value unchanged. |
 | Online | `true` | Returns the registry value with no changes |
 | Air gap | `true` or omitted | Returns the local registry address |
 
@@ -122,8 +126,6 @@ spec:
     image:
       registry: '{{repl ReplicatedImageRegistry (HelmValue ".image.registry") }}'
 ```
-
-The `repository` field does not need to be templated. It passes through from the chart's `values.yaml` unchanged.
 
 #### Rewrite upstream image references for third-party Helm extensions
 


### PR DESCRIPTION
## Summary
- Remove `ReplicatedImageRepository` from all EC v3 docs — vendors only need to template the `registry` field
- Update `ReplicatedImageRegistry` docs to reflect new behavior (returns full proxy path)
- Update all examples in template-functions.mdx, embedded-using.mdx, and embedded-v3-migrate.mdx
- Simplify the template functions about page

Companion to replicatedhq/ec#393

🤖 Generated with [Claude Code](https://claude.com/claude-code)