### PR TITLE
Fix stale base image description for Replicated SDK

### DIFF
--- a/docs/vendor/replicated-sdk-slsa-validating.md
+++ b/docs/vendor/replicated-sdk-slsa-validating.md
@@ -10,7 +10,7 @@ This topic describes how to verify the authenticity and integrity of Replicated 
 
 Attestations enable the inspection of an image to determine its origin, the identity of its creator, the creation process, and its contents. When building software using the Replicated SDK, the image's SBOM and SLSA-based provenance attestations help your customers assess your application's supply chain security.
 
-The Replicated SDK build process uses Chainguard's Wolfi-based images to minimize the number of CVEs. The build process automatically generates:
+The Replicated SDK build process uses [apko](https://github.com/chainguard-dev/apko) with packages from Replicated's [SecureBuild](https://securebuild.com/) package repository to minimize the number of CVEs. The build process automatically generates:
 - SLSA provenance attestations
 - Image signatures
 - SBOM


### PR DESCRIPTION
## Summary

The "Purpose of attestations" section on `replicated-sdk-slsa-validating.md` still claims the SDK build uses "Chainguard's Wolfi-based images." That is no longer accurate: starting with SDK 1.18.2 (2026-03-25), the build migrated from Wolfi to Replicated's SecureBuild package repository (`cve0.io`) via [replicatedhq/replicated-sdk#409](https://github.com/replicatedhq/replicated-sdk/pull/409).

The current SDK build pipeline:
- Uses [apko](https://github.com/chainguard-dev/apko) with packages from `https://apk.cve0.io` (see [`deploy/apko.yaml`](https://github.com/replicatedhq/replicated-sdk/blob/main/deploy/apko.yaml) and [`deploy/melange.yaml`](https://github.com/replicatedhq/replicated-sdk/blob/main/deploy/melange.yaml)).
- Signs with `cve0-signing.rsa.pub` instead of Chainguard's signing key.

This PR updates the sentence to reflect the current state while keeping the list of generated attestations (SLSA, signatures, SBOM) unchanged.

## Test plan

- [ ] Run `npm start` locally and confirm the page renders.
- [ ] Confirm Vale reports no new errors on the changed line.