### PR TITLE
docs: add mute instance health alerts for notification subscriptions

### DIFF
--- a/docs/vendor/event-notifications-manage.mdx
+++ b/docs/vendor/event-notifications-manage.mdx
@@ -47,9 +47,9 @@ Muting applies to the following health event types only:
 - Instance Version Behind
 - Custom Metric Threshold Reached
 
-Mutes are scoped to the subscription — other subscriptions that cover the same instance are not affected.
+The mute applies to the subscription only — other subscriptions that cover the same instance are not affected.
 
-When one or more instances are muted, an amber banner appears at the top of the **History** tab listing the active mutes. The subscription card on the **Overview** page also shows a badge with the count of muted instances.
+When you mute one or more instances, an amber banner appears at the top of the **History** tab listing the active mutes. The subscription card on the **Overview** page also shows a badge with the count of muted instances.
 
 ### Mute an instance
 
@@ -61,7 +61,7 @@ To mute health alerts for a specific instance:
 1. Select a mute duration: **7 days**, **30 days**, or **Indefinitely**.
 1. Confirm the mute.
 
-The Vendor Portal will not deliver health alerts for the muted instance on this subscription until the mute expires or is removed.
+The Vendor Portal will not deliver health alerts for the muted instance on this subscription until the mute expires or you remove it.
 
 ### Remove a mute
 
@@ -69,7 +69,7 @@ To remove a mute before it expires:
 
 1. In the Vendor Portal, go to **Notifications > History**.
 1. In the active-mutes banner, click **Manage mutes**.
-1. Click **Unmute** next to the instance you want to re-enable.
+1. For the instance you want to re-enable, click **Unmute**.
 
 ## Edit a notification
 

--- a/docs/vendor/event-notifications-manage.mdx
+++ b/docs/vendor/event-notifications-manage.mdx
@@ -37,39 +37,39 @@ To resend a failed notification:
 1. Expand the failed event and click **Resend email** or **Resend webhook**.
 1. Confirm the resend.
 
-## Mute health alerts for a specific instance
+## Mute health alert notifications for specific instances
 
-You can mute a specific instance on a notification subscription to suppress recurring health alerts for that instance. Muting is useful when an instance is in a known degraded state and you want to reduce noise without disabling the subscription entirely.
+For any subscription that alerts on instance health events (such as Custom Metric Threadhold Reached or Instance Version Behind events), you can mute notifications for specific instances. Muting is useful when an instance is in a known degraded state and you want to reduce noise without disabling the subscription entirely.
 
-Muting applies to the following health event types only:
+When you mute health alerts for an instance, the Vendor Portal blocks notifications from the given subscription for that instance. Other subscriptions that apply to the instance are _not_ muted.
+
+The Vendor Portal lists muted instances in a banner at the top of the **Notifications > History** tab. The subscription card on the **Notifications > Overview** page also shows a badge with the count of muted instances.
+
+You can mute notifications for the following event types only:
 - Instance State Duration
 - Instance State Flapping
 - Instance Version Behind
 - Custom Metric Threshold Reached
 
-The mute applies to the subscription only — other subscriptions that cover the same instance are not affected.
-
-When you mute one or more instances, an amber banner appears at the top of the **History** tab listing the active mutes. The subscription card on the **Overview** page also shows a badge with the count of muted instances.
-
 ### Mute an instance
 
-To mute health alerts for a specific instance:
+To mute an instance:
 
 1. In the Vendor Portal, go to **Notifications > History**.
-1. Expand a health event row for the instance you want to mute.
+1. Expand a row for the instance you want to mute.
+   :::note
+   Muting is supported only for subscriptions that alert on instance health events.
+   :::
 1. Click **Mute instance**.
-1. Select a mute duration: **7 days**, **30 days**, or **Indefinitely**.
-1. Confirm the mute.
+1. Select a duration to mute the instance (7 days, 30 days, or Indefinitely), and confirm.
 
-The Vendor Portal will not deliver health alerts for the muted instance on this subscription until the mute expires or you remove it.
+### Unmute an instance
 
-### Remove a mute
-
-To remove a mute before it expires:
+To unmute an instance:
 
 1. In the Vendor Portal, go to **Notifications > History**.
-1. In the active-mutes banner, click **Manage mutes**.
-1. For the instance you want to re-enable, click **Unmute**.
+1. In the banner at the top of the page, click **Manage mutes**.
+1. For the target instance, click **Unmute**.
 
 ## Edit a notification
 

--- a/docs/vendor/event-notifications-manage.mdx
+++ b/docs/vendor/event-notifications-manage.mdx
@@ -1,6 +1,6 @@
 # Manage event notification subscriptions (Beta)
 
-This topic describes how to view, edit, disable, and delete event notifications in the Replicated Vendor Portal. For more information about the Event Notifications (Beta) feature, see [About event notifications (Beta)](/vendor/event-notifications).
+This topic describes how to view, edit, mute, disable, and delete event notifications in the Replicated Vendor Portal. For more information about the Event Notifications (Beta) feature, see [About event notifications (Beta)](/vendor/event-notifications).
 
 ## View notification subscriptions
 
@@ -36,6 +36,40 @@ To resend a failed notification:
 1. Go to **Notifications** > **History**.
 1. Expand the failed event and click **Resend email** or **Resend webhook**.
 1. Confirm the resend.
+
+## Mute health alerts for a specific instance
+
+You can mute a specific instance on a notification subscription to suppress recurring health alerts for that instance. Muting is useful when an instance is in a known degraded state and you want to reduce noise without disabling the subscription entirely.
+
+Muting applies to the following health event types only:
+- Instance State Duration
+- Instance State Flapping
+- Instance Version Behind
+- Custom Metric Threshold Reached
+
+Mutes are scoped to the subscription — other subscriptions that cover the same instance are not affected.
+
+When one or more instances are muted, an amber banner appears at the top of the **History** tab listing the active mutes. The subscription card on the **Overview** page also shows a badge with the count of muted instances.
+
+### Mute an instance
+
+To mute health alerts for a specific instance:
+
+1. In the Vendor Portal, go to **Notifications > History**.
+1. Expand a health event row for the instance you want to mute.
+1. Click **Mute instance**.
+1. Select a mute duration: **7 days**, **30 days**, or **Indefinitely**.
+1. Confirm the mute.
+
+The Vendor Portal will not deliver health alerts for the muted instance on this subscription until the mute expires or is removed.
+
+### Remove a mute
+
+To remove a mute before it expires:
+
+1. In the Vendor Portal, go to **Notifications > History**.
+1. In the active-mutes banner, click **Manage mutes**.
+1. Click **Unmute** next to the instance you want to re-enable.
 
 ## Edit a notification
 

--- a/styles/config/vocabularies/TechJargon/accept.txt
+++ b/styles/config/vocabularies/TechJargon/accept.txt
@@ -92,3 +92,4 @@ SSO
 TOTP
 ttl
 keyless
+Unmute


### PR DESCRIPTION
## What this PR does

Adds documentation for the new instance mute feature shipping in replicatedhq/vandoor#9613.

**Do not merge until vandoor#9613 is released.**

### Changes

- `event-notifications-manage.mdx`: New **Mute health alerts for a specific instance** section covering:
  - When and why to use mutes (known-degraded instance, reduce noise without disabling subscription)
  - Which 4 health event types support muting (Instance State Duration, Instance State Flapping, Instance Version Behind, Custom Metric Threshold Reached)
  - Subscription-scoped behavior
  - How to mute an instance (from the History tab, with 7-day / 30-day / indefinite options)
  - How to remove a mute before expiry (via the active-mutes banner)
  - Mention of the active-mutes amber banner and muted-instances badge on subscription cards
  - Updated page intro to include "mute"