### PR TITLE
docs(custom-domains): warn that switching default custom domain breaks existing installs

### DIFF
--- a/docs/vendor/custom-domains-using.md
+++ b/docs/vendor/custom-domains-using.md
@@ -101,6 +101,10 @@ When you set a custom domain as the default, it is used by default for all new r
 
 Only releases that are promoted to a channel _after_ you set a default domain use the new default domain. Any existing releases that were promoted before you set the default continue to use the same domain that they used previously.
 
+:::important
+When you change the default custom domain for the Replicated registry or proxy registry to a _different_ custom domain, image pulls fail for existing installations of releases promoted under the previous default. The image pull secret rendered into Helm values does not include credentials for the previous custom domain. Ensure existing installations have upgraded to a release promoted under the new custom domain before you change the default.
+:::
+
 :::note
 In Embedded Cluster installations, the KOTS Admin Console will use the domains specified in the `domains.proxyRegistryDomain` and `domains.replicatedAppDomain` fields of the Embedded Cluster Config when making requests to the proxy registry and app service, regardless of the default domain or the domain assigned to the given release channel. For more information about using custom domains in Embedded Cluster installations, see [Configure Embedded Cluster to Use Custom Domains](#ec) above.
 :::


### PR DESCRIPTION
Adds an important admonition in "Set a default domain" explaining that changing the default custom domain for the registry or proxy registry causes image pulls to fail for installations of releases promoted under the previous default, and that customers should upgrade first.

from this story: https://app.shortcut.com/replicated/story/136331/custom-domain-activation-breaks-existing-sdk-releases