### PR TITLE
[! wait to merge !] Document failure alert contact for webhook notification subscriptions

### DIFF
--- a/docs/vendor/event-notifications-create.mdx
+++ b/docs/vendor/event-notifications-create.mdx
@@ -74,6 +74,12 @@ To create an event notification subscription:
          
          The test result displays the HTTP status code and response time, or an error message with troubleshooting guidance. If you configured a signing secret, the test request is signed with HMAC-SHA256 so you can also verify your signature validation logic.
 
+      1. (Optional) In the **Failure alert contact** field, enter the email address that should receive notifications when webhook delivery permanently fails after all retries are exhausted.
+
+         You can type a team member's name or email address to search for suggestions, or enter any external email address (such as an on-call routing address for PagerDuty or OpsGenie).
+
+         If no failure alert contact is configured, Replicated notifies the subscription creator and all team admins by default.
+
    <!-- TODO: Add screenshot of delivery method selection -->
 
 1. Click **Create Notification**.

--- a/docs/vendor/event-notifications-create.mdx
+++ b/docs/vendor/event-notifications-create.mdx
@@ -74,11 +74,11 @@ To create an event notification subscription:
          
          The test result displays the HTTP status code and response time, or an error message with troubleshooting guidance. If you configured a signing secret, the test request is signed with HMAC-SHA256 so you can also verify your signature validation logic.
 
-      1. (Optional) In the **Failure alert contact** field, enter the email address that should receive notifications when webhook delivery permanently fails after all retries are exhausted.
+      1. (Optional) In the **Failure alert contact** field, enter the email address to notify when webhook delivery permanently fails.
 
-         You can type a team member's name or email address to search for suggestions, or enter any external email address (such as an on-call routing address for PagerDuty or OpsGenie).
+         Type a team member's name or email to search for suggestions. You can also enter any external email address, such as an on-call routing address for PagerDuty or OpsGenie.
 
-         If no failure alert contact is configured, Replicated notifies the subscription creator and all team admins by default.
+         Without a failure alert contact, Replicated notifies the subscription creator and all team admins by default.
 
    <!-- TODO: Add screenshot of delivery method selection -->
 

--- a/docs/vendor/event-notifications-manage.mdx
+++ b/docs/vendor/event-notifications-manage.mdx
@@ -91,6 +91,7 @@ To edit a notification:
    - Add or update a custom subscription name to help identify the subscription
    - Add or remove event types, or modify filters on existing event types to broaden or narrow the scope
    - Change the delivery method or destination
+   - Update the **Failure alert contact** to change who receives webhook delivery failure notifications
    - Check or uncheck the **Enable this notification** checkbox to pause or unpause the notification
 
 1. Click **Save Changes**.


### PR DESCRIPTION
## Summary

- Adds documentation for the new **Failure alert contact** field on webhook notification subscriptions
- Field is optional and webhook-only: lets vendors route delivery failure emails to a specific address (e.g. a PagerDuty/OpsGenie routing address) instead of the default creator + all team admins
- Documents the field in both the create flow (`event-notifications-create.mdx`) and the edit flow (`event-notifications-manage.mdx`)

Paired with vendor portal PR: replicatedhq/vandoor#9631

## Test plan

- [ ] Verify the new step appears in the correct position in the webhook delivery section of the create doc
- [ ] Verify the edit doc bullet reads naturally alongside the other edit examples