### PR TITLE
Extend support docs to cover feature requests

### DIFF
--- a/docs/vendor/support-submit-request.md
+++ b/docs/vendor/support-submit-request.md
@@ -18,7 +18,7 @@ The following prerequisites must be met to submit support requests:
 
 * Your team must have a replicated-collab repository configured. If you are a team administrator and need information about getting a collab repository set up and adding users, see [Adding Users to the Collab Repository](team-management-github-username#add).
 
-## Open a support request from a support bundle
+## (Recommended) Open a support request from a support bundle
 
 If you open a support request when viewing a bundle on the Vendor Portal **Support Bundle Analysis** page, the support request form is pre-populated with information from the support bundle and the associated customer license. The support bundle is also automatically attached to the request.
 

--- a/docs/vendor/support-submit-request.md
+++ b/docs/vendor/support-submit-request.md
@@ -1,12 +1,12 @@
-# Submit a support request
+# Submit a Support Request or Feature Request
 
-This topic describes how to open a support request with the Replicated team, including information about the fields in the support request form. It also describes how to attach new support bundles to an existing support issue.
+This topic describes how to open a support request or submit a feature request to the Replicated team. It includes information about the fields in the support request form, how to submit feature requests, and how to attach new support bundles to an existing support issue.
 
 For more information about working with support bundles, see [Generating Support Bundles](/vendor/support-bundle-generating).
 
 ## Overview
 
-You can submit support requests and support bundles to Replicated through the Replicated Vendor Portal.
+You can submit support requests, feature requests, and support bundles to Replicated through the Replicated Vendor Portal. Both support requests and feature requests use the same support page, which guides you through a multi-step wizard to select a product area, review self-service resources, and then submit your request.
 
 Replicated recommends that you always provide a support bundle when you open a new support request, and that you attach new bundles to an existing support issue when conditions change or new problems arise. Uploading a support bundle is secure and helps the Replicated support team troubleshoot your application faster. Severity 1 issues are resolved three times faster when you submit a support bundle with your support request.
 
@@ -40,25 +40,31 @@ To submit a support request from the **Support Bundle Analysis** page:
 
 1. Click **Submit support request**.
 
-## Open a support request from the support page {#support-page}
+## Open a request from the support page {#support-page}
+
+The support page uses a multi-step wizard to guide you through submitting a support request or feature request:
+
+1. **Select a product area**: Choose the product related to your request. The available products depend on your account.
+1. **Review self-service resources**: Browse recent community articles and documentation links to see if your question has already been answered. From this page, you can open a support request, make a feature request, or view open issues and requests on GitHub.
+1. **Submit your request**: Complete the support request or feature request form.
+
+To get started, go to **[Support](https://vendor.replicated.com/support)** in the Vendor Portal.
+
+:::note
+If your team has a collab repository configured, you can click **View open issues and requests** on the self-service page to see all submitted issues and feature requests on GitHub.
+:::
+
+### Submit a support request {#submit-support-request}
 
 Replicated support SLAs are a combination of the customer license type, your Replicated plan, which product is impacted, and other considerations. Your answers to the questions in the support request form generate a severity calculation that is posted on the GitHub issue as a label, and potentially result in a page for high severity incidents.
 
-The support page uses a multi-step wizard to guide you through submitting a support request or feature request.
-
-To submit a support request from the Vendor Portal **Support** page:
+To submit a support request:
 
 1. In the Vendor Portal, go to **[Support](https://vendor.replicated.com/support)**.
 
-1. Select the product area related to your request. The available products depend on your account.
+1. Select the product area related to your request.
 
-1. On the self-service page, review the suggested community articles and documentation links to see if your question has already been answered. If you still need help, click **Open a support request**.
-
-   :::note
-   You can also click **Make a feature request** to submit a feature request instead. Feature requests collect a title, problem description, and an optional proposed solution.
-
-   If your team has a collab repository configured, you can also click **View open issues and requests** to see all submitted issues and feature requests on GitHub.
-   :::
+1. On the self-service page, review the suggested resources. If you still need help, click **Open a support request**.
 
 1. (KOTS, Embedded Cluster, and kURL only) Upload one or more support bundles. The Vendor Portal uses support bundle metadata to pre-populate customer information in the request form.
 
@@ -149,6 +155,49 @@ To submit a support request from the Vendor Portal **Support** page:
    - Continue and submit as Severity 1, which pages an on-call engineer
 
    After you submit the support request, you receive a link to your support issue where you can interact with the support team.
+
+### Submit a feature request {#submit-feature-request}
+
+You can submit feature requests to share ideas for new features or improvements to Replicated products. Feature requests are submitted through the same support page wizard as support requests.
+
+To submit a feature request:
+
+1. In the Vendor Portal, go to **[Support](https://vendor.replicated.com/support)**.
+
+1. Select the product area related to your request.
+
+1. On the self-service page, click **Make a feature request**.
+
+1. Complete the feature request form:
+
+    <table>
+      <tr>
+        <th width="30%">Field</th>
+        <th width="70%">Description</th>
+      </tr>
+      <tr>
+        <th>Request Title</th>
+        <td>
+          <p>(Required) A short title for your feature request.</p>
+        </td>
+      </tr>
+      <tr>
+        <th>What is the problem you're trying to solve?</th>
+        <td>
+          <p>(Required) Describe the problem or use case that this feature would address.</p>
+        </td>
+      </tr>
+      <tr>
+        <th>Do you have a proposed product change that would solve this problem?</th>
+        <td>
+          <p>(Optional) Describe any specific product changes or solutions you have in mind.</p>
+        </td>
+      </tr>
+    </table>
+
+1. Click **Submit Request**.
+
+   After you submit the feature request, it is tracked as an issue in your team's collab repository on GitHub.
 
 ## Provide support bundles to Replicated after opening a support request {#add-bundle-after}
 

--- a/docs/vendor/support-submit-request.md
+++ b/docs/vendor/support-submit-request.md
@@ -159,7 +159,7 @@ To submit a feature request:
 1. On the self-service page, click **Make a feature request**.
 
    :::note
-   If your team has a collab repository configured, you can click **View open issues and requests** on the self-service page to see all issues and feature requests in your Replicated collab repository in GitHub.
+   You can click **View open issues and requests** on the self-service page to see all issues and feature requests in your Replicated collab repository in GitHub.
    :::
 
 1. Complete the feature request form:

--- a/docs/vendor/support-submit-request.md
+++ b/docs/vendor/support-submit-request.md
@@ -1,12 +1,12 @@
-# Submit a Support Request or Feature Request
+# Submit a support request or feature request
 
-This topic describes how to open a support request or submit a feature request to the Replicated team. It includes information about the fields in the support request form, how to submit feature requests, and how to attach new support bundles to an existing support issue.
+This topic describes how to open a support request or submit a feature request to the Replicated team. It covers the support request form fields, feature requests, and attaching support bundles to existing issues.
 
 For more information about working with support bundles, see [Generating Support Bundles](/vendor/support-bundle-generating).
 
 ## Overview
 
-You can submit support requests, feature requests, and support bundles to Replicated through the Replicated Vendor Portal. Both support requests and feature requests use the same support page, which guides you through a multi-step wizard to select a product area, review self-service resources, and then submit your request.
+You can submit support requests, feature requests, and support bundles through the Vendor Portal. Both support requests and feature requests use the same support page. A multi-step wizard guides you through selecting a product area, reviewing self-service resources, and submitting your request.
 
 Replicated recommends that you always provide a support bundle when you open a new support request, and that you attach new bundles to an existing support issue when conditions change or new problems arise. Uploading a support bundle is secure and helps the Replicated support team troubleshoot your application faster. Severity 1 issues are resolved three times faster when you submit a support bundle with your support request.
 
@@ -45,18 +45,18 @@ To submit a support request from the **Support Bundle Analysis** page:
 The support page uses a multi-step wizard to guide you through submitting a support request or feature request:
 
 1. **Select a product area**: Choose the product related to your request. The available products depend on your account.
-1. **Review self-service resources**: Browse recent community articles and documentation links to see if your question has already been answered. From this page, you can open a support request, make a feature request, or view open issues and requests on GitHub.
+1. **Review self-service resources**: Browse recent community articles and documentation links to find existing answers. From this page, you can open a support request, make a feature request, or view open issues on GitHub.
 1. **Submit your request**: Complete the support request or feature request form.
 
 To get started, go to **[Support](https://vendor.replicated.com/support)** in the Vendor Portal.
 
 :::note
-If your team has a collab repository configured, you can click **View open issues and requests** on the self-service page to see all submitted issues and feature requests on GitHub.
+If your team has a collab repository configured, click **View open issues and requests** on the self-service page to see all issues and feature requests on GitHub.
 :::
 
 ### Submit a support request {#submit-support-request}
 
-Replicated support SLAs are a combination of the customer license type, your Replicated plan, which product is impacted, and other considerations. Your answers to the questions in the support request form generate a severity calculation that is posted on the GitHub issue as a label, and potentially result in a page for high severity incidents.
+Replicated calculates support severity based on customer license type, your Replicated plan, the affected product, and other factors. Your answers to the support request form generate a severity label on the GitHub issue and can page an engineer for high severity incidents.
 
 To submit a support request:
 
@@ -158,7 +158,7 @@ To submit a support request:
 
 ### Submit a feature request {#submit-feature-request}
 
-You can submit feature requests to share ideas for new features or improvements to Replicated products. Feature requests are submitted through the same support page wizard as support requests.
+You can submit feature requests to share ideas for new features or improvements to Replicated products. You submit feature requests through the same support page wizard as support requests.
 
 To submit a feature request:
 
@@ -197,7 +197,7 @@ To submit a feature request:
 
 1. Click **Submit Request**.
 
-   After you submit the feature request, it is tracked as an issue in your team's collab repository on GitHub.
+   After you submit the feature request, Replicated creates an issue in your team's collab repository on GitHub.
 
 ## Provide support bundles to Replicated after opening a support request {#add-bundle-after}
 

--- a/docs/vendor/support-submit-request.md
+++ b/docs/vendor/support-submit-request.md
@@ -1,12 +1,12 @@
 # Submit a support request or feature request
 
-This topic describes how to open a support request or submit a feature request to the Replicated team. It covers the support request form fields, feature requests, and attaching support bundles to existing issues.
+This topic describes how to open a support request or submit a feature request to the Replicated team. It also describes how to attach support bundles to existing support issues.
 
 For more information about working with support bundles, see [Generating Support Bundles](/vendor/support-bundle-generating).
 
 ## Overview
 
-You can submit support requests, feature requests, and support bundles through the Vendor Portal. Both support requests and feature requests use the same support page. A multi-step wizard guides you through selecting a product area, reviewing self-service resources, and submitting your request.
+You can submit support requests, feature requests, and support bundles through the Vendor Portal. For support and feature requests, a multi-step wizard guides you through selecting a product area, reviewing self-service resources, and submitting your request.
 
 Replicated recommends that you always provide a support bundle when you open a new support request, and that you attach new bundles to an existing support issue when conditions change or new problems arise. Uploading a support bundle is secure and helps the Replicated support team troubleshoot your application faster. Severity 1 issues are resolved three times faster when you submit a support bundle with your support request.
 
@@ -18,7 +18,7 @@ The following prerequisites must be met to submit support requests:
 
 * Your team must have a replicated-collab repository configured. If you are a team administrator and need information about getting a collab repository set up and adding users, see [Adding Users to the Collab Repository](team-management-github-username#add).
 
-## (Recommended) Open a support request from a support bundle
+## Open a support request from a support bundle
 
 If you open a support request when viewing a bundle on the Vendor Portal **Support Bundle Analysis** page, the support request form is pre-populated with information from the support bundle and the associated customer license. The support bundle is also automatically attached to the request.
 
@@ -31,30 +31,16 @@ To submit a support request from the **Support Bundle Analysis** page:
 1. At the top of the **Support Bundle Analysis** page, click **Submit support ticket**.
 
     :::note
-    The **Share with Replicated** button on the **Support Bundle Analysis** page does _not_ open a support request. You might be directed to use the **Share with Replicated** option when you are already interacting with a Replicated team member. For more information, see [Provide Support Bundles to Replicated After Opening a Support Request](#add-bundle-after).
+    The **Share with Replicated** button on the **Support Bundle Analysis** page does _not_ open a support request. You might be directed to use the **Share with Replicated** option when you are already interacting with a Replicated team member. For more information, see [Provide support bundles to Replicated after opening a support request](#add-bundle-after).
     :::
 
-1. In section 1 of the support request form, review the pre-populated information and make any changes as needed. For more information about these fields, see [Open a Support Request from the Support Page](#support-page) below.
+1. In section 1 of the support request form, review the pre-populated information and make any changes as needed. For more information about these fields, see [Submit a support request from the Support page](#submit-support-request) below.
 
 1. Complete any empty fields, including adding an issue title and description.
 
 1. Click **Submit support request**.
 
-## Open a request from the support page {#support-page}
-
-The support page uses a multi-step wizard to guide you through submitting a support request or feature request:
-
-1. **Select a product area**: Choose the product related to your request. The available products depend on your account.
-1. **Review self-service resources**: Browse recent community articles and documentation links to find existing answers. From this page, you can open a support request, make a feature request, or view open issues on GitHub.
-1. **Submit your request**: Complete the support request or feature request form.
-
-To get started, go to **[Support](https://vendor.replicated.com/support)** in the Vendor Portal.
-
-:::note
-If your team has a collab repository configured, click **View open issues and requests** on the self-service page to see all issues and feature requests on GitHub.
-:::
-
-### Submit a support request {#submit-support-request}
+## Submit a support request from the Support page {#submit-support-request}
 
 Replicated calculates support severity based on customer license type, your Replicated plan, the affected product, and other factors. Your answers to the support request form generate a severity label on the GitHub issue and can page an engineer for high severity incidents.
 
@@ -65,6 +51,10 @@ To submit a support request:
 1. Select the product area related to your request.
 
 1. On the self-service page, review the suggested resources. If you still need help, click **Open a support request**.
+
+   :::note
+   You can click **View open issues and requests** on the self-service page to see all issues and feature requests in your Replicated collab repository in GitHub.
+   :::
 
 1. (KOTS, Embedded Cluster, and kURL only) Upload one or more support bundles. The Vendor Portal uses support bundle metadata to pre-populate customer information in the request form.
 
@@ -156,9 +146,9 @@ To submit a support request:
 
    After you submit the support request, you receive a link to your support issue where you can interact with the support team.
 
-### Submit a feature request {#submit-feature-request}
+## Submit a feature request {#submit-feature-request}
 
-You can submit feature requests to share ideas for new features or improvements to Replicated products. You submit feature requests through the same support page wizard as support requests.
+You can submit feature requests to share ideas for new features or improvements to Replicated products.
 
 To submit a feature request:
 
@@ -167,6 +157,10 @@ To submit a feature request:
 1. Select the product area related to your request.
 
 1. On the self-service page, click **Make a feature request**.
+
+   :::note
+   If your team has a collab repository configured, you can click **View open issues and requests** on the self-service page to see all issues and feature requests in your Replicated collab repository in GitHub.
+   :::
 
 1. Complete the feature request form:
 


### PR DESCRIPTION
Preview: https://deploy-preview-4001--replicated-docs.netlify.app/vendor/support-submit-request

## Summary
- Updates the support request docs page to also cover submitting feature requests
- Restructures the "Open a request from the support page" section with a wizard overview showing all 3 steps (product selection, self-service resources, submit)
- Adds a dedicated "Submit a feature request" subsection documenting the feature request form fields (title, problem description, proposed solution)
- The feature request flow was previously buried in a :::note inside the support request steps, making it hard for vendors to discover

## Test plan
- [ ] Verify the page renders correctly in the docs site preview
- [ ] Confirm all anchor links (#support-page, #submit-support-request, #submit-feature-request, #add-bundle-after) work
- [ ] Check that the internal cross-reference from the support bundle section still resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)