### PR TITLE
docs(troubleshoot): document liveness probe + deploymentStatus as recommended app health check pattern

### DIFF
--- a/docs/partials/support-bundles/_deploy-status-cr.mdx
+++ b/docs/partials/support-bundles/_deploy-status-cr.mdx
@@ -12,10 +12,10 @@ spec:
         outcomes:
           - fail:
               when: "< 1"
-              message: The API deployment does not have any ready replicas.
+              message: The api deployment does not have any ready replicas. Check that the application's liveness probes are passing and that the application is not in a crash loop.
           - warn:
               when: "= 1"
-              message: The API deployment has only a single ready replica.
+              message: The api deployment has only a single ready replica.
           - pass:
-              message: There are multiple replicas of the API deployment ready.
+              message: The api deployment is healthy and has multiple ready replicas.
 ```

--- a/docs/partials/support-bundles/_deploy-status-secret.mdx
+++ b/docs/partials/support-bundles/_deploy-status-secret.mdx
@@ -20,10 +20,10 @@ stringData:
             outcomes:
               - fail:
                   when: "< 1"
-                  message: The API deployment does not have any ready replicas.
+                  message: The api deployment does not have any ready replicas. Check that the application's liveness probes are passing and that the application is not in a crash loop.
               - warn:
                   when: "= 1"
-                  message: The API deployment has only a single ready replica.
+                  message: The api deployment has only a single ready replica.
               - pass:
-                  message: There are multiple replicas of the API deployment ready.
+                  message: The api deployment is healthy and has multiple ready replicas.
 ```

--- a/docs/vendor/support-bundle-examples.mdx
+++ b/docs/vendor/support-bundle-examples.mdx
@@ -25,10 +25,15 @@ This topic includes common examples of support bundle specifications. For more e
 
 ## Check application health
 
-The examples below use the `deploymentStatus` analyzer to check whether the required number of replicas are available for an application deployment. The `deploymentStatus` analyzer uses data from the default `clusterResources` collector.
+The following examples use the `deploymentStatus` analyzer to check whether the required number of replicas are available for an application deployment. The `deploymentStatus` analyzer uses data from the default `clusterResources` collector.
 
 :::tip Why this approach?
-The `deploymentStatus` analyzer surfaces the cluster's own view of application health, whether liveness probes are passing and pods are ready, without requiring additional collectors or RBAC. Alternative collectors (`http`, `exec`, `runPod`) can probe health endpoints directly but each has environment-specific limitations: `http` cannot resolve in-cluster DNS from the CLI; `exec` requires `pods/exec` RBAC and tools such as `curl`, `wget`, or `nc` in the container; `runPod` requires `pods/create` RBAC and, in air gap environments, the image must already be present on the node.
+The `deploymentStatus` analyzer reflects the cluster's own view of application health and requires no additional collectors or RBAC. It checks whether liveness probes are passing and the required number of replicas are ready.
+
+Alternative collectors can probe health endpoints directly, but each has environment-specific limitations:
+- `http` cannot resolve in-cluster DNS from the CLI.
+- `exec` requires `pods/exec` RBAC and tools such as `curl`, `wget`, or `nc` in the container.
+- `runPod` requires `pods/create` RBAC. In air gap environments, the image must already be present on the node.
 :::
 
 For more information, see [Deployment Status](https://troubleshoot.sh/docs/analyze/deployment-status/) and [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) in the Troubleshoot documentation.

--- a/docs/vendor/support-bundle-examples.mdx
+++ b/docs/vendor/support-bundle-examples.mdx
@@ -28,7 +28,7 @@ This topic includes common examples of support bundle specifications. For more e
 The examples below use the `deploymentStatus` analyzer to check whether the required number of replicas are available for an application deployment. The `deploymentStatus` analyzer uses data from the default `clusterResources` collector.
 
 :::tip Why this approach?
-The `deploymentStatus` analyzer surfaces the kubelet's authoritative view of application health — whether liveness probes are passing and pods are ready — without requiring additional collectors or RBAC. Alternative collectors (`http`, `exec`, `runPod`) can probe health endpoints directly but each has environment-specific limitations: `http` cannot resolve in-cluster DNS from the CLI; `exec` requires `pods/exec` RBAC and tools such as `curl`, `wget`, or `nc` in the container; `runPod` requires `pods/create` RBAC and, in air gap environments, the image must already be present on the node.
+The `deploymentStatus` analyzer surfaces the cluster's own view of application health, whether liveness probes are passing and pods are ready, without requiring additional collectors or RBAC. Alternative collectors (`http`, `exec`, `runPod`) can probe health endpoints directly but each has environment-specific limitations: `http` cannot resolve in-cluster DNS from the CLI; `exec` requires `pods/exec` RBAC and tools such as `curl`, `wget`, or `nc` in the container; `runPod` requires `pods/create` RBAC and, in air gap environments, the image must already be present on the node.
 :::
 
 For more information, see [Deployment Status](https://troubleshoot.sh/docs/analyze/deployment-status/) and [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) in the Troubleshoot documentation.

--- a/docs/vendor/support-bundle-examples.mdx
+++ b/docs/vendor/support-bundle-examples.mdx
@@ -23,9 +23,13 @@ import RunPodsCr from "../partials/support-bundles/_run-pods-cr.mdx"
 
 This topic includes common examples of support bundle specifications. For more examples, see the [Troubleshoot example repository](https://github.com/replicatedhq/troubleshoot/tree/main/examples/support-bundle) in GitHub.
 
-## Check API deployment status
+## Check application health
 
-The examples below use the `deploymentStatus` analyzer to check the version of Kubernetes running in the cluster. The `deploymentStatus` analyzer uses data from the default `clusterResources` collector.
+The recommended approach for checking application health in a support bundle is to use the `deploymentStatus` analyzer with the default `clusterResources` collector.
+
+This approach surfaces the kubelet's authoritative view of application health — whether pods are passing their liveness probes and have the required number of ready replicas. Because it reads from the `clusterResources` collector that is included by default, it requires no additional collectors or RBAC permissions and works reliably whether the bundle is generated from the CLI or from inside the cluster.
+
+While other collectors can probe application health endpoints directly, each has environment-specific limitations: the `http` collector runs client-side and cannot resolve in-cluster DNS when the bundle is generated from the CLI; the `exec` collector requires `pods/exec` RBAC and that tools such as `curl`, `wget`, or `nc` are available in the container; and `runPod` requires `pods/create` RBAC and, in air gap environments, the image must already be available on the node.
 
 For more information, see [Deployment Status](https://troubleshoot.sh/docs/analyze/deployment-status/) and [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) in the Troubleshoot documentation.
 
@@ -36,7 +40,7 @@ For more information, see [Deployment Status](https://troubleshoot.sh/docs/analy
   <TabItem value="custom-resource" label="SupportBundle Custom Resource">
     <DeployStatusCr/>
   </TabItem>
-</Tabs> 
+</Tabs>
 
 ## Check HTTP requests
 

--- a/docs/vendor/support-bundle-examples.mdx
+++ b/docs/vendor/support-bundle-examples.mdx
@@ -25,11 +25,11 @@ This topic includes common examples of support bundle specifications. For more e
 
 ## Check application health
 
-The recommended approach for checking application health in a support bundle is to use the `deploymentStatus` analyzer with the default `clusterResources` collector.
+The examples below use the `deploymentStatus` analyzer to check whether the required number of replicas are available for an application deployment. The `deploymentStatus` analyzer uses data from the default `clusterResources` collector.
 
-This approach surfaces the kubelet's authoritative view of application health — whether pods are passing their liveness probes and have the required number of ready replicas. Because it reads from the `clusterResources` collector that is included by default, it requires no additional collectors or RBAC permissions and works reliably whether the bundle is generated from the CLI or from inside the cluster.
-
-While other collectors can probe application health endpoints directly, each has environment-specific limitations: the `http` collector runs client-side and cannot resolve in-cluster DNS when the bundle is generated from the CLI; the `exec` collector requires `pods/exec` RBAC and that tools such as `curl`, `wget`, or `nc` are available in the container; and `runPod` requires `pods/create` RBAC and, in air gap environments, the image must already be available on the node.
+:::tip Why this approach?
+The `deploymentStatus` analyzer surfaces the kubelet's authoritative view of application health — whether liveness probes are passing and pods are ready — without requiring additional collectors or RBAC. Alternative collectors (`http`, `exec`, `runPod`) can probe health endpoints directly but each has environment-specific limitations: `http` cannot resolve in-cluster DNS from the CLI; `exec` requires `pods/exec` RBAC and tools such as `curl`, `wget`, or `nc` in the container; `runPod` requires `pods/create` RBAC and, in air gap environments, the image must already be present on the node.
+:::
 
 For more information, see [Deployment Status](https://troubleshoot.sh/docs/analyze/deployment-status/) and [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) in the Troubleshoot documentation.
 

--- a/docs/vendor/support-bundle-examples.mdx
+++ b/docs/vendor/support-bundle-examples.mdx
@@ -25,16 +25,13 @@ This topic includes common examples of support bundle specifications. For more e
 
 ## Check application health
 
-The following examples use the `deploymentStatus` analyzer to check whether the required number of replicas are available for an application deployment. The `deploymentStatus` analyzer uses data from the default `clusterResources` collector.
+This example shows how to use the `deploymentStatus` analyzer to check an application's health.
+The `deploymentStatus` analyzer uses data from the default `clusterResources` collector to check if liveness probes are passing and if the required number of replicas are ready for an application deployment.
 
-:::tip Why this approach?
-The `deploymentStatus` analyzer reflects the cluster's own view of application health and requires no additional collectors or RBAC. It checks whether liveness probes are passing and the required number of replicas are ready.
-
-Alternative collectors can probe health endpoints directly, but each has environment-specific limitations:
+Replicated recommends using the `deploymentStatus` analyzer to check application health because it doesn't require any additional collectors besides `clusterResources`. It also requires no additional RBAC permissions. The `http`, `exec`, and `runPod` collectors can probe health endpoints directly, but each has environment-specific limitations:
 - `http` cannot resolve in-cluster DNS from the CLI.
 - `exec` requires `pods/exec` RBAC and tools such as `curl`, `wget`, or `nc` in the container.
-- `runPod` requires `pods/create` RBAC. In air gap environments, the image must already be present on the node.
-:::
+- `runPod` requires `pods/create` RBAC. In air-gapped environments, the image must already be present on the node.
 
 For more information, see [Deployment Status](https://troubleshoot.sh/docs/analyze/deployment-status/) and [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) in the Troubleshoot documentation.
 

--- a/styles/config/vocabularies/TechJargon/accept.txt
+++ b/styles/config/vocabularies/TechJargon/accept.txt
@@ -92,3 +92,4 @@ SSO
 TOTP
 ttl
 keyless
+liveness


### PR DESCRIPTION
## Summary

- Renames the \"Check API deployment status\" section in `support-bundle-examples.mdx` to \"Check application health\" and rewrites the intro to establish `deploymentStatus` + `clusterResources` as the recommended approach for checking application health in support bundles
- Adds a `:::tip Why this approach?` admonition explaining why this pattern is preferred (surfaces the cluster's own view of health, no extra RBAC, works in all environments) and briefly describes the limitations of `http`, `exec`, and `runPod` as alternatives
- Updates outcome messages in both `_deploy-status-secret.mdx` and `_deploy-status-cr.mdx` to reference liveness probe failures and crash loops, making the failure guidance more actionable

## Test Plan

- [ ] Verify the `## Check application health` section renders correctly with the tip admonition
- [ ] Verify the tabbed Secret/CR YAML examples display correctly
- [ ] Verify all other sections on the examples page are unchanged
- [ ] Check that the outcome messages in the YAML examples reference liveness probes and crash loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)