### PR TITLE
Deprecate pushing Docker images to the Replicated registry

### DIFF
--- a/docs/vendor/packaging-private-registry-security.md
+++ b/docs/vendor/packaging-private-registry-security.md
@@ -1,11 +1,8 @@
 # Replicated registry security
 
-:::important
-Replicated has deprecated pushing Docker images to the Replicated registry. Replicated recommends using the proxy registry for all private image distribution. For more information, see [About the Replicated Proxy Registry](/vendor/private-images-about).
-:::
+This document lists the security measures and processes in place for the Replicated registry.
 
-This document lists the security measures and processes in place for the Replicated registry. For more information about the Replicated registry, see [About the Replicated Registry Option for KOTS Installations](private-images-replicated).
-
+The Replicated registry is a private OCI registry hosted by Replicated at `registry.replicated.com`. When you promote a release, the Replicated Vendor Portal automatically extracts any Helm charts included in the release and pushes them as OCI objects to the Replicated registry.
 
 ## Single tenant isolation
 

--- a/docs/vendor/packaging-private-registry-security.md
+++ b/docs/vendor/packaging-private-registry-security.md
@@ -1,7 +1,7 @@
 # Replicated registry security
 
 :::important
-Pushing Docker images to the Replicated registry is deprecated. Replicated recommends using the proxy registry for all private image distribution. For more information, see [About the Replicated Proxy Registry](/vendor/private-images-about).
+Replicated has deprecated pushing Docker images to the Replicated registry. Replicated recommends using the proxy registry for all private image distribution. For more information, see [About the Replicated Proxy Registry](/vendor/private-images-about).
 :::
 
 This document lists the security measures and processes in place for the Replicated registry. For more information about the Replicated registry, see [About the Replicated Registry Option for KOTS Installations](private-images-replicated).

--- a/docs/vendor/packaging-private-registry-security.md
+++ b/docs/vendor/packaging-private-registry-security.md
@@ -1,6 +1,10 @@
 # Replicated registry security
 
-This document lists the security measures and processes in place to ensure that images pushed to the Replicated registry remain private. For more information about pushing images to the Replicated registry, see [About the Replicated Registry Option for KOTS Installations](private-images-replicated).
+:::important
+Pushing Docker images to the Replicated registry is deprecated. Replicated recommends using the proxy registry for all private image distribution. For more information, see [About the Replicated Proxy Registry](/vendor/private-images-about).
+:::
+
+This document lists the security measures and processes in place for the Replicated registry. For more information about the Replicated registry, see [About the Replicated Registry Option for KOTS Installations](private-images-replicated).
 
 
 ## Single tenant isolation

--- a/docs/vendor/private-images-kots.mdx
+++ b/docs/vendor/private-images-kots.mdx
@@ -170,3 +170,19 @@ To use the proxy registry with applications packaged as Kubernetes Operators:
 1. Create a new release with your changes. Promote the release to a development channel. See [Managing Releases with Vendor Portal](releases-creating-releases).
 
 1. Install in a development environment to test your changes.
+
+## Migrate from the Replicated registry to the proxy registry {#migrate-replicated-registry}
+
+Replicated has deprecated the ability to push images to the Replicated registry. Images that are already hosted on the Replicated registry will continue to be available for pull access.
+
+If you already host any Docker images on the Replicated registry, Replicated recommends that you move your images to an external registry and use the Replicated proxy registry.
+
+To migrate from the Replicated registry to the proxy registry:
+
+1. Push your images to your own external registry. For the full list of supported image registries, see [Supported registries](/vendor/packaging-private-images#supported-registries) in _Add and manage external registries_.
+
+1. In the Vendor Portal, go to **Image Registries > Add External Registry** and add the credentials for your registry. For more information, see [Add and manage external registries](/vendor/packaging-private-images).
+
+1. Configure your application to pull images through the proxy registry. See the instructions for your target install type on this page:
+   * [Embedded Cluster v3 (Beta)](#configure-v3)
+   * [Embedded Cluster v2, KOTS, or kURL](#embedded-cluster-v2-kots-or-kurl)

--- a/docs/vendor/private-images-replicated.mdx
+++ b/docs/vendor/private-images-replicated.mdx
@@ -1,32 +1,22 @@
 import TeamTokenNote from "../partials/vendor-api/_team-token-note.mdx"
 
-# About the Replicated registry option for KOTS installations
+# Push images to the Replicated registry (Deprecated)
 
 :::important
-Replicated has deprecated pushing Docker images to the Replicated registry. Replicated recommends that all vendors use the proxy registry to distribute private images. Vendors who push images to the Replicated registry should migrate to an external registry and use the proxy registry for distribution. For more information, see [About the Replicated Proxy Registry](/vendor/private-images-about).
+Replicated has deprecated the ability to push images to the Replicated registry. Images that are already hosted on the Replicated registry will continue to be available for pull access.
+
+Replicated recommends that all software vendors use the Replicated proxy registry instead of the Replicated registry. The proxy registry provides a globally-distributed and highly-performant method to grant pull-through access to application images stored in your own external registry. For more information, see [About the Replicated proxy registry](/vendor/private-images-about).
+
+If you already host any Docker images on the Replicated registry, Replicated recommends that you move your images to an external registry and use the Replicated proxy registry. For more information, see [Migrate from the Replicated registry to the proxy registry](/vendor/private-images-kots#migrate-replicated-registry).
 :::
 
-This topic describes the Replicated registry and how to migrate to the recommended proxy registry. The information in this topic applies only to installations managed with Replicated KOTS.
+This topic describes the Replicated registry. The information in this topic applies only to installations managed with Replicated KOTS.
 
 ## Overview
 
-The Replicated registry (`registry.replicated.com`) allows vendors to host private container images for KOTS-managed applications. However, Replicated has deprecated the ability to push Docker images to the Replicated registry.
-
-For all image distribution, Replicated recommends using the Replicated proxy registry. The proxy registry provides a globally-distributed and highly-performant method to grant pull-through access to application images stored in your own external registry. For more information, see [About the Replicated Proxy Registry](/vendor/private-images-about).
+The Replicated registry (`registry.replicated.com`) allows vendors to host private container images for KOTS-managed applications.
 
 For information about security for the Replicated registry, see [Replicated Registry Security](packaging-private-registry-security).
-
-## Migrate to the proxy registry
-
-If you push Docker images to the Replicated registry, Replicated recommends migrating to an external registry and using the Replicated proxy registry for distribution. Compatible external registries include Docker Hub, Amazon Elastic Container Registry (ECR), and Google Artifact Registry.
-
-To migrate:
-
-1. Push your images to your own external registry.
-1. Configure the proxy registry to grant your customers pull-through access to your external registry. For more information, see [About the Replicated Proxy Registry](/vendor/private-images-about).
-1. Update your application manifests to reference images through the proxy registry.
-
-Images that are already hosted on the Replicated registry will continue to be available for pull access. You do not need to take action for existing images that are already in use.
 
 ## Limitations
 
@@ -40,14 +30,18 @@ The Replicated registry has the following limitations:
 
 * The ability to push images to the Replicated registry is available only for KOTS-managed installations. Pushing images to the Replicated registry is not supported for Helm installations.
 
-## Push images to the Replicated registry (deprecated) {#push-images}
+## Push images to the Replicated registry (Deprecated) {#push-images}
 
 :::important
-Replicated has deprecated pushing Docker images to the Replicated registry. For the recommended approach, see [Migrate to the proxy registry](#migrate-to-the-proxy-registry).
+Replicated has deprecated the ability to push images to the Replicated registry. Images that are already hosted on the Replicated registry will continue to be available for pull access.
+
+Replicated recommends that all software vendors use the Replicated proxy registry instead of the Replicated registry. The proxy registry provides a globally-distributed and highly-performant method to grant pull-through access to application images stored in your own external registry. For more information, see [About the Replicated proxy registry](/vendor/private-images-about).
+
+If you already host any Docker images on the Replicated registry, Replicated recommends that you move your images to an external registry and use the Replicated proxy registry. For more information, see [Migrate from the Replicated registry to the proxy registry](/vendor/private-images-kots#migrate-replicated-registry).
 :::
 
 <details>
-<summary>View deprecated push instructions</summary>
+<summary>View the deprecated push instructions</summary>
 
 This procedure describes how to tag and push images to the Replicated registry. For more information about building, tagging, and pushing Docker images, see the
 [Docker CLI documentation](https://docs.docker.com/engine/reference/commandline/cli/).

--- a/docs/vendor/private-images-replicated.mdx
+++ b/docs/vendor/private-images-replicated.mdx
@@ -3,14 +3,14 @@ import TeamTokenNote from "../partials/vendor-api/_team-token-note.mdx"
 # About the Replicated registry option for KOTS installations
 
 :::important
-Pushing Docker images to the Replicated registry is deprecated. Replicated recommends that all vendors use the proxy registry to distribute private images. Vendors who currently push images to the Replicated registry should migrate to an external registry and use the proxy registry for distribution. For more information, see [About the Replicated Proxy Registry](/vendor/private-images-about).
+Replicated has deprecated pushing Docker images to the Replicated registry. Replicated recommends that all vendors use the proxy registry to distribute private images. Vendors who push images to the Replicated registry should migrate to an external registry and use the proxy registry for distribution. For more information, see [About the Replicated Proxy Registry](/vendor/private-images-about).
 :::
 
 This topic describes the Replicated registry and how to migrate to the recommended proxy registry. The information in this topic applies only to installations managed with Replicated KOTS.
 
 ## Overview
 
-The Replicated registry (`registry.replicated.com`) allows vendors to host private container images for KOTS-managed applications. However, the ability to push Docker images to the Replicated registry is deprecated.
+The Replicated registry (`registry.replicated.com`) allows vendors to host private container images for KOTS-managed applications. However, Replicated has deprecated the ability to push Docker images to the Replicated registry.
 
 For all image distribution, Replicated recommends using the Replicated proxy registry. The proxy registry provides a globally-distributed and highly-performant method to grant pull-through access to application images stored in your own external registry. For more information, see [About the Replicated Proxy Registry](/vendor/private-images-about).
 
@@ -18,7 +18,7 @@ For information about security for the Replicated registry, see [Replicated Regi
 
 ## Migrate to the proxy registry
 
-If you currently push Docker images to the Replicated registry, Replicated recommends migrating to an external registry (such as Docker Hub, Amazon ECR, or Google Artifact Registry) and using the Replicated proxy registry for distribution.
+If you push Docker images to the Replicated registry, Replicated recommends migrating to an external registry and using the Replicated proxy registry for distribution. Compatible external registries include Docker Hub, Amazon Elastic Container Registry (ECR), and Google Artifact Registry.
 
 To migrate:
 
@@ -26,7 +26,7 @@ To migrate:
 1. Configure the proxy registry to grant your customers pull-through access to your external registry. For more information, see [About the Replicated Proxy Registry](/vendor/private-images-about).
 1. Update your application manifests to reference images through the proxy registry.
 
-Images that are already hosted on the Replicated registry will continue to be available for pull access. No action is needed for existing images that are already in use.
+Images that are already hosted on the Replicated registry will continue to be available for pull access. You do not need to take action for existing images that are already in use.
 
 ## Limitations
 
@@ -43,7 +43,7 @@ The Replicated registry has the following limitations:
 ## Push images to the Replicated registry (deprecated) {#push-images}
 
 :::important
-Pushing Docker images to the Replicated registry is deprecated. See [Migrate to the proxy registry](#migrate-to-the-proxy-registry) above for the recommended approach.
+Replicated has deprecated pushing Docker images to the Replicated registry. For the recommended approach, see [Migrate to the proxy registry](#migrate-to-the-proxy-registry).
 :::
 
 <details>

--- a/docs/vendor/private-images-replicated.mdx
+++ b/docs/vendor/private-images-replicated.mdx
@@ -2,21 +2,31 @@ import TeamTokenNote from "../partials/vendor-api/_team-token-note.mdx"
 
 # About the Replicated registry option for KOTS installations
 
-This topic describes how to push images to the Replicated registry. The information in this topic applies only to installations managed with Replicated KOTS.
+:::important
+Pushing Docker images to the Replicated registry is deprecated. Replicated recommends that all vendors use the proxy registry to distribute private images. Vendors who currently push images to the Replicated registry should migrate to an external registry and use the proxy registry for distribution. For more information, see [About the Replicated Proxy Registry](/vendor/private-images-about).
+:::
+
+This topic describes the Replicated registry and how to migrate to the recommended proxy registry. The information in this topic applies only to installations managed with Replicated KOTS.
 
 ## Overview
 
-For applications installed with KOTS, you can optionally host private images on the Replicated registry. Hosting your images on the Replicated registry can be useful for testing purposes.
+The Replicated registry (`registry.replicated.com`) allows vendors to host private container images for KOTS-managed applications. However, the ability to push Docker images to the Replicated registry is deprecated.
 
-For all production releases, Replicated recommends using the Replicated proxy registry for both private and public image distribution, rather than hosting images on the Replicated registry. The proxy registry provides a globally-distributed and highly-performant method to grant pull-through access to application images. For more information, see [About the Replicated Proxy Registry](/vendor/private-images-about).
-
-Images pushed to the Replicated registry are displayed on the **Images** page in the Vendor Portal:
-
-![Replicated Private Registry section of the vendor portal Images page](/images/images-replicated-registry.png)
-
-[View a larger version of this image](/images/images-replicated-registry.png)
+For all image distribution, Replicated recommends using the Replicated proxy registry. The proxy registry provides a globally-distributed and highly-performant method to grant pull-through access to application images stored in your own external registry. For more information, see [About the Replicated Proxy Registry](/vendor/private-images-about).
 
 For information about security for the Replicated registry, see [Replicated Registry Security](packaging-private-registry-security).
+
+## Migrate to the proxy registry
+
+If you currently push Docker images to the Replicated registry, Replicated recommends migrating to an external registry (such as Docker Hub, Amazon ECR, or Google Artifact Registry) and using the Replicated proxy registry for distribution.
+
+To migrate:
+
+1. Push your images to your own external registry.
+1. Configure the proxy registry to grant your customers pull-through access to your external registry. For more information, see [About the Replicated Proxy Registry](/vendor/private-images-about).
+1. Update your application manifests to reference images through the proxy registry.
+
+Images that are already hosted on the Replicated registry will continue to be available for pull access. No action is needed for existing images that are already in use.
 
 ## Limitations
 
@@ -30,7 +40,14 @@ The Replicated registry has the following limitations:
 
 * The ability to push images to the Replicated registry is available only for KOTS-managed installations. Pushing images to the Replicated registry is not supported for Helm installations.
 
-## Push images to the Replicated registry
+## Push images to the Replicated registry (deprecated) {#push-images}
+
+:::important
+Pushing Docker images to the Replicated registry is deprecated. See [Migrate to the proxy registry](#migrate-to-the-proxy-registry) above for the recommended approach.
+:::
+
+<details>
+<summary>View deprecated push instructions</summary>
 
 This procedure describes how to tag and push images to the Replicated registry. For more information about building, tagging, and pushing Docker images, see the
 [Docker CLI documentation](https://docs.docker.com/engine/reference/commandline/cli/).
@@ -80,4 +97,6 @@ Docker format:
    docker push registry.replicated.com/myapp/worker:1.0.1
    ```    
 
-1. In the [Vendor Portal](https://vendor.replicated.com/), go to **Images** and scroll down to the **Replicated Private Registry** section to confirm that the image was pushed. 
+1. In the [Vendor Portal](https://vendor.replicated.com/), go to **Images** and scroll down to the **Replicated Private Registry** section to confirm that the image was pushed.
+
+</details>

--- a/sidebars.js
+++ b/sidebars.js
@@ -499,14 +499,7 @@ const sidebars = {
         "vendor/private-images-kots",
         "vendor/private-images-tags-digests",
         "vendor/packaging-public-images",
-        {
-          type: "category",
-          label: "Replicated Private Registry",
-          items: [
-            "vendor/private-images-replicated",
-            "vendor/packaging-private-registry-security",
-          ],
-        },
+        "vendor/private-images-replicated",
         "vendor/tutorial-ecr-private-images",
       ],
     },
@@ -901,6 +894,7 @@ const sidebars = {
         "enterprise/sbom-validating",
         "vendor/vendor-password-integrity",
         "vendor/replicated-sdk-slsa-validating",
+        "vendor/packaging-private-registry-security",
       ],
     },
   ],


### PR DESCRIPTION
Preview
* https://deploy-preview-3986--replicated-docs.netlify.app/vendor/private-images-replicated
* https://deploy-preview-3986--replicated-docs.netlify.app/vendor/packaging-private-registry-security

## Summary

- Adds deprecation banners (`:::important`) to both the Replicated registry push page and the registry security page
- Rewrites the overview to lead with "deprecated" and directs vendors to the proxy registry
- Adds a new "Migrate to the proxy registry" section with clear migration steps
- Collapses the existing push instructions behind a `<details>` toggle so they remain accessible for vendors in the grace period but are no longer front-and-center
- Updates the security page intro to remove language encouraging pushes

## Pages changed

- `docs/vendor/private-images-replicated.mdx` (main push instructions page)
- `docs/vendor/packaging-private-registry-security.md` (registry security page)

## Context

The Replicated registry will continue to serve helm charts and existing images, but vendors should no longer push Docker images directly. This is the first step toward sunsetting vendor push access, with entitlement-based enforcement to follow on the platform side.

## Test plan

- [ ] Verify Docusaurus build passes
- [ ] Review deprecation banner rendering
- [ ] Confirm `<details>` toggle works for collapsed push instructions
- [ ] Verify all internal links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)