### PR TITLE
docs: add send test email action for event notifications

### DIFF
--- a/docs/vendor/event-notifications-create.mdx
+++ b/docs/vendor/event-notifications-create.mdx
@@ -44,7 +44,7 @@ To create an event notification subscription:
 
       1. Click **Send test email** to send a sample notification to the configured email address and verify delivery.
 
-         The test email is sent to the configured recipient with a `[TEST]` prefix in the subject line and a disclaimer in the body to indicate that it is a test. The email body uses representative sample values (such as "Acme Corp" for customer names) rather than real data from your account.
+         Test emails include a `[TEST]` prefix in the subject line and a disclaimer in the body to distinguish them from real event notifications. The body contains representative sample values (such as "Acme Corp" for customer names) rather than real data from your account.
 
    * For webhook delivery:
       

--- a/docs/vendor/event-notifications-create.mdx
+++ b/docs/vendor/event-notifications-create.mdx
@@ -42,9 +42,9 @@ To create an event notification subscription:
 
       1. Enter an email address.
 
-      1. Click **Send test email** to send a sample notification to the configured email address and verify delivery.
+      1. Click **Send test email** to send a test email to the configured email address and verify delivery.
 
-         Test emails include a `[TEST]` prefix in the subject line and a disclaimer in the body to distinguish them from real event notifications. The body contains representative sample values (such as "Acme Corp" for customer names) rather than real data from your account.
+         Test emails use representative sample values (such as "Acme Corp" for customer names) rather than real data from your account.
 
    * For webhook delivery:
       

--- a/docs/vendor/event-notifications-create.mdx
+++ b/docs/vendor/event-notifications-create.mdx
@@ -38,8 +38,14 @@ To create an event notification subscription:
 
 1. Do one of the following, depending on your notification delivery method:
    
-   * For email delivery, enter an email address.
-   
+   * For email delivery:
+
+      1. Enter an email address.
+
+      1. Click **Send test email** to send a sample notification to the configured email address and verify delivery.
+
+         The test email is sent to the configured recipient with a `[TEST]` prefix in the subject line and a disclaimer in the body to indicate that it is a test. The email body uses representative sample values (such as "Acme Corp" for customer names) rather than real data from your account.
+
    * For webhook delivery:
       
       1. Enter a webhook URL. The endpoint must meet the following requirements:

--- a/docs/vendor/event-notifications.mdx
+++ b/docs/vendor/event-notifications.mdx
@@ -94,5 +94,5 @@ The following table compares the functionality offered by Instance Notifications
 | **Filtering** | Instance-level only | Multi-field filters (app, customer, channel, etc.) |
 | **Permissions** | User-scoped | Team-scoped RBAC |
 | **Webhook Security** | Basic | HMAC-SHA256 signing |
-| **Webhook Testing** | Manual | Built-in payload preview and test webhook button |
+| **Delivery Testing** | Manual | Built-in payload preview and test buttons for both email and webhook delivery |
 | **Notification History** | Minimal | Full delivery attempt tracking with event details |


### PR DESCRIPTION
Relevant vandoor PR: https://github.com/replicatedhq/vandoor/pull/9579

shortcut ticket: https://app.shortcut.com/replicated/story/136633/add-send-test-capability-to-email-notifications-matching-the-existing-test-webhook-pattern