### PR TITLE
Deprecate identity provider feature

### DIFF
--- a/docs/enterprise/auth-changing-passwords.md
+++ b/docs/enterprise/auth-changing-passwords.md
@@ -7,7 +7,7 @@ The Admin Console password is salted and one-way hashed using bcrypt. The irreve
 For more information about bcrypt, see [bcrypt](https://en.wikipedia.org/wiki/Bcrypt) on Wikipedia.
 
 :::note
-Users with Identity Provider (IDP) access cannot change their password using this procedure. If an attempt is made, IDP users receive a message in the user interface to contact the identity service provider to change their password. For more information about resetting an IDP user password, see [Resetting Authentication](auth-identity-provider#resetting-authentication) in _Use an Identity Provider for User Access (Beta)_.
+Users with Identity Provider (IDP) access cannot change their password using this procedure. If an attempt is made, IDP users receive a message in the user interface to contact the identity service provider to change their password. For more information about resetting an IDP user password, see [Resetting Authentication](auth-identity-provider#resetting-authentication) in _Use an Identity Provider for User Access (Deprecated)_.
 :::
 
 To change your Admin Console password:

--- a/docs/enterprise/auth-identity-provider.md
+++ b/docs/enterprise/auth-identity-provider.md
@@ -1,7 +1,7 @@
 # Use an identity provider for user access (Deprecated)
 
 :::note
-Replicated deprecated the identity service. This feature works only in clusters created by Replicated kURL. Replicated will not extend it to other install methods such as KOTS existing cluster or Embedded Cluster, and does not plan further development.
+The Replicated identity service feature is deprecated. This feature works only in clusters created by Replicated kURL. Replicated will not extend the identity service to other installation methods such as KOTS existing cluster or Embedded Cluster, and does not plan further development.
 :::
 
 When you install an application for the first time, the Replicated KOTS Admin Console is secured with a single shared password for all users. It is possible to further configure the Admin Console to authenticate users with your organization's user management system. This feature is only available for licenses that have the Replicated identity service feature enabled.

--- a/docs/enterprise/auth-identity-provider.md
+++ b/docs/enterprise/auth-identity-provider.md
@@ -1,4 +1,8 @@
-# Use an identity provider for user access (Beta)
+# Use an identity provider for user access (Deprecated)
+
+:::important
+The identity service is deprecated. This feature is supported only in clusters created by Replicated kURL, and will not be extended to other install methods such as KOTS existing cluster or Embedded Cluster. No new development is planned for this feature.
+:::
 
 When you install an application for the first time, the Replicated KOTS Admin Console is secured with a single shared password for all users. It is possible to further configure the Admin Console to authenticate users with your organization's user management system. This feature is only available for licenses that have the Replicated identity service feature enabled.
 

--- a/docs/enterprise/auth-identity-provider.md
+++ b/docs/enterprise/auth-identity-provider.md
@@ -1,7 +1,7 @@
 # Use an identity provider for user access (Deprecated)
 
-:::important
-The identity service is deprecated. This feature is supported only in clusters created by Replicated kURL, and will not be extended to other install methods such as KOTS existing cluster or Embedded Cluster. No new development is planned for this feature.
+:::note
+Replicated deprecated the identity service. This feature works only in clusters created by Replicated kURL. Replicated will not extend it to other install methods such as KOTS existing cluster or Embedded Cluster, and does not plan further development.
 :::
 
 When you install an application for the first time, the Replicated KOTS Admin Console is secured with a single shared password for all users. It is possible to further configure the Admin Console to authenticate users with your organization's user management system. This feature is only available for licenses that have the Replicated identity service feature enabled.


### PR DESCRIPTION
Preview link: https://deploy-preview-3984--replicated-docs.netlify.app/enterprise/auth-identity-provider

## Summary
- Marks the KOTS Admin Console identity service (IdP/Dex integration) as **Deprecated** instead of Beta
- Adds a deprecation admonition clarifying the feature is only supported in kURL clusters and will not be extended to KOTS existing cluster or Embedded Cluster
- Updates cross-reference in auth-changing-passwords.md

## Test plan
- [ ] Verify the deprecation admonition renders correctly on the docs site
- [ ] Confirm the cross-reference link in auth-changing-passwords.md still resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)