### PR TITLE
docs: document config group auto-hide behavior and label item workaround

### DIFF
--- a/docs/reference/custom-resource-config.mdx
+++ b/docs/reference/custom-resource-config.mdx
@@ -186,6 +186,10 @@ Each group contains an array of items that map to input fields on the Admin Cons
 
 For more information, see [Item Properties](#item-properties) and [Item Types](#item-types) below.
 
+:::note
+If all items in a group are hidden because their `when` conditions evaluate to false, the entire group is hidden, including its `title` and `description`. To ensure that the group remains visible and shows messaging to the user, include a `label` item in the group that is not hidden. For more information, see [Show messaging for unavailable features](/vendor/config-screen-conditional#show-messaging-for-unavailable-features) in _Using Conditional Statements in Configuration Fields_.
+:::
+
 ## Item Properties
 
 Items have a `name`, `title`, `type`, and other optional properties.

--- a/docs/vendor/config-screen-conditional.mdx
+++ b/docs/vendor/config-screen-conditional.mdx
@@ -107,6 +107,39 @@ As shown in the image below, the **Config** page displays the `new_feature_confi
 
 [View a larger version of this image](/images/config-example-newfeature.png)
 
+### Show messaging for unavailable features
+
+When all items in a group are hidden by `when` conditions, the entire group is hidden, including its title and description. To display a message to users when a feature is unavailable (for example, to inform them that they need to upgrade their license to access certain configuration options), add a `label` item to the group that is shown in the negated condition.
+
+In the following example, the `enterprise_features` group contains two items that are shown only when the user's license includes the `enterprise_features` field set to `true`. The `upgrade_notice` item uses `type: label` with a negated `when` condition so that it is displayed when the entitlement is missing, ensuring the group remains visible with an informational message.
+
+```yaml
+apiVersion: kots.io/v1beta1
+kind: Config
+metadata:
+  name: config-sample
+spec:
+  groups:
+    - name: enterprise_features
+      title: Enterprise Features
+      description: Advanced configuration options.
+      items:
+      - name: advanced_setting
+        title: Advanced Setting
+        type: text
+        when: '{{repl (LicenseFieldValue "enterprise_features" | ParseBool) }}'
+      - name: another_advanced_setting
+        title: Another Advanced Setting
+        type: text
+        when: '{{repl (LicenseFieldValue "enterprise_features" | ParseBool) }}'
+      - name: upgrade_notice
+        type: label
+        title: "Upgrade your license to access these features."
+        when: '{{repl not (LicenseFieldValue "enterprise_features" | ParseBool) }}'
+```
+
+In this example, when the `enterprise_features` license field is missing or false, only the `upgrade_notice` label is shown and the group remains visible. When the entitlement is present, the label is hidden and the actual configuration items are shown.
+
 ### License field value integer comparison
 
 You can show or hide configuration fields based on the values in a license to ensure that users only see configuration options for the features and entitlements granted by their license. You can also compare integer values from license fields to control the configuration experience for your users.


### PR DESCRIPTION
## Summary

Documents the behavior where config groups with zero visible items auto-hide entirely (including title and description), and provides guidance on using a `label` item with a negated `when` condition to display messaging to users when features are unavailable.

[SC-136957](https://app.shortcut.com/replicated/story/136957)

## Changes

- **Reference docs (`custom-resource-config.mdx`)**: Added a note under the `items` group property explaining the auto-hide behavior and linking to the conditional guide.
- **Vendor guide (`config-screen-conditional.mdx`)**: Added a new **"Show messaging for unavailable features"** section with a complete YAML example demonstrating the `label` + `when` pattern. The example uses `LicenseFieldValue` with `ParseBool` to conditionally show/hide items based on a license field (`enterprise_features`), and shows an informational label when the entitlement is missing.