### PR TITLE
docs: add release build failed notification event

### DIFF
--- a/docs/reference/notifications-events-filters.md
+++ b/docs/reference/notifications-events-filters.md
@@ -199,6 +199,17 @@ When a release is promoted to a channel.
 
 When a release is demoted from a channel.
 
+### Release Build Failed
+
+When an air gap bundle build fails for a release on a channel.
+
+The following table describes the available filters for the Release Build Failed event type:
+
+| Filter | Required | Options |
+|--------|----------|---------|
+| Application | No | Any application |
+| Channel | No | Any channel for the selected application |
+
 ### Release Assets Downloaded {#release-assets-downloaded}
 
 When a customer pulls a release asset (Helm chart, Embedded Cluster bundle, or proxy registry image). Each individual asset pull triggers one Release Assets Downloaded event.

--- a/docs/reference/notifications-events-filters.md
+++ b/docs/reference/notifications-events-filters.md
@@ -201,7 +201,7 @@ When a release is demoted from a channel.
 
 ### Release Build Failed
 
-When an air gap bundle build fails for a release on a channel.
+When an release build fails for a release on a channel.
 
 The following table describes the available filters for the Release Build Failed event type:
 

--- a/docs/vendor/event-notifications-create.mdx
+++ b/docs/vendor/event-notifications-create.mdx
@@ -111,7 +111,7 @@ As a Product Manager, I want to be notified when a new release version is made a
 
 ### Release engineer: Release build failed
 
-As a Release Engineer, I want to be notified when an air gap bundle build fails on a testing or production channel so that I can investigate the failure before customers try to install or upgrade.
+As a Release Engineer, I want alerts when an air gap bundle build fails on a testing or production channel. This helps me investigate before customers install or upgrade.
 
 - **Event Type:** Release Build Failed
 - **Configuration:**

--- a/docs/vendor/event-notifications-create.mdx
+++ b/docs/vendor/event-notifications-create.mdx
@@ -109,6 +109,16 @@ As a Product Manager, I want to be notified when a new release version is made a
   - Filter - Channel: Select "Stable"
 - **Delivery Method:** Email to `pm-team@company.com` or webhook to #pm-team channel in Slack
 
+### Release engineer: Release build failed
+
+As a Release Engineer, I want to be notified when an air gap bundle build fails on a testing or production channel so that I can investigate the failure before customers try to install or upgrade.
+
+- **Event Type:** Release Build Failed
+- **Configuration:**
+  - Filter - Application: Select your application
+  - Filter - Channel: Select "Unstable", "Beta", or "Stable", depending on the channels you monitor
+- **Delivery Method:** Webhook to your team chat or email to your release engineering alias
+
 ### Development leader: Paid customer downloads release assets
 
 As a Development Leader, I want to be notified when a paid customer pulls release assets to initiate a paid install.


### PR DESCRIPTION
## Summary
- document the new Release Build Failed event in Event Notifications
- add a subscription example for release engineers

## Context
This accompanies the Vandoor feature PR: https://github.com/replicatedhq/vandoor/pull/9603

That PR adds direct notifications when an air gap bundle build fails.