### PR TITLE
[! wait to merge !] Remove Beta label from Event Notifications docs (GA)

### DIFF
--- a/docs/reference/notifications-events-filters.md
+++ b/docs/reference/notifications-events-filters.md
@@ -1,8 +1,7 @@
-# Event types and filters (Beta)
+# Event types and filters
+For more information about the Event Notifications feature, see [About event notifications](/vendor/event-notifications).
 
-For more information about the Event Notifications (Beta) feature, see [About event notifications (Beta)](/vendor/event-notifications).
-
-This topic lists the types of events supported for the Event Notifications (Beta) feature.
+This topic lists the types of events supported for the Event Notifications feature.
 
 ## Channel events
 

--- a/docs/vendor/event-notifications-create.mdx
+++ b/docs/vendor/event-notifications-create.mdx
@@ -53,7 +53,7 @@ To create an event notification subscription:
          - Must respond with a 2xx status code (200-299) for successful delivery
          - Response time must be less than five seconds
 
-      1. (Recommended) Enter a signing secret for HMAC signature verification. For more information, see [Verify webhook signatures](event-notifications-webhooks#verify-webhook-signatures) in _Configure and test webhooks_.
+      1. (Recommended) Enter a signing secret for Hash-based Message Authentication Code (HMAC) signature verification. For more information, see [Verify webhook signatures](event-notifications-webhooks#verify-webhook-signatures) in _Configure and test webhooks_.
       
       1. (Optional) Expand **Advanced configuration** to add custom HTTP headers for authenticating with your endpoint (for example, `Authorization: Bearer token`). For more information, see [About adding custom HTTP headers](event-notifications-webhooks#custom-headers) in _Configure and test webhooks_.
 

--- a/docs/vendor/event-notifications-create.mdx
+++ b/docs/vendor/event-notifications-create.mdx
@@ -1,6 +1,5 @@
-# Create event notification subscriptions (Beta)
-
-This topic describes how to create event notification subscriptions in the Replicated Vendor Portal. For more information about the Event Notifications (Beta) feature, see [About event notifications (Beta)](/vendor/event-notifications).
+# Create event notification subscriptions
+This topic describes how to create event notification subscriptions in the Replicated Vendor Portal. For more information about the Event Notifications feature, see [About event notifications](/vendor/event-notifications).
 
 ## Create an event notification
 
@@ -22,7 +21,7 @@ To create an event notification subscription:
 
    Subscription names can contain up to 255 ASCII characters (letters, numbers, and basic punctuation).
 
-1. Select one or more event types to include in the subscription. For the full list of available event types, see [Event types and filters (Beta)](/reference/notifications-events-filters).
+1. Select one or more event types to include in the subscription. For the full list of available event types, see [Event types and filters](/reference/notifications-events-filters).
 
    :::note
    Alternatively, click **Configure with AI instead**. With the AI-assisted notification builder, you can describe in natural language the events that you want to be notified about. For example, "Notify me when trial customers upload support bundles" or "Alert me when instances fall more than 3 versions behind on the Stable channel". The AI builder has context of pre-defined event types and filters, but cannot create new event types or filters.
@@ -30,7 +29,7 @@ To create an event notification subscription:
 
 1. (Optional) For each of the events that you selected, click the filter icon to configure event filters. Click **Done** to save the filters.
 
-    For more information about how the Vendor Portal uses filters to trigger notifications, see [Events and filters](/vendor/event-notifications#events-and-filters) in _About event notifications (Beta)_.
+    For more information about how the Vendor Portal uses filters to trigger notifications, see [Events and filters](/vendor/event-notifications#events-and-filters) in _About event notifications_.
 
     ![Event filters](/images/notification-event-filters.png)
 
@@ -54,9 +53,9 @@ To create an event notification subscription:
          - Must respond with a 2xx status code (200-299) for successful delivery
          - Response time must be less than five seconds
 
-      1. (Recommended) Enter a signing secret for HMAC signature verification. For more information, see [Verify webhook signatures](event-notifications-webhooks#verify-webhook-signatures) in _Configure and test webhooks (Beta)_.
+      1. (Recommended) Enter a signing secret for HMAC signature verification. For more information, see [Verify webhook signatures](event-notifications-webhooks#verify-webhook-signatures) in _Configure and test webhooks_.
       
-      1. (Optional) Expand **Advanced configuration** to add custom HTTP headers for authenticating with your endpoint (for example, `Authorization: Bearer token`). For more information, see [About adding custom HTTP headers](event-notifications-webhooks#custom-headers) in _Configure and test webhooks (Beta)_.
+      1. (Optional) Expand **Advanced configuration** to add custom HTTP headers for authenticating with your endpoint (for example, `Authorization: Bearer token`). For more information, see [About adding custom HTTP headers](event-notifications-webhooks#custom-headers) in _Configure and test webhooks_.
 
          <img alt="Webhook delivery fields" src="/images/notification-webhook-delivery.png" width="600px"/>
 

--- a/docs/vendor/event-notifications-manage.mdx
+++ b/docs/vendor/event-notifications-manage.mdx
@@ -1,6 +1,5 @@
-# Manage event notification subscriptions (Beta)
-
-This topic describes how to view, edit, mute, disable, and delete event notifications in the Replicated Vendor Portal. For more information about the Event Notifications (Beta) feature, see [About event notifications (Beta)](/vendor/event-notifications).
+# Manage event notification subscriptions
+This topic describes how to view, edit, mute, disable, and delete event notifications in the Replicated Vendor Portal. For more information about the Event Notifications feature, see [About event notifications](/vendor/event-notifications).
 
 ## View notification subscriptions
 

--- a/docs/vendor/event-notifications-webhooks.mdx
+++ b/docs/vendor/event-notifications-webhooks.mdx
@@ -1,6 +1,5 @@
-# Configure and test webhooks (Beta)
-
-This topic describes how to configure and test webhooks for event notifications. For information about how to create a notification using a webhook URL, see [Create event notification subscriptions (Beta)](/vendor/event-notifications-create).
+# Configure and test webhooks
+This topic describes how to configure and test webhooks for event notifications. For information about how to create a notification using a webhook URL, see [Create event notification subscriptions](/vendor/event-notifications-create).
 
 Webhooks allow you to receive notifications as HTTP POST requests to an endpoint you control. This enables integration with services like Slack, PagerDuty, custom monitoring systems, and other tools that support webhook integrations.
 

--- a/docs/vendor/event-notifications.mdx
+++ b/docs/vendor/event-notifications.mdx
@@ -1,6 +1,5 @@
-# About event notifications (Beta)
-
-This topic provides an overview of the Event Notifications (Beta) feature, which allows you to set up notifications for key events from the Vendor Portal.
+# About event notifications
+This topic provides an overview of the Event Notifications feature, which allows you to set up notifications for key events from the Vendor Portal.
 
 ## Overview
 
@@ -12,7 +11,7 @@ The following shows an example of the notifications **Overview** page:
 
 [View a larger version of this image](/images/notifications-overview.png)
 
-The Vendor Portal queues events to Amazon Simple Queue Service (SQS) for reliable processing, and matches notifications against your custom event filters in real time. You can receive notifications through email or webhook. For information about how to create and subscribe to event notifications, see [Create event notification subscriptions (Beta)](event-notifications-create).
+The Vendor Portal queues events to Amazon Simple Queue Service (SQS) for reliable processing, and matches notifications against your custom event filters in real time. You can receive notifications through email or webhook. For information about how to create and subscribe to event notifications, see [Create event notification subscriptions](event-notifications-create).
 
 ## Events and filters
 
@@ -22,7 +21,7 @@ This section describes the types of events and filters that are available for cr
 
 You can create notifications for various types of events, including events related to application instances, customers, support bundles, releases, and channels. For example, you can get a notification when an instance reaches a Ready state in the customer environment, when the customer uploads a new support bundle, or when a customer license is expiring soon.
 
-For the full list of available event types and event-specific filters, see [Event types and filters (Beta)](/reference/notifications-events-filters).
+For the full list of available event types and event-specific filters, see [Event types and filters](/reference/notifications-events-filters).
 
 ### Multi-event notifications
 
@@ -34,7 +33,7 @@ For example, if you create a notification with both the **Release Created** and 
 
 You can configure a unique set of filters for each event that you add to a notification. An event must match _all_ its filters to trigger the notification (AND logic).
 
-The filters available depend on the event type. All events support filtering by application name. Other common filters that apply to most event types include the channel, customer name, and license type. For more information, see [Event types and filters (Beta)](/reference/notifications-events-filters).
+The filters available depend on the event type. All events support filtering by application name. Other common filters that apply to most event types include the channel, customer name, and license type. For more information, see [Event types and filters](/reference/notifications-events-filters).
 
 ### Filters with multiple values
 
@@ -89,7 +88,7 @@ For more information, see [Configure RBAC policies](team-management-rbac-configu
 
 ## Limitations
 
-Event Notifications (Beta) has the following limitations:
+Event Notifications has the following limitations:
 
 - Notification events generated are not included in the [Instance Bulk Data Export API](instance-data-export)
 - It is possible to create a notification for some resource types, such as customers and support bundles, but not to access the notification linked asset due to your allowed user permissions. This is most likely to impact teams with [enterprise and custom RBAC policies](team-management-rbac-configuring). For example, someone with the [Sales RBAC role](team-management-rbac-configuring) can create a notification for a customer uploading a support bundle, but does not have permission to view the linked specific customer bundle due to their RBAC role permissions.
@@ -97,13 +96,13 @@ Event Notifications (Beta) has the following limitations:
 
 ## Comparison to instance notifications (Classic)
 
-Event Notifications (Beta) is the next generation of instance notification functionality in the Vendor Portal. Compared to [Instance Notifications (Classic)](instance-notifications-config), Event Notifications offers more event types, fine-grained filtering, flexible delivery routing, notification history tracking, and better access control.
+Event Notifications is the next generation of instance notification functionality in the Vendor Portal. Compared to [Instance Notifications (Classic)](instance-notifications-config), Event Notifications offers more event types, fine-grained filtering, flexible delivery routing, notification history tracking, and better access control.
 
-You can use Event Notifications (Beta) concurrently with Instance Notifications (Classic) while you evaluate and transition.
+You can use Event Notifications concurrently with Instance Notifications (Classic) while you evaluate and transition.
 
-The following table compares the functionality offered by Instance Notifications (Classic) and Event Notifications (Beta):
+The following table compares the functionality offered by Instance Notifications (Classic) and Event Notifications:
 
-| Feature | Instance Notifications (Classic) | Event Notifications (Beta) |
+| Feature | Instance Notifications (Classic) | Event Notifications |
 |---------|------------------------------|---------------------------|
 | **Event Types** | Three event types: App Status, System Events, Custom Metrics | More than 20 event types across six categories |
 | **Scope** | Per-instance subscriptions | Team-wide with flexible filtering |

--- a/docs/vendor/instance-notifications-config.mdx
+++ b/docs/vendor/instance-notifications-config.mdx
@@ -4,7 +4,7 @@ import NotificationsAbout from "../partials/instance-insights/_notifications-abo
 # Configure instance notifications (classic)
 
 :::caution
-Event Notifications (Beta) replaces Instance Notifications (Classic), offering more event types, better filtering, and improved delivery options. While Instance Notifications (Classic) is still supported, Replicated recommends using Event Notifications (Beta). For more information about how to configure event notifications, see [About Event Notifications (Beta)](event-notifications).
+Event Notifications replaces Instance Notifications (Classic), offering more event types, better filtering, and improved delivery options. While Instance Notifications (Classic) is still supported, Replicated recommends using Event Notifications. For more information about how to configure event notifications, see [About Event Notifications](event-notifications).
 :::
 
 <NotificationsAbout/>
@@ -21,7 +21,7 @@ Instance notifications can be disabled when they are no longer needed. For examp
 
 ## Prerequisite
 
-For Slack notifications, you must configure a Slack webhook in the Vendor Portal at the Team level before you can turn on instance notifications. For more information, see [Configuring a Slack Webhook (Beta)](team-management-slack-config).
+For Slack notifications, you must configure a Slack webhook in the Vendor Portal at the Team level before you can turn on instance notifications. For more information, see [Configuring a Slack Webhook](team-management-slack-config).
 
 For email notification, no prior configuration is required. The email address listed in your Vendor Portal account settings is used.
 
@@ -64,6 +64,6 @@ There is a 30-second buffer between event detection and notifications being sent
 
 ## See also
 
-- [Event Notifications (Beta)](event-notifications) - New notification system with more event types and better filtering
-- [Create Event Notification Subscriptions (Beta)](event-notifications-create) - Get started with Event Notifications
+- [Event Notifications](event-notifications) - New notification system with more event types and better filtering
+- [Create Event Notification Subscriptions](event-notifications-create) - Get started with Event Notifications
 - [Comparison: Classic vs. Event Notifications](event-notifications#comparison-to-instance-notifications-classic) - Feature comparison


### PR DESCRIPTION
Relates to https://app.shortcut.com/replicated/story/136151

Event Notifications is now GA. Removes " (Beta)" from page titles and body text across the six affected pages:

- `docs/vendor/event-notifications.mdx`
- `docs/vendor/event-notifications-create.mdx`
- `docs/vendor/event-notifications-manage.mdx`
- `docs/vendor/event-notifications-webhooks.mdx`
- `docs/reference/notifications-events-filters.md`
- `docs/vendor/instance-notifications-config.mdx`

The `"Beta"` release channel name referenced in `event-notifications-create.mdx` is unchanged.