### PR TITLE
docs(cli/channel-demote): drop spurious 'release' from command examples

### DIFF
--- a/docs/reference/replicated-cli-channel-demote.mdx
+++ b/docs/reference/replicated-cli-channel-demote.mdx
@@ -14,10 +14,10 @@ replicated channel demote CHANNEL_ID_OR_NAME [flags]
 
 ```
   # Demote a release from a channel by channel sequence
-  replicated channel release demote Beta --channel-sequence 15
+  replicated channel demote Beta --channel-sequence 15
 
   # Demote a release from a channel by release sequence
-  replicated channel release demote Beta --release-sequence 12
+  replicated channel demote Beta --release-sequence 12
 ```
 
 ### Options


### PR DESCRIPTION
Fixes #3973.

Reporter found that `replicated channel release demote ...` (copy-pasted from docs) fails with `Error: unknown flag: --channel-sequence`. The real command is `replicated channel demote ...` — there's no `release` subcommand between `channel` and `demote`; the page's own heading and synopsis (lines 1 and 10) already use the correct form.

```diff
- replicated channel release demote Beta --channel-sequence 15
+ replicated channel demote Beta --channel-sequence 15

- replicated channel release demote Beta --release-sequence 12
+ replicated channel demote Beta --release-sequence 12
```

Verified via `grep -rn 'channel release demote' docs` — the two occurrences were isolated to this one page. Docs-only.