### PR TITLE
Document support bundle upload size limits

### DIFF
--- a/docs/reference/replicated-sdk-apis.md
+++ b/docs/reference/replicated-sdk-apis.md
@@ -197,6 +197,10 @@ Upload a support bundle through the SDK. The bundle is streamed to Replicated fo
 * The environment must have outbound internet access
 * The request must include the `Content-Length` header
 
+:::note
+Unlike support bundle uploads through the Admin Console or Enterprise Portal, which are limited to 500 MB, this endpoint uploads directly to cloud storage using a presigned URL. There is no enforced size limit on bundles uploaded through the SDK.
+:::
+
 ```bash
 POST http://replicated:3000/api/v1/supportbundle
 Content-Type: application/gzip

--- a/docs/reference/replicated-sdk-apis.md
+++ b/docs/reference/replicated-sdk-apis.md
@@ -197,10 +197,6 @@ Upload a support bundle through the SDK. The bundle is streamed to Replicated fo
 * The environment must have outbound internet access
 * The request must include the `Content-Length` header
 
-:::note
-The Admin Console and Enterprise Portal limit support bundle uploads to 500 MB. This endpoint has no size limit because it uploads directly to cloud storage.
-:::
-
 ```bash
 POST http://replicated:3000/api/v1/supportbundle
 Content-Type: application/gzip

--- a/docs/reference/replicated-sdk-apis.md
+++ b/docs/reference/replicated-sdk-apis.md
@@ -198,7 +198,7 @@ Upload a support bundle through the SDK. The bundle is streamed to Replicated fo
 * The request must include the `Content-Length` header
 
 :::note
-Unlike support bundle uploads through the Admin Console or Enterprise Portal, which are limited to 500 MB, this endpoint uploads directly to cloud storage using a presigned URL. There is no enforced size limit on bundles uploaded through the SDK.
+The Admin Console and Enterprise Portal limit support bundle uploads to 500 MB. This endpoint has no size limit because it uploads directly to cloud storage.
 :::
 
 ```bash

--- a/docs/vendor/enterprise-portal-about.mdx
+++ b/docs/vendor/enterprise-portal-about.mdx
@@ -39,6 +39,8 @@ For information about using the Enterprise Portal, see [Access and Use the Enter
 
 * Air gap instance records do not appear in the Enterprise Portal until the end customer creates an air gap instance record by either uploading a support bundle for that instance or manually entering instance information. For more information, see [View Active and Inactive Instances](/vendor/enterprise-portal-use#view-active-and-inactive-instances) in _Access and Use the Enterprise Portal_.
 
+* Support bundles uploaded through the Enterprise Portal are limited to 500 MB. For larger bundles, use the [Replicated SDK API](/reference/replicated-sdk-apis#post-supportbundle) upload endpoint, which uploads directly to storage with no size restriction.
+
 * There is a known issue when using a custom domain for the Enterprise Portal if any of your customers use link transformers such as Microsoft Defender Safe Links. For more information, see [Known Issue](custom-domains#known-issue) in _About Custom Domains_. 
 
 ## Comparison to the Download Portal

--- a/docs/vendor/enterprise-portal-about.mdx
+++ b/docs/vendor/enterprise-portal-about.mdx
@@ -39,7 +39,7 @@ For information about using the Enterprise Portal, see [Access and Use the Enter
 
 * Air gap instance records do not appear in the Enterprise Portal until the end customer creates an air gap instance record by either uploading a support bundle for that instance or manually entering instance information. For more information, see [View Active and Inactive Instances](/vendor/enterprise-portal-use#view-active-and-inactive-instances) in _Access and Use the Enterprise Portal_.
 
-* Support bundles uploaded through the Enterprise Portal are limited to 500 MB. For larger bundles, use the [Replicated SDK API](/reference/replicated-sdk-apis#post-supportbundle) upload endpoint, which uploads directly to storage with no size restriction.
+* The Enterprise Portal limits support bundle uploads to 500 MB. For larger bundles, use the [Replicated SDK API](/reference/replicated-sdk-apis#post-supportbundle) upload endpoint, which has no size restriction.
 
 * There is a known issue when using a custom domain for the Enterprise Portal if any of your customers use link transformers such as Microsoft Defender Safe Links. For more information, see [Known Issue](custom-domains#known-issue) in _About Custom Domains_. 
 

--- a/docs/vendor/enterprise-portal-use.mdx
+++ b/docs/vendor/enterprise-portal-use.mdx
@@ -314,6 +314,8 @@ To manage user settings in the Enterprise Portal:
 
 End customers can use the portal to collect, upload, and manage support bundles.
 
+The Enterprise Portal limits support bundle uploads to 500 MB. If your support bundle is larger than 500 MB, use the Replicated SDK API `POST /supportbundle` endpoint instead. This endpoint has no size limit because it uploads the bundle directly to cloud storage. For more information, see [supportbundle](/reference/replicated-sdk-apis) in _Replicated SDK API_.
+
 To manage support bundles in the Enterprise Portal:
 
 1. In the Enterprise Portal, go to **Support**.

--- a/docs/vendor/enterprise-portal-use.mdx
+++ b/docs/vendor/enterprise-portal-use.mdx
@@ -328,8 +328,4 @@ To manage support bundles in the Enterprise Portal:
 
    * To upload a support bundle, click **Upload support bundle**.
 
-     :::note
-     Support bundles uploaded through the Enterprise Portal are limited to 500 MB. For larger bundles, use the [Replicated SDK API](/reference/replicated-sdk-apis#post-supportbundle) upload endpoint, which uploads directly to storage with no size restriction.
-     :::
-
    * To view, download, or delete previous support bundles, select **Download** or **Delete** in the **Support Bundles** table.

--- a/docs/vendor/enterprise-portal-use.mdx
+++ b/docs/vendor/enterprise-portal-use.mdx
@@ -328,4 +328,8 @@ To manage support bundles in the Enterprise Portal:
 
    * To upload a support bundle, click **Upload support bundle**.
 
+     :::note
+     Support bundles uploaded through the Enterprise Portal are limited to 500 MB. For larger bundles, use the [Replicated SDK API](/reference/replicated-sdk-apis#post-supportbundle) upload endpoint, which uploads directly to storage with no size restriction.
+     :::
+
    * To view, download, or delete previous support bundles, select **Download** or **Delete** in the **Support Bundles** table.

--- a/docs/vendor/support-enabling-direct-bundle-uploads.md
+++ b/docs/vendor/support-enabling-direct-bundle-uploads.md
@@ -29,4 +29,4 @@ Direct bundle uploads are disabled by default. To enable this feature for your c
 
 - You will not receive a notification when a customer sends a support bundle to the Vendor Portal. To avoid overlooking these uploads, activate this feature only if there is a reliable escalation process already in place for the customer license.
 - This feature only supports online KOTS installations. If enabled, but installed in air gap mode, the upload button will not appear.
-- There is a 500 MB limit for support bundles uploaded directly via the Admin Console. For larger bundles, use the [Replicated SDK API](/reference/replicated-sdk-apis#post-supportbundle) upload endpoint, which has no size restriction.
+- There is a 500 MB limit for support bundles uploaded directly through the Admin Console. For larger bundles, use the [Replicated SDK API](/reference/replicated-sdk-apis#post-supportbundle) upload endpoint, which has no size restriction.

--- a/docs/vendor/support-enabling-direct-bundle-uploads.md
+++ b/docs/vendor/support-enabling-direct-bundle-uploads.md
@@ -29,4 +29,4 @@ Direct bundle uploads are disabled by default. To enable this feature for your c
 
 - You will not receive a notification when a customer sends a support bundle to the Vendor Portal. To avoid overlooking these uploads, activate this feature only if there is a reliable escalation process already in place for the customer license.
 - This feature only supports online KOTS installations. If enabled, but installed in air gap mode, the upload button will not appear.
-- There is a 500mb limit for support bundles uploaded directly via the Admin Console.
+- There is a 500 MB limit for support bundles uploaded directly via the Admin Console. For larger bundles, use the [Replicated SDK API](/reference/replicated-sdk-apis#post-supportbundle) upload endpoint, which has no size restriction.


### PR DESCRIPTION
Preview: 
https://deploy-preview-3992--replicated-docs.netlify.app

## Summary

- Add 500 MB size limit note to the Enterprise Portal support bundle upload docs (`enterprise-portal-use.mdx`)
- Call out that the SDK API upload endpoint has no size restriction (`replicated-sdk-apis.md`)
- Add SDK API cross-reference to the Admin Console direct upload limitations (`support-enabling-direct-bundle-uploads.md`)

Context: The 500 MB limit on EP and Admin Console uploads was either undocumented or only partially documented, and the SDK API's advantage of bypassing this limit (direct-to-S3 presigned URL) was not mentioned anywhere.

Relates to: https://github.com/replicated-collab/pixee-replicated/issues/124

## Test plan
- [ ] Verify the three pages render correctly in the docs site preview
- [ ] Confirm internal links resolve (`/reference/replicated-sdk-apis#post-supportbundle`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)