### PR TITLE
Update preflight and sb spec guidance

### DIFF
--- a/docs/vendor/preflight-defining.mdx
+++ b/docs/vendor/preflight-defining.mdx
@@ -1,116 +1,80 @@
 # Define preflight checks
 
-This topic describes how to define preflight checks in Helm and Kubernetes manifest-based applications. For more information about preflight checks, see [About Preflight Checks and Support Bundles](/vendor/preflight-support-bundle-about).
+This topic describes how to define custom preflight checks for your application. For more information about preflight checks, see [About Preflight Checks and Support Bundles](/vendor/preflight-support-bundle-about).
 
-The information in this topic applies to applications that are installed with Helm or with Replicated KOTS.
+## Add a preflight spec to a release
 
-## Step 1: Create the manifest file
+You can define custom preflight checks for your application by adding a preflight spec to your Helm chart templates.
 
-You can define preflight checks in a Kubernetes Secret or in a Preflight custom resource. The type of manifest file that you use depends on your application type (Helm or Kubernetes manifest-based) and the installation methods that your application supports (Helm, KOTS v1.101.0 or later, or KOTS v1.100.3 or earlier).
+To add a preflight spec to a release for your application:
 
-* **Helm Applications**: For Helm applications, see the following guidance:
+1. In your Helm chart `templates` directory, create a YAML file. Name the file `preflights.yaml` or similar.
 
-   * **(Recommended) Helm or KOTS v1.101.0 or Later**: For Helm applications installed with Helm or KOTS v1.101.0 or later, define the preflight checks in a Kubernetes Secret in your Helm chart `templates`. See [Kubernetes Secret](#secret).
+1. In the YAML file, add the following to create a Kubernetes Secret with the label `troubleshoot.sh/kind: preflight`:
 
-   * **KOTS v1.100.3 or Earlier**: For Helm applications installed with KOTS v1.100.3 or earlier, define the preflight checks in a Preflight custom resource. See [Preflight Custom Resource](#preflight-cr).
-
-* **Kubernetes Manifest-Based Applications**: For Kubernetes manifest-based applications, define the preflight checks in a Preflight custom resource. See [Preflight Custom Resource](#preflight-cr).
-
-### Kubernetes secret {#secret}
-
-For Helm applications installed with Helm or KOTS v1.101.0 or later, define preflight checks in a Kubernetes Secret in your Helm chart `templates`. This allows you to define the preflights spec only one time to support running preflight checks in both Helm and KOTS installations.
-
-Add the following YAML to a Kubernetes Secret in your Helm chart `templates` directory:
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  labels:
-    troubleshoot.sh/kind: preflight
-  name: "{{ .Release.Name }}-preflight-config"
-stringData:
-  preflight.yaml: |
-    apiVersion: troubleshoot.sh/v1beta2
-    kind: Preflight
+   ```yaml
+   # templates/preflight.yaml
+    apiVersion: v1
+    kind: Secret
     metadata:
-      name: preflight-sample
-    spec:
-      collectors: []
-      analyzers: []
-```
+      # the troubleshoot.sh/kind: preflight label is required
+      labels:
+        troubleshoot.sh/kind: preflight
+      name: "{{ .Release.Name }}-preflight-config"
+   ```
 
-As shown above, the Secret must include the following:
+1. In the Secret, add a `stringData` field with a key named `preflight.yaml`. This ensures the `preflight` binary can use this Secret when it runs from the CLI.
 
-* The label `troubleshoot.sh/kind: preflight`
-* A `stringData` field with a key named `preflight.yaml` so that the preflight binary can use this Secret when it runs from the CLI
+    ```yaml
+    # templates/preflight.yaml
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        troubleshoot.sh/kind: preflight
+      name: "{{ .Release.Name }}-preflight-config"
+    stringData:
+      # add a preflight.yaml key under stringData
+      preflight.yaml: |
+        apiVersion: troubleshoot.sh/v1beta2
+        kind: Preflight
+        metadata:
+          name: preflights
+        spec:
+          collectors: []
+          analyzers: []
+    ```
 
-### Preflight custom resource {#preflight-cr}
+1. Update `spec.collectors` and `spec.analyzers` with any collectors and analyzers that you want to use in the preflight checks for your application. For common examples, see [Examples of preflight specs](/vendor/preflight-examples).
 
-Define preflight checks in a Preflight custom resource for the following installation types:
-* Kubernetes manifest-based applications installed with any version of KOTS
-* Helm applications installed with KOTS v1.100.3 and earlier
+    For the complete list of available collectors and analyzers, see the [Collect](https://troubleshoot.sh/docs/collect/all/) and [Analyze](https://troubleshoot.sh/docs/analyze/) sections in the Troubleshoot documentation.
+
     :::note
-    For Helm charts installed with KOTS v1.101.0 and later, Replicated recommends that you define preflight checks in a Secret in the Helm chart `templates` instead of using the Preflight custom resource. See [Create a Secret](#secret) above.
-
-    In KOTS v1.101.0 and later, preflights defined in the Helm chart override the Preflight custom resource used by KOTS. During installation, if KOTS v1.101.0 and later cannot find preflights specified in the Helm chart archive, then KOTS searches for `kind: Preflight` in the root of the release.
+    The [clusterInfo](https://troubleshoot.sh/docs/collect/cluster-info/) and [clusterResources](https://troubleshoot.sh/docs/collect/cluster-resources/) collectors are included automatically to gather information about the cluster and cluster resources. You do not need manually include the `clusterInfo` or `clusterResources` collectors in the specification.
+    
+    To use only the `clusterInfo` and `clusterResources` collectors, delete the `spec.collectors` key from the preflight spec.
     :::
 
-Add the following YAML to a new file in a release:
+1. Test the preflight checks by running them in a cluster using the preflight plugin and Helm CLI. For information about how to install the preflight plugin and run preflight checks, see [Run preflight checks for Helm installations](/vendor/preflight-running).
 
-```yaml
-apiVersion: troubleshoot.sh/v1beta2
-kind: Preflight
-metadata:
-  name: preflights
-spec:
-  collectors: []
-  analyzers: []
-```
+1. From the root directory of your Helm chart, package the chart into a `.tgz` archive:
 
-For more information about the Preflight custom resource, see [Preflight and Support Bundle](/reference/custom-resource-preflight).
+   ```bash
+   helm package --dependency-update .
+   ```
 
-## Step 2: Define collectors and analyzers
+1. Add the chart archive to a new release. Promote the release to an internal development channel, and install the release in a development environment to test your changes.
 
-This section describes how to define collectors and analyzers for preflight checks based on your application needs. You add the collectors and analyzers that you want to use in the `spec.collectors` and `spec.analyzers` keys in the manifest file that you created.
+## (Optional) Block installation with required (strict) preflights {#strict}
 
-### Collectors
-
-Collectors gather information from the cluster, the environment, the application, or other sources. Collectors generate output that is then used by the analyzers that you define to generate results for the preflight checks. 
-
-The following default collectors are included automatically to gather information about the cluster and cluster resources:
-* [clusterInfo](https://troubleshoot.sh/docs/collect/cluster-info/)
-* [clusterResources](https://troubleshoot.sh/docs/collect/cluster-resources/)
-
-You do not need manually include the `clusterInfo` or `clusterResources` collectors in the specification. To use only the `clusterInfo` and `clusterResources` collectors, delete the `spec.collectors` key from the preflight specification.
-
-The Troubleshoot open source project includes several additional collectors that you can include in the specification to gather more information from the installation environment. To view all the available collectors, see [All Collectors](https://troubleshoot.sh/docs/collect/all/) in the Troubleshoot documentation.
-
-### Analyzers
-
-Analyzers use the output from the collectors to generate results for the preflight checks, including the criteria for pass, fail, and warn outcomes and custom messages for each outcome.
-
-For example, in a preflight check that checks the version of Kubernetes running in the target cluster, the analyzer can define a fail outcome when the cluster is running a version of Kubernetes less than 1.25 that includes the following custom message to the user: `The application requires Kubernetes 1.25.0 or later, and recommends 1.27.0`.
-
-The Troubleshoot open source project includes several analyzers that you can include in your preflight check specification. The following are some of the analyzers in the Troubleshoot project that use the default `clusterInfo` or `clusterResources` collectors:
-* [clusterPodStatuses](https://troubleshoot.sh/docs/analyze/cluster-pod-statuses/)
-* [clusterVersion](https://troubleshoot.sh/docs/analyze/cluster-version/)
-* [deploymentStatus](https://troubleshoot.sh/docs/analyze/deployment-status/)
-* [distribution](https://troubleshoot.sh/docs/analyze/distribution/)
-* [nodeResources](https://troubleshoot.sh/docs/analyze/node-resources/)
-* [statefulsetStatus](https://troubleshoot.sh/docs/analyze/stateful-set-status/)
-* [storageClass](https://troubleshoot.sh/docs/analyze/storage-class/)
-
-To view all the available analyzers, see the [Analyze](https://troubleshoot.sh/docs/analyze/) section of the Troubleshoot documentation.
-
-### Block installation with required (strict) preflights {#strict}
-
-For applications installed with KOTS or Embedded Cluster, you can set any preflight analyzer to `strict: true`. When `strict: true` is set, any `fail` outcomes for the analyzer block the deployment of the release.
+For applications installed with a Replicated installer (Embedded Cluster, KOTS, kURL), you can set any preflight analyzer to `strict: true`. When `strict: true` is set, any `fail` outcomes for the analyzer block the deployment of the release.
 
 :::note
 Strict preflight analyzers are ignored if the `exclude` property is also included and evaluates to `true`. See [exclude](https://troubleshoot.sh/docs/analyze/#exclude) in the Troubleshoot documentation.
 :::
 
-### Examples
+The following image shows how a `fail` outcome is displayed when `strict: true` is set on an analyzer, which prevents installation from continuing if the preflight check fails:
 
-For common examples of collectors and analyzers used in preflight checks, see [Examples of Preflight Specs](/vendor/preflight-examples).
+![Preflight checks in Admin Console showing fail message with strict mode](/images/preflight-mysql-fail-strict.png)
+
+[View a larger version of this image](/images/preflight-mysql-fail-strict.png)

--- a/docs/vendor/preflight-defining.mdx
+++ b/docs/vendor/preflight-defining.mdx
@@ -79,18 +79,20 @@ The following image shows how a `fail` outcome appears when you set `strict: tru
 
 [View a larger version of this image](/images/preflight-mysql-fail-strict.png)
 
-## Add a preflight spec for non-Helm applications or installations with KOTS v1.100.3 and earlier
+## Define preflights for non-Helm applications or KOTS v1.100.3 and earlier
 
-For non-Helm applications or KOTS v1.100.3 and earlier, add the following SupportBundle custom resource at the root level of your release:
+For non-Helm applications or installations with KOTS v1.100.3 and earlier, add the Preflight custom resource to a YAML file at the root level of your release:
 
 ```yaml
-# support-bundle.yaml
+# preflights.yaml
 
 apiVersion: troubleshoot.sh/v1beta2
-kind: SupportBundle
+kind: Preflight
 metadata:
-  name: example
+  name: preflights
 spec:
   collectors: []
   analyzers: []
-```  
+```
+
+Customize the collectors and analyzers as desired.

--- a/docs/vendor/preflight-defining.mdx
+++ b/docs/vendor/preflight-defining.mdx
@@ -50,7 +50,7 @@ To add a preflight spec to a release for your application:
     For the complete list of available collectors and analyzers, see the [Collect](https://troubleshoot.sh/docs/collect/all/) and [Analyze](https://troubleshoot.sh/docs/analyze/) sections in the Troubleshoot documentation.
 
     :::note
-    The [clusterInfo](https://troubleshoot.sh/docs/collect/cluster-info/) and [clusterResources](https://troubleshoot.sh/docs/collect/cluster-resources/) collectors are included automatically to gather information about the cluster and cluster resources. You do not need manually include the `clusterInfo` or `clusterResources` collectors in the specification.
+    Troubleshoot automatically includes the [clusterInfo](https://troubleshoot.sh/docs/collect/cluster-info/) and [clusterResources](https://troubleshoot.sh/docs/collect/cluster-resources/) collectors to gather information about the cluster and cluster resources. You do not need to manually include the `clusterInfo` or `clusterResources` collectors in the specification.
     
     To use only the `clusterInfo` and `clusterResources` collectors, delete the `spec.collectors` key from the preflight spec.
     :::
@@ -67,14 +67,30 @@ To add a preflight spec to a release for your application:
 
 ## (Optional) Block installation with required (strict) preflights {#strict}
 
-For applications installed with a Replicated installer (Embedded Cluster, KOTS, kURL), you can set any preflight analyzer to `strict: true`. When `strict: true` is set, any `fail` outcomes for the analyzer block the deployment of the release.
+For applications installed with a Replicated installer (Embedded Cluster, KOTS, kURL), you can set any preflight analyzer to `strict: true`. When you set `strict: true`, any `fail` outcomes for the analyzer block the deployment of the release.
 
 :::note
-Strict preflight analyzers are ignored if the `exclude` property is also included and evaluates to `true`. See [exclude](https://troubleshoot.sh/docs/analyze/#exclude) in the Troubleshoot documentation.
+Troubleshoot ignores strict preflight analyzers if the `exclude` property is also included and evaluates to `true`. See [exclude](https://troubleshoot.sh/docs/analyze/#exclude) in the Troubleshoot documentation.
 :::
 
-The following image shows how a `fail` outcome is displayed when `strict: true` is set on an analyzer, which prevents installation from continuing if the preflight check fails:
+The following image shows how a `fail` outcome appears when you set `strict: true` on an analyzer, which prevents installation from continuing if the preflight check fails:
 
 ![Preflight checks in Admin Console showing fail message with strict mode](/images/preflight-mysql-fail-strict.png)
 
 [View a larger version of this image](/images/preflight-mysql-fail-strict.png)
+
+## Add a preflight spec for non-Helm applications or installations with KOTS v1.100.3 and earlier
+
+For non-Helm applications or KOTS v1.100.3 and earlier, add the following SupportBundle custom resource at the root level of your release:
+
+```yaml
+# support-bundle.yaml
+
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: example
+spec:
+  collectors: []
+  analyzers: []
+```  

--- a/docs/vendor/preflight-examples.mdx
+++ b/docs/vendor/preflight-examples.mdx
@@ -10,11 +10,11 @@ import NodeCpuSecret from "../partials/preflights/_node-cpu-secret.mdx"
 
 # Example preflight specs
 
-This section includes common examples of preflight check specifications. For more examples, see the [Troubleshoot example repository](https://github.com/replicatedhq/troubleshoot/tree/main/examples/preflight) in GitHub.
+This section includes example preflight check specifications. For more, see the [Troubleshoot example repository](https://github.com/replicatedhq/troubleshoot/tree/main/examples/preflight) in GitHub.
 
 ## Check HTTP or HTTPS requests from the cluster
 
-The examples below use the `http` collector and the `textAnalyze` analyzer to check that an HTTP request to the Slack API at `https://api.slack.com/methods/api.test` made from the cluster returns a successful response of `"status": 200,`.
+The example below uses the `http` collector and the `textAnalyze` analyzer to check that an HTTP request to the Slack API at `https://api.slack.com/methods/api.test` made from the cluster returns a successful response of `"status": 200,`.
 
 For more information, see [HTTP](https://troubleshoot.sh/docs/collect/http/) and [Regular Expression](https://troubleshoot.sh/docs/analyze/regex/) in the Troubleshoot documentation.
 
@@ -26,7 +26,7 @@ For more information, see [HTTP](https://troubleshoot.sh/docs/collect/http/) and
 
 ## Check Kubernetes version
 
-The examples below use the `clusterVersion` analyzer to check the version of Kubernetes running in the cluster. The `clusterVersion` analyzer uses data from the default `clusterInfo` collector. The `clusterInfo` collector is automatically included.
+The example below uses the `clusterVersion` analyzer to check the version of Kubernetes running in the cluster. The `clusterVersion` analyzer uses data from the default `clusterInfo` collector. The `clusterInfo` collector is automatically included.
 
 For more information, see [Cluster Version](https://troubleshoot.sh/docs/analyze/cluster-version/) and [Cluster Info](https://troubleshoot.sh/docs/collect/cluster-info/) in the Troubleshoot documentation.
 
@@ -38,7 +38,7 @@ For more information, see [Cluster Version](https://troubleshoot.sh/docs/analyze
 
 ## Check Kubernetes distribution
 
-The examples below use the `distribution` analyzer to check the Kubernetes distribution of the cluster. The `distribution` analyzer uses data from the default `clusterInfo` collector. The `clusterInfo` collector is automatically included.
+The example below uses the `distribution` analyzer to check the Kubernetes distribution of the cluster. The `distribution` analyzer uses data from the default `clusterInfo` collector. The `clusterInfo` collector is automatically included.
 
 For more information, see [Cluster Info](https://troubleshoot.sh/docs/collect/cluster-info/) and [Distribution](https://troubleshoot.sh/docs/analyze/distribution/) in the Troubleshoot documentation.
 
@@ -50,7 +50,7 @@ For more information, see [Cluster Info](https://troubleshoot.sh/docs/collect/cl
 
 ## Check MySQL version using template functions
 
-The examples below use the `mysql` collector and the `mysql` analyzer to check the version of MySQL running in the cluster.
+The example below uses the `mysql` collector and the `mysql` analyzer to check the version of MySQL running in the cluster.
 
 For more information, see [Collect > MySQL](https://troubleshoot.sh/docs/collect/mysql/) and [Analyze > MySQL](https://troubleshoot.sh/docs/analyze/mysql/) in the Troubleshoot documentation.
 
@@ -62,7 +62,7 @@ For more information about using Helm template functions to access values from t
 
 ## Check node memory
 
-The examples below use the `nodeResources` analyzer to check that nodes in the cluster meet memory requirements. The `nodeResources` analyzer uses data from the default `clusterResources` collector. The `clusterResources` collector is automatically included.
+The example below uses the `nodeResources` analyzer to check that nodes in the cluster meet memory requirements. The `nodeResources` analyzer uses data from the default `clusterResources` collector. The `clusterResources` collector is automatically included.
 
 For more information, see [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) and [Node Resources](https://troubleshoot.sh/docs/analyze/node-resources/) in the Troubleshoot documentation.
 
@@ -74,7 +74,7 @@ For more information, see [Cluster Resources](https://troubleshoot.sh/docs/colle
 
 ## Check node storage class availability
 
-The examples below use the `storageClass` analyzer to check that a required storage class is available in the nodes in the cluster. The `storageClass` analyzer uses data from the default `clusterResources` collector. The `clusterResources` collector is automatically included.
+The example below uses the `storageClass` analyzer to check that a required storage class is available in the nodes in the cluster. The `storageClass` analyzer uses data from the default `clusterResources` collector. The `clusterResources` collector is automatically included.
 
 For more information, see [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) and [Node Resources](https://troubleshoot.sh/docs/analyze/node-resources/) in the Troubleshoot documentation.
 
@@ -86,7 +86,7 @@ For more information, see [Cluster Resources](https://troubleshoot.sh/docs/colle
 
 ## Check node ephemeral storage
 
-The examples below use the `nodeResources` analyzer to check the ephemeral storage available in the nodes in the cluster. The `nodeResources` analyzer uses data from the default `clusterResources` collector. The `clusterResources` collector is automatically included.
+The example below uses the `nodeResources` analyzer to check the ephemeral storage available in the nodes in the cluster. The `nodeResources` analyzer uses data from the default `clusterResources` collector. The `clusterResources` collector is automatically included.
 
 For more information, see [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) and [Node Resources](https://troubleshoot.sh/docs/analyze/node-resources/) in the Troubleshoot documentation.
 
@@ -98,7 +98,7 @@ For more information, see [Cluster Resources](https://troubleshoot.sh/docs/colle
 
 ## Check requirements are met by at least one node
 
-The examples below use the `nodeResources` analyzer with filters to check that the requirements for memory, CPU cores, and architecture are met by at least one node in the cluster. The `nodeResources` analyzer uses data from the default `clusterResources` collector. The `clusterResources` collector is automatically included.
+The example below uses the `nodeResources` analyzer with filters to check that the requirements for memory, CPU cores, and architecture are met by at least one node in the cluster. The `nodeResources` analyzer uses data from the default `clusterResources` collector. The `clusterResources` collector is automatically included.
 
 For more information, see [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) and [Node Resources](https://troubleshoot.sh/docs/analyze/node-resources/) in the Troubleshoot documentation.
 
@@ -110,7 +110,7 @@ For more information, see [Cluster Resources](https://troubleshoot.sh/docs/colle
 
 ## Check total cpu cores across nodes
 
-The examples below use the `nodeResources` analyzer to check total CPU cores across nodes in the cluster. The `nodeResources` analyzer uses data from the default `clusterResources` collector. The `clusterResources` collector is automatically included.
+The example below uses the `nodeResources` analyzer to check total CPU cores across nodes in the cluster. The `nodeResources` analyzer uses data from the default `clusterResources` collector. The `clusterResources` collector is automatically included.
 
 For more information, see [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) and [Node Resources](https://troubleshoot.sh/docs/analyze/node-resources/) in the Troubleshoot documentation.
 

--- a/docs/vendor/preflight-examples.mdx
+++ b/docs/vendor/preflight-examples.mdx
@@ -1,24 +1,12 @@
 import HttpSecret from "../partials/preflights/_http-requests-secret.mdx"
-import HttpCr from "../partials/preflights/_http-requests-cr.mdx"
 import MySqlSecret from "../partials/preflights/_mysql-secret.mdx"
-import MySqlCr from "../partials/preflights/_mysql-cr.mdx"
 import K8sVersionSecret from "../partials/preflights/_k8s-version-secret.mdx"
-import K8sVersionCr from "../partials/preflights/_k8s-version-cr.mdx"
 import K8sDistroSecret from "../partials/preflights/_k8s-distro-secret.mdx"
-import K8sDistroCr from "../partials/preflights/_k8s-distro-cr.mdx"
 import NodeReqSecret from "../partials/preflights/_node-req-secret.mdx"
-import NodeReqCr from "../partials/preflights/_node-req-cr.mdx"
-import NodeCountSecret from "../partials/preflights/_node-count-secret.mdx"
 import NodeMemSecret from "../partials/preflights/_node-mem-secret.mdx"
-import NodeMemCr from "../partials/preflights/_node-mem-cr.mdx"
 import NodeStorageClassSecret from "../partials/preflights/_node-storage-secret.mdx"
-import NodeStorageClassCr from "../partials/preflights/_node-storage-cr.mdx"
 import NodeEphemStorageSecret from "../partials/preflights/_node-ephem-storage-secret.mdx"
-import NodeEphemStorageCr from "../partials/preflights/_node-ephem-storage-cr.mdx"
 import NodeCpuSecret from "../partials/preflights/_node-cpu-secret.mdx"
-import NodeCpuCr from "../partials/preflights/_node-cpu-cr.mdx"
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Example preflight specs
 
@@ -30,17 +18,11 @@ The examples below use the `http` collector and the `textAnalyze` analyzer to ch
 
 For more information, see [HTTP](https://troubleshoot.sh/docs/collect/http/) and [Regular Expression](https://troubleshoot.sh/docs/analyze/regex/) in the Troubleshoot documentation.
 
-<Tabs>
-  <TabItem value="secret" label="Kubernetes Secret" default>
-    <HttpSecret/>
-  </TabItem>
-  <TabItem value="custom-resource" label="Preflight Custom Resource">
-    <HttpCr/>
-    <p>The following shows how the <code>pass</code> outcome for this preflight check is displayed in the Admin Console during KOTS installation or upgrade:</p>
-    <img alt="Preflight checks in Admin Console showing pass message" src="/images/preflight-http-pass.png"/>
-    <a href="/images/preflight-http-pass.png">View a larger version of this image</a>
-  </TabItem>
-</Tabs>
+<HttpSecret/>
+
+![Preflight checks in Admin Console showing pass message](/images/preflight-http-pass.png)
+
+[View a larger version of this image](/images/preflight-http-pass.png)
 
 ## Check Kubernetes version
 
@@ -48,17 +30,11 @@ The examples below use the `clusterVersion` analyzer to check the version of Kub
 
 For more information, see [Cluster Version](https://troubleshoot.sh/docs/analyze/cluster-version/) and [Cluster Info](https://troubleshoot.sh/docs/collect/cluster-info/) in the Troubleshoot documentation.
 
-<Tabs>
-  <TabItem value="secret" label="Kubernetes Secret" default>
-    <K8sVersionSecret/>
-  </TabItem>
-  <TabItem value="custom-resource" label="Preflight Custom Resource">
-    <K8sVersionCr/>
-    <p>The following shows how the <code>warn</code> outcome for this preflight check is displayed in the Admin Console during KOTS installation or upgrade:</p>
-    <img alt="Preflight checks in Admin Console showing warning message" src="/images/preflight-k8s-version-warn.png"/>
-    <a href="/images/preflight-k8s-version-warn.png">View a larger version of this image</a>
-  </TabItem>
-</Tabs>
+<K8sVersionSecret/>
+
+![Preflight checks in Admin Console showing warning message](/images/preflight-k8s-version-warn.png)
+
+[View a larger version of this image](/images/preflight-k8s-version-warn.png)
 
 ## Check Kubernetes distribution
 
@@ -66,17 +42,11 @@ The examples below use the `distribution` analyzer to check the Kubernetes distr
 
 For more information, see [Cluster Info](https://troubleshoot.sh/docs/collect/cluster-info/) and [Distribution](https://troubleshoot.sh/docs/analyze/distribution/) in the Troubleshoot documentation.
 
-<Tabs>
-  <TabItem value="secret" label="Kubernetes Secret" default>
-    <K8sDistroSecret/>
-  </TabItem>
-  <TabItem value="custom-resource" label="Preflight Custom Resource">
-    <K8sDistroCr/>
-    <p>The following shows how the <code>pass</code> outcome for this preflight check is displayed in the Admin Console during KOTS installation or upgrade:</p>
-    <img alt="Preflight checks in Admin Console showing pass message" src="/images/preflight-k8s-distro.png"/>
-    <a href="/images/preflight-k8s-distro.png">View a larger version of this image</a>
-  </TabItem>
-</Tabs>
+<K8sDistroSecret/>
+
+![Preflight checks in Admin Console showing pass message](/images/preflight-k8s-distro.png)
+
+[View a larger version of this image](/images/preflight-k8s-distro.png)
 
 ## Check MySQL version using template functions
 
@@ -84,39 +54,23 @@ The examples below use the `mysql` collector and the `mysql` analyzer to check t
 
 For more information, see [Collect > MySQL](https://troubleshoot.sh/docs/collect/mysql/) and [Analyze > MySQL](https://troubleshoot.sh/docs/analyze/mysql/) in the Troubleshoot documentation.
 
-<Tabs>
-  <TabItem value="secret" label="Kubernetes Secret" default>
-    <p>This example uses Helm template functions to render the credentials and connection details for the MySQL server that were supplied by the user. Additionally, it uses Helm template functions to create a conditional statement so that the MySQL collector and analyzer are included in the preflight checks only when MySQL is deployed, as indicated by a <code>.Values.global.mysql.enabled</code> field evaluating to true.</p>
-    <p>For more information about using Helm template functions to access values from the values file, see <a href="https://helm.sh/docs/chart_template_guide/values_files/">Values Files</a>.</p>
-    <MySqlSecret/>
-  </TabItem>
-  <TabItem value="custom-resource" label="Preflight Custom Resource">
-    <p>This example uses Replicated template functions in the Config context to render the credentials and connection details for the MySQL server that were supplied by the user in the Replicated Admin Console <strong>Config</strong> page. Replicated recommends using a template function for the URI, as shown above, to avoid exposing sensitive information. For more information about template functions, see <a href="/reference/template-functions-about">About Template Functions</a>.</p>
-    <p>This example also uses an analyzer with <code>strict: true</code>, which prevents installation from continuing if the preflight check fails.</p>
-    <MySqlCr/>
-    <p>The following shows how a <code>fail</code> outcome for this preflight check is displayed in the Admin Console during KOTS installation or upgrade when <code>strict: true</code> is set for the analyzer:</p>
-    <img alt="Strict preflight checks in Admin Console showing fail message" src="/images/preflight-mysql-fail-strict.png"/>
-    <a href="/images/preflight-mysql-fail-strict.png">View a larger version of this image</a>
-  </TabItem>
-</Tabs>
+This example uses Helm template functions to render the credentials and connection details for the MySQL server that were supplied by the user. Additionally, it uses Helm template functions to create a conditional statement so that the MySQL collector and analyzer are included in the preflight checks only when MySQL is deployed, as indicated by a `.Values.global.mysql.enabled` field evaluating to true.
+
+For more information about using Helm template functions to access values from the values file, see [Values Files](https://helm.sh/docs/chart_template_guide/values_files/).
+
+<MySqlSecret/>
 
 ## Check node memory
 
-The examples below use the `nodeResources` analyzer to check that a required storage class is available in the nodes in the cluster. The `nodeResources` analyzer uses data from the default `clusterResources` collector. The `clusterResources` collector is automatically included.
+The examples below use the `nodeResources` analyzer to check that nodes in the cluster meet memory requirements. The `nodeResources` analyzer uses data from the default `clusterResources` collector. The `clusterResources` collector is automatically included.
 
 For more information, see [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) and [Node Resources](https://troubleshoot.sh/docs/analyze/node-resources/) in the Troubleshoot documentation.
 
-<Tabs>
-  <TabItem value="secret" label="Kubernetes Secret" default>
-    <NodeMemSecret/>
-  </TabItem>
-  <TabItem value="custom-resource" label="Preflight Custom Resource">
-    <NodeMemCr/>
-    <p>The following shows how a <code>warn</code> outcome for this preflight check is displayed in the Admin Console during KOTS installation or upgrade:</p>
-    <img alt="Preflight checks in Admin Console showing warn message" src="/images/preflight-node-memory-warn.png"/>
-    <a href="/images/preflight-node-memory-warn.png">View a larger version of this image</a>
-  </TabItem>
-</Tabs>
+<NodeMemSecret/>
+
+![Preflight checks in Admin Console showing warn message](/images/preflight-node-memory-warn.png)
+
+[View a larger version of this image](/images/preflight-node-memory-warn.png)
 
 ## Check node storage class availability
 
@@ -124,17 +78,11 @@ The examples below use the `storageClass` analyzer to check that a required stor
 
 For more information, see [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) and [Node Resources](https://troubleshoot.sh/docs/analyze/node-resources/) in the Troubleshoot documentation.
 
-<Tabs>
-  <TabItem value="secret" label="Kubernetes Secret" default>
-    <NodeStorageClassSecret/>
-  </TabItem>
-  <TabItem value="custom-resource" label="Preflight Custom Resource">
-    <NodeStorageClassCr/>
-    <p>The following shows how a <code>fail</code> outcome for this preflight check is displayed in the Admin Console during KOTS installation or upgrade:</p>
-    <img alt="Preflight checks in Admin Console showing fail message" src="/images/preflight-storageclass-fail.png"/>
-    <a href="/images/preflight-storageclass-fail.png">View a larger version of this image</a>
-  </TabItem>
-</Tabs>
+<NodeStorageClassSecret/>
+
+![Preflight checks in Admin Console showing fail message](/images/preflight-storageclass-fail.png)
+
+[View a larger version of this image](/images/preflight-storageclass-fail.png)
 
 ## Check node ephemeral storage
 
@@ -142,17 +90,11 @@ The examples below use the `nodeResources` analyzer to check the ephemeral stora
 
 For more information, see [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) and [Node Resources](https://troubleshoot.sh/docs/analyze/node-resources/) in the Troubleshoot documentation.
 
-<Tabs>
-  <TabItem value="secret" label="Kubernetes Secret" default>
-    <NodeEphemStorageSecret/>
-  </TabItem>
-  <TabItem value="custom-resource" label="Preflight Custom Resource">
-    <NodeEphemStorageCr/>
-    <p>The following shows how a <code>pass</code> outcome for this preflight check is displayed in the Admin Console during KOTS installation or upgrade:</p>
-    <img alt="Preflight checks in Admin Console showing pass message" src="/images/preflight-ephemeral-storage-pass.png"/>
-    <a href="/images/preflight-ephemeral-storage-pass.png">View a larger version of this image</a>
-  </TabItem>
-</Tabs>
+<NodeEphemStorageSecret/>
+
+![Preflight checks in Admin Console showing pass message](/images/preflight-ephemeral-storage-pass.png)
+
+[View a larger version of this image](/images/preflight-ephemeral-storage-pass.png)
 
 ## Check requirements are met by at least one node
 
@@ -160,32 +102,20 @@ The examples below use the `nodeResources` analyzer with filters to check that t
 
 For more information, see [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) and [Node Resources](https://troubleshoot.sh/docs/analyze/node-resources/) in the Troubleshoot documentation.
 
-<Tabs>
-  <TabItem value="secret" label="Kubernetes Secret" default>
-    <NodeReqSecret/>
-  </TabItem>
-  <TabItem value="custom-resource" label="Preflight Custom Resource">
-    <NodeReqCr/>
-    <p>The following shows how the <code>fail</code> outcome for this preflight check is displayed in the Admin Console during KOTS installation or upgrade:</p>
-    <img alt="Preflight checks in Admin Console showing fail message" src="/images/preflight-node-filters-faill.png"/>
-    <a href="/images/preflight-node-filters-faill.png">View a larger version of this image</a>
-  </TabItem>
-</Tabs>
+<NodeReqSecret/>
+
+![Preflight checks in Admin Console showing fail message](/images/preflight-node-filters-faill.png)
+
+[View a larger version of this image](/images/preflight-node-filters-faill.png)
 
 ## Check total cpu cores across nodes
 
-The examples below use the `nodeResources` analyzer to check the version of Kubernetes running in the cluster. The `nodeResources` analyzer uses data from the default `clusterResources` collector. The `clusterResources` collector is automatically included.
+The examples below use the `nodeResources` analyzer to check total CPU cores across nodes in the cluster. The `nodeResources` analyzer uses data from the default `clusterResources` collector. The `clusterResources` collector is automatically included.
 
 For more information, see [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) and [Node Resources](https://troubleshoot.sh/docs/analyze/node-resources/) in the Troubleshoot documentation.
 
-<Tabs>
-  <TabItem value="secret" label="Kubernetes Secret" default>
-    <NodeCpuSecret/>
-  </TabItem>
-  <TabItem value="custom-resource" label="Preflight Custom Resource">
-    <NodeCpuCr/>
-    <p>The following shows how the <code>pass</code> outcome for this preflight check is displayed in the Admin Console during KOTS installation or upgrade:</p>
-    <img alt="Preflight checks in Admin Console showing fail message" src="/images/preflight-cpu-pass.png"/>
-    <a href="/images/preflight-cpu-pass.png">View a larger version of this image</a>
-  </TabItem>
-</Tabs>
+<NodeCpuSecret/>
+
+![Preflight checks in Admin Console showing pass message](/images/preflight-cpu-pass.png)
+
+[View a larger version of this image](/images/preflight-cpu-pass.png)

--- a/docs/vendor/support-bundle-customizing.mdx
+++ b/docs/vendor/support-bundle-customizing.mdx
@@ -90,6 +90,16 @@ To add collectors and analyzers:
     Good analyzers clearly identify failure modes and provide troubleshooting guidance for the user. For example, if you can identify a log message that indicates a problem in your database component, write an analyzer to check for that log. Include a description of the error for the user.
     :::
 
+1. Test the support bundle by following the instructions in [Generating a Support Bundle](/vendor/support-bundle-generating).
+
+1. From the root directory of your Helm chart, package the chart into a `.tgz` archive:
+
+   ```bash
+   helm package --dependency-update .
+   ```
+
+1. Add the chart archive to a new release. Promote the release to an internal development channel, and install the release in a development environment to test your changes.
+
 ### Customize the default `clusterResources` collector
 
 You can edit the default [`clusterResources`](https://troubleshoot.sh/docs/collect/cluster-resources/) using the following properties:
@@ -146,9 +156,9 @@ spec:
         exclude: true
 ```
 
-## Add a support bundle spec for non-Helm applications or installations with KOTS v1.94.1 and earlier
+## Add a support bundle spec for non-Helm applications or KOTS v1.94.1 and earlier
 
-For non-Helm applications or KOTS v1.94.1 and earlier, add the following SupportBundle custom resource at the root level of your release:
+For non-Helm applications or installations with KOTS v1.94.1 and earlier, add the SupportBundle custom resource to a YAML file at the root level of your release:
 
 ```yaml
 # support-bundle.yaml
@@ -160,4 +170,6 @@ metadata:
 spec:
   collectors: []
   analyzers: []
-```  
+```
+
+Customize the collectors and analyzers as desired.

--- a/docs/vendor/support-bundle-customizing.mdx
+++ b/docs/vendor/support-bundle-customizing.mdx
@@ -2,8 +2,6 @@
 
 This topic describes how to add a default support bundle spec to a release for your application. It also describes how to customize the default support bundle spec based on your application's needs. For more information about support bundles, see [About Preflight Checks and Support Bundles](/vendor/preflight-support-bundle-about).
 
-The information in this topic applies to Helm applications and Kubernetes manifest-based application installed with Helm or with Replicated KOTS.
-
 ## Add the default support bundle spec to a release
 
 When you add an empty support bundle spec to your Helm chart, the spec automatically includes the [clusterInfo](https://troubleshoot.sh/docs/collect/cluster-info/) and [clusterResources](https://troubleshoot.sh/docs/collect/cluster-resources/) collectors by default. You do not need manually include these collectors in the spec.
@@ -13,7 +11,7 @@ To add the default support bundle spec to a release for your application:
 1. In your Helm chart `templates` directory, create a YAML file. Name the file `support-bundle.yaml` or similar.
 
     :::note
-    If your application is deployed as multiple Helm charts, Replicated recommends that you create separate support bundle specs for each subchart. This allows you to make specs that are specific to different components of your application. When a support bundle is generated, all the specs are combined to provide a single bundle.
+    If you deploy your application as multiple Helm charts, Replicated recommends that you create separate support bundle specs for each subchart. This allows you to make specs that are specific to different components of your application. When Replicated generates a support bundle, it combines all the specs into a single bundle.
     :::
 
 1. In the YAML file, add the following to create a Kubernetes Secret with the default support bundle spec:
@@ -41,7 +39,7 @@ To add the default support bundle spec to a release for your application:
 
 1. (Recommended) Customize the default spec by adding more collectors and analyzers or editing the default collectors. See [Customize the default support bundle spec](#customize-the-spec) on this page.
 
-1. If your application is deployed as multiple subcharts, repeat the previous steps to add a support bundle spec to the templates directory of each chart.
+1. If you deploy your application as multiple subcharts, repeat the previous steps to add a support bundle spec to the templates directory of each chart.
 
 1. Test the support bundle by following the instructions in [Generating a Support Bundle](/vendor/support-bundle-generating).
 
@@ -89,14 +87,14 @@ To add collectors and analyzers:
     - [postgresql](https://troubleshoot.sh/docs/analyze/postgresql/), [mysql](https://troubleshoot.sh/docs/analyze/mysql/), and [redis](https://troubleshoot.sh/docs/analyze/redis/)
 
     :::note
-    Good analyzers clearly identify failure modes and provide troubleshooting guidance for the user. For example, if you can identify a log message from your database component that indicates a problem, you should write an analyzer that checks for that log and provides a description of the error to the user. 
+    Good analyzers clearly identify failure modes and provide troubleshooting guidance for the user. For example, if you can identify a log message that indicates a problem in your database component, write an analyzer to check for that log. Include a description of the error for the user.
     :::
 
 ### Customize the default `clusterResources` collector
 
 You can edit the default [`clusterResources`](https://troubleshoot.sh/docs/collect/cluster-resources/) using the following properties:
 
-* `namespaces`: The list of namespaces where the resources and information is collected. If the `namespaces` key is not specified, then the `clusterResources` collector defaults to collecting information from all namespaces. The `default` namespace cannot be removed, but you can specify additional namespaces.
+* `namespaces`: The list of namespaces from which to collect resources and information. If the `namespaces` key is not specified, then the `clusterResources` collector defaults to collecting information from all namespaces. You cannot remove the `default` namespace, but you can specify additional namespaces.
 
 * `ignoreRBAC`: When true, the `clusterResources` collector does not check for RBAC authorization before collecting resource information from each namespace. This is useful when your cluster uses authorization webhooks that do not support SelfSubjectRuleReviews. Defaults to false.
 
@@ -135,9 +133,9 @@ For more information, see [Namespace](/reference/template-functions-static-conte
 
 ### Exclude the default collectors
 
-Although Replicated recommends including the default `clusterInfo` and `clusterResources` collectors because they collect a large amount of data to help with installation and debugging, you can optionally exclude them. 
+Replicated recommends including the default `clusterInfo` and `clusterResources` collectors because they collect a large amount of data for installation and debugging. However, you can exclude them.
 
-The following example shows how to exclude both the clusterInfo and clusterResources collectors from your support bundle spec:
+The following example shows how to exclude both the `clusterInfo` and `clusterResources` collectors from your support bundle spec:
 
 ```yaml
 spec:
@@ -147,3 +145,19 @@ spec:
     - clusterResources:
         exclude: true
 ```
+
+## Add a support bundle spec for non-Helm applications or installations with KOTS v1.94.1 and earlier
+
+For non-Helm applications or KOTS v1.94.1 and earlier, add the following SupportBundle custom resource at the root level of your release:
+
+```yaml
+# support-bundle.yaml
+
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: example
+spec:
+  collectors: []
+  analyzers: []
+```  

--- a/docs/vendor/support-bundle-customizing.mdx
+++ b/docs/vendor/support-bundle-customizing.mdx
@@ -4,135 +4,101 @@ This topic describes how to add a default support bundle spec to a release for y
 
 The information in this topic applies to Helm applications and Kubernetes manifest-based application installed with Helm or with Replicated KOTS.
 
-## Step 1: Add the default spec to a manifest file
+## Add the default support bundle spec to a release
 
-You can add the support bundle spec to a Kubernetes Secret or a SupportBundle custom resource. The type of manifest file that you use depends on your application type (Helm or manifest-based) and installation method (Helm or KOTS).
+When you add an empty support bundle spec to your Helm chart, the spec automatically includes the [clusterInfo](https://troubleshoot.sh/docs/collect/cluster-info/) and [clusterResources](https://troubleshoot.sh/docs/collect/cluster-resources/) collectors by default. You do not need manually include these collectors in the spec.
 
-Use the following guidance to determine which type of manifest file to use for creating a support bundle spec:
+To add the default support bundle spec to a release for your application:
 
-* **Helm Applications**: For Helm applications, see the following guidance:
+1. In your Helm chart `templates` directory, create a YAML file. Name the file `support-bundle.yaml` or similar.
 
-   * **(Recommended) Helm or KOTS v1.94.2 and Later**: For Helm applications installed with Helm or KOTS v1.94.2 or later, create the support bundle spec in a Kubernetes Secret in your Helm chart `templates`. See [Kubernetes Secret](#secret).
+    :::note
+    If your application is deployed as multiple Helm charts, Replicated recommends that you create separate support bundle specs for each subchart. This allows you to make specs that are specific to different components of your application. When a support bundle is generated, all the specs are combined to provide a single bundle.
+    :::
 
-   * **KOTS v1.94.1 and Earlier**: For Helm applications installed with KOTS v1.94.1 or earlier, create the support bundle spec in a Preflight custom resource. See [SupportBundle Custom Resource](#sb-cr).
+1. In the YAML file, add the following to create a Kubernetes Secret with the default support bundle spec:
 
-* **Kubernetes Manifest-Based Applications**: For Kubernetes manifest-based applications, create the support bundle spec in a Preflight custom resource. See [SupportBundle Custom Resource](#sb-cr).
-
-### Kubernetes secret {#secret}
-
-You can define support bundle specs in a Kubernetes Secret for the following installation types:
-* Installations with Helm
-* Helm applications installed with KOTS v1.94.2 and later
-
-In your Helm chart `templates` directory, add the following YAML to a Kubernetes Secret:   
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  labels:
-    troubleshoot.sh/kind: support-bundle
-  name: example
-stringData:
-  support-bundle-spec: |
-    apiVersion: troubleshoot.sh/v1beta2
-    kind: SupportBundle
+    ```yaml
+    # templates/support-bundle.yaml
+    apiVersion: v1
+    kind: Secret
     metadata:
-      name: support-bundle
-    spec:
-      collectors: []
-      analyzers: []
-```
+      # troubleshoot.sh/kind: support-bundle label is required
+      labels:
+        troubleshoot.sh/kind: support-bundle
+      name: example
+    # add the spec in a support-bundle-spec key under stringData
+    stringData:
+      support-bundle-spec: |
+        apiVersion: troubleshoot.sh/v1beta2
+        kind: SupportBundle
+        metadata:
+          name: support-bundle
+        spec:
+          collectors: []
+          analyzers: []
+    ```
 
-As shown above, the Secret must include the following:
+1. (Recommended) Customize the default spec by adding more collectors and analyzers or editing the default collectors. See [Customize the default support bundle spec](#customize-the-spec) on this page.
 
-* The label `troubleshoot.sh/kind: support-bundle`
-* A `stringData` field with a key named `support-bundle-spec`  
+1. If your application is deployed as multiple subcharts, repeat the previous steps to add a support bundle spec to the templates directory of each chart.
 
-This empty support bundle spec includes the following collectors by default:
-* [clusterInfo](https://troubleshoot.sh/docs/collect/cluster-info/)
-* [clusterResources](https://troubleshoot.sh/docs/collect/cluster-resources/)
+1. Test the support bundle by following the instructions in [Generating a Support Bundle](/vendor/support-bundle-generating).
 
-You do not need manually include the `clusterInfo` or `clusterResources` collectors in the spec.
+1. From the root directory of your Helm chart, package the chart into a `.tgz` archive:
 
-:::note
-If your application is deployed as multiple Helm charts, Replicated recommends that you create separate support bundle specs for each subchart. This allows you to make specs that are specific to different components of your application. When a support bundle is generated, all the specs are combined to provide a single bundle.
-:::
+   ```bash
+   helm package --dependency-update .
+   ```
 
-After you create this empty support bundle spec, you can test the support bundle by following the instructions in [Generating a Support Bundle](/vendor/support-bundle-generating). You can customize the support bundle spec by adding collectors and analyzers or editing the default collectors. For more information, see [Step 2: Customize the spec](/vendor/support-bundle-customizing#customize-the-spec) below.
+1. Add the chart archive to a new release. Promote the release to an internal development channel, and install the release in a development environment to test your changes.
 
-### SupportBundle custom resource {#sb-cr}
+## (Recommended) Customize the default support bundle spec {#customize-the-spec}
 
-You can define support bundle specs in a SupportBundle custom resource for the following installation types:
-* Kubernetes manifest-based applications installed with KOTS
-* Helm applications installed with KOTS v1.94.1 and earlier
-
-In a release for your application, add the following YAML to a new `support-bundle.yaml` manifest file:
-
-```yaml
-apiVersion: troubleshoot.sh/v1beta2
-kind: SupportBundle
-metadata:
-  name: example
-spec:
-  collectors: []
-  analyzers: []
-```
-For more information about the SupportBundle custom resource, see [Preflight and Support Bundle](/reference/custom-resource-preflight).
-
-This empty support bundle spec includes the following collectors by default:
-* [clusterInfo](https://troubleshoot.sh/docs/collect/cluster-info/)
-* [clusterResources](https://troubleshoot.sh/docs/collect/cluster-resources/)
-
-You do not need manually include the `clusterInfo` or `clusterResources` collectors in the spec.
-
-After you create this empty support bundle spec, you can test the support bundle by following the instructions in [Generating a Support Bundle](/vendor/support-bundle-generating). You can customize the support bundle spec by adding collectors and analyzers or editing the default collectors. For more information, see [Step 2: Customize the spec](/vendor/support-bundle-customizing#customize-the-spec) below.
-
-## Step 2: Customize the spec {#customize-the-spec}
-
-You can customize the support bundles for your application by:
+You can customize the support bundle spec by:
 * Adding collectors and analyzers
 * Editing or excluding the default `clusterInfo` and `clusterResources` collectors
 
-### Add collectors
+### Add collectors and analyzers
 
-Collectors gather information from the cluster, the environment, the application, or other sources. Collectors generate output that is then used by the analyzers that you define.
+For common examples of collectors and analyzers used in support bundle specs, see [Examples of support bundle specs](/vendor/support-bundle-examples).
 
-In addition to the default `clusterInfo` and `clusterResources` collectors, the Troubleshoot open source project includes several collectors that you can include in the spec to gather more information from the installation environment. To view all the available collectors, see [All Collectors](https://troubleshoot.sh/docs/collect/all/) in the Troubleshoot documentation.
+To add collectors and analyzers:
 
-The following are some recommended collectors:
+1. In your Helm chart's templates directory, open the Kubernetes Secret that contains the support bundle spec.
 
-- [logs](https://troubleshoot.sh/docs/collect/logs/)
-- [secret](https://troubleshoot.sh/docs/collect/secret/) and [configMap](https://troubleshoot.sh/docs/collect/configmap/)
-- [postgresql](https://troubleshoot.sh/docs/collect/postgresql/), [mysql](https://troubleshoot.sh/docs/collect/mysql/), and [redis](https://troubleshoot.sh/docs/collect/redis/)
-- [runPod](https://troubleshoot.sh/docs/collect/run-pod/)
-- [copy](https://troubleshoot.sh/docs/collect/copy/) and [copyFromHost](https://troubleshoot.sh/docs/collect/copy-from-host/)
-- [http](https://troubleshoot.sh/docs/collect/http/)
+1. Update `spec.collectors` with additional collectors based on your application needs. For a list of all available collectors, see [All Collectors](https://troubleshoot.sh/docs/collect/all/) in the Troubleshoot documentation.
 
-### Add analyzers
+    The following are some recommended collectors:
 
-Analyzers use the data from the collectors to generate output for the support bundle. Good analyzers clearly identify failure modes and provide troubleshooting guidance for the user. For example, if you can identify a log message from your database component that indicates a problem, you should write an analyzer that checks for that log and provides a description of the error to the user.
+    - [logs](https://troubleshoot.sh/docs/collect/logs/)
+    - [secret](https://troubleshoot.sh/docs/collect/secret/) and [configMap](https://troubleshoot.sh/docs/collect/configmap/)
+    - [postgresql](https://troubleshoot.sh/docs/collect/postgresql/), [mysql](https://troubleshoot.sh/docs/collect/mysql/), and [redis](https://troubleshoot.sh/docs/collect/redis/)
+    - [runPod](https://troubleshoot.sh/docs/collect/run-pod/)
+    - [copy](https://troubleshoot.sh/docs/collect/copy/) and [copyFromHost](https://troubleshoot.sh/docs/collect/copy-from-host/)
+    - [http](https://troubleshoot.sh/docs/collect/http/)
 
-The Troubleshoot open source project includes several analyzers that you can include in the spec. To view all the available analyzers, see the [Analyze](https://troubleshoot.sh/docs/analyze/) section of the Troubleshoot documentation.
+1. Update `spec.analyzers` with additional analyzers based on your application needs. For the list of all available analyzers, see the [Analyze](https://troubleshoot.sh/docs/analyze/) section in the Troubleshoot documentation.
 
-The following are some recommended analyzers:
+    The following are some recommended analyzers:
+    - [textAnalyze](https://troubleshoot.sh/docs/analyze/regex/)
+    - [deploymentStatus](https://troubleshoot.sh/docs/analyze/deployment-status/)
+    - [clusterPodStatuses](https://troubleshoot.sh/docs/analyze/cluster-pod-statuses/)
+    - [replicasetStatus](https://troubleshoot.sh/docs/analyze/replicaset-status/)
+    - [statefulsetStatus](https://troubleshoot.sh/docs/analyze/statefulset-status/)
+    - [postgresql](https://troubleshoot.sh/docs/analyze/postgresql/), [mysql](https://troubleshoot.sh/docs/analyze/mysql/), and [redis](https://troubleshoot.sh/docs/analyze/redis/)
 
-- [textAnalyze](https://troubleshoot.sh/docs/analyze/regex/)
-- [deploymentStatus](https://troubleshoot.sh/docs/analyze/deployment-status/)
-- [clusterPodStatuses](https://troubleshoot.sh/docs/analyze/cluster-pod-statuses/)
-- [replicasetStatus](https://troubleshoot.sh/docs/analyze/replicaset-status/)
-- [statefulsetStatus](https://troubleshoot.sh/docs/analyze/statefulset-status/)
-- [postgresql](https://troubleshoot.sh/docs/analyze/postgresql/), [mysql](https://troubleshoot.sh/docs/analyze/mysql/), and [redis](https://troubleshoot.sh/docs/analyze/redis/)
+    :::note
+    Good analyzers clearly identify failure modes and provide troubleshooting guidance for the user. For example, if you can identify a log message from your database component that indicates a problem, you should write an analyzer that checks for that log and provides a description of the error to the user. 
+    :::
 
 ### Customize the default `clusterResources` collector
 
-You can edit the default `clusterResources` using the following properties:
+You can edit the default [`clusterResources`](https://troubleshoot.sh/docs/collect/cluster-resources/) using the following properties:
 
 * `namespaces`: The list of namespaces where the resources and information is collected. If the `namespaces` key is not specified, then the `clusterResources` collector defaults to collecting information from all namespaces. The `default` namespace cannot be removed, but you can specify additional namespaces.
 
-* `ignoreRBAC`: When true, the `clusterResources` collector does not check for RBAC authorization before collecting resource information from each namespace. This is useful when your cluster uses authorization webhooks that do not support SelfSubjectRuleReviews. Defaults to false. 
-
-For more information, see [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) in the Troubleshoot documentation.
+* `ignoreRBAC`: When true, the `clusterResources` collector does not check for RBAC authorization before collecting resource information from each namespace. This is useful when your cluster uses authorization webhooks that do not support SelfSubjectRuleReviews. Defaults to false.
 
 The following example shows how to specify the namespaces where the `clusterResources` collector collects information:
 
@@ -181,7 +147,3 @@ spec:
     - clusterResources:
         exclude: true
 ```
-
-### Examples
-
-For common examples of collectors and analyzers used in support bundle specs, see [Examples of Support Bundle Specs](/vendor/support-bundle-examples).

--- a/docs/vendor/support-bundle-examples.mdx
+++ b/docs/vendor/support-bundle-examples.mdx
@@ -10,7 +10,7 @@ import RunPodsSecret from "../partials/support-bundles/_run-pods-secret.mdx"
 
 # Example support bundle specs
 
-This topic includes common examples of support bundle specifications. For more examples, see the [Troubleshoot example repository](https://github.com/replicatedhq/troubleshoot/tree/main/examples/support-bundle) in GitHub.
+This topic includes example support bundle specifications. For more, see the [Troubleshoot example repository](https://github.com/replicatedhq/troubleshoot/tree/main/examples/support-bundle) in GitHub.
 
 ## Check application health
 
@@ -30,7 +30,7 @@ For more information, see [Deployment Status](https://troubleshoot.sh/docs/analy
 
 If your application has its own API that serves status, metrics, performance data, and so on, this information can be collected and analyzed.
 
-The examples below use the `http` collector and the `textAnalyze` analyzer to check that an HTTP request to the Slack API at `https://api.slack.com/methods/api.test` made from the cluster returns a successful response of `"status": 200,`.
+The example below uses the `http` collector and the `textAnalyze` analyzer to check that an HTTP request to the Slack API at `https://api.slack.com/methods/api.test` made from the cluster returns a successful response of `"status": 200,`.
 
 For more information, see [HTTP](https://troubleshoot.sh/docs/collect/http/) and [Regular Expression](https://troubleshoot.sh/docs/analyze/regex/) in the Troubleshoot documentation.
 
@@ -38,7 +38,7 @@ For more information, see [HTTP](https://troubleshoot.sh/docs/collect/http/) and
 
 ## Check Kubernetes version
 
-The examples below use the `clusterVersion` analyzer to check the version of Kubernetes running in the cluster. The `clusterVersion` analyzer uses data from the default `clusterInfo` collector.
+The example below uses the `clusterVersion` analyzer to check the version of Kubernetes running in the cluster. The `clusterVersion` analyzer uses data from the default `clusterInfo` collector.
 
 For more information, see [Cluster Version](https://troubleshoot.sh/docs/analyze/cluster-version/) and [Cluster Info](https://troubleshoot.sh/docs/collect/cluster-info/) in the Troubleshoot documentation.
 
@@ -46,7 +46,7 @@ For more information, see [Cluster Version](https://troubleshoot.sh/docs/analyze
 
 ## Check node resources
 
-The examples below use the `nodeResources` analyzer to check that the minimum requirements are met for memory, CPU cores, number of nodes, and ephemeral storage. The `nodeResources` analyzer uses data from the default `clusterResources` collector.
+The example below uses the `nodeResources` analyzer to check that the minimum requirements are met for memory, CPU cores, number of nodes, and ephemeral storage. The `nodeResources` analyzer uses data from the default `clusterResources` collector.
 
 For more information, see [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) and [Node Resources](https://troubleshoot.sh/docs/analyze/node-resources/) in the Troubleshoot documentation.
 
@@ -54,7 +54,7 @@ For more information, see [Cluster Resources](https://troubleshoot.sh/docs/colle
 
 ## Check node status
 
-The following examples use the `nodeResources` analyzers to check the status of the nodes in the cluster. The `nodeResources` analyzer uses data from the default `clusterResources` collector.
+The following example uses the `nodeResources` analyzer to check the status of the nodes in the cluster. The `nodeResources` analyzer uses data from the default `clusterResources` collector.
 
 For more information, see [Node Resources](https://troubleshoot.sh/docs/analyze/node-resources/) and [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) in the Troubleshoot documentation.
 
@@ -62,17 +62,17 @@ For more information, see [Node Resources](https://troubleshoot.sh/docs/analyze/
 
 ## Collect logs using multiple selectors
 
-The examples below use the `logs` collector to collect logs from various Pods where application workloads are running. They also use the `textAnalyze` collector to analyze the logs for a known error.
+The example below uses the `logs` collector to collect logs from various Pods where application workloads are running. It also uses the `textAnalyze` collector to analyze the logs for a known error.
 
 For more information, see [Pod Logs](https://troubleshoot.sh/docs/collect/logs/) and [Regular Expression](https://troubleshoot.sh/docs/analyze/regex/) in the Troubleshoot documentation.
 
-You can use the `selector` attribute of the `logs` collector to find Pods that have the specified labels. Depending on the complexity of an application's labeling schema, you might need a few different declarations of the logs collector, as shown in the examples below. You can include the `logs` collector as many times as needed.
+You can use the `selector` attribute of the `logs` collector to find Pods that have the specified labels. Depending on the complexity of an application's labeling schema, you might need a few different declarations of the logs collector, as shown in this example. You can include the `logs` collector as many times as needed.
 
 <LogsSelectorsSecret/>
 
 ## Collect logs using `limits`
 
-The examples below use the `logs` collector to collect Pod logs from the Pod where the application is running. These specifications use the `limits` field to set a `maxAge` and `maxLines` to limit the output provided.
+The example below uses the `logs` collector to collect Pod logs from the Pod where the application is running. This specification uses the `limits` field to set a `maxAge` and `maxLines` to limit the output provided.
 
 For more information, see [Pod Logs](https://troubleshoot.sh/docs/collect/logs/) in the Troubleshoot documentation.
 
@@ -80,7 +80,7 @@ For more information, see [Pod Logs](https://troubleshoot.sh/docs/collect/logs/)
 
 ## Collect Redis and MySQL server information
 
-The following examples use the `redis` and `mysql` collectors to collect information about Redis and MySQL servers running in the cluster.
+The following example uses the `redis` and `mysql` collectors to collect information about Redis and MySQL servers running in the cluster.
 
 For more information, see [Redis](https://troubleshoot.sh/docs/collect/redis/) and [MySQL](https://troubleshoot.sh/docs/collect/mysql/) in the Troubleshoot documentation.
 
@@ -88,7 +88,7 @@ For more information, see [Redis](https://troubleshoot.sh/docs/collect/redis/) a
 
 ## Run and analyze a pod
 
-The examples below use the `textAnalyze` analyzer to check that a command successfully executes in a Pod running in the cluster. The Pod specification is defined in the `runPod` collector.
+The example below uses the `textAnalyze` analyzer to check that a command successfully executes in a Pod running in the cluster. The Pod specification is defined in the `runPod` collector.
 
 For more information, see [Run Pods](https://troubleshoot.sh/docs/collect/run-pod/) and [Regular Expression](https://troubleshoot.sh/docs/analyze/regex/) in the Troubleshoot documentation.
 

--- a/docs/vendor/support-bundle-examples.mdx
+++ b/docs/vendor/support-bundle-examples.mdx
@@ -1,23 +1,12 @@
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import HttpSecret from "../partials/support-bundles/_http-requests-secret.mdx"
-import HttpCr from "../partials/support-bundles/_http-requests-cr.mdx"
 import NodeStatusSecret from "../partials/support-bundles/_node-status-secret.mdx"
-import NodeStatusCr from "../partials/support-bundles/_node-status-cr.mdx"
 import K8sVersionSecret from "../partials/support-bundles/_k8s-version-secret.mdx"
-import K8sVersionCr from "../partials/support-bundles/_k8s-version-cr.mdx"
 import DeployStatusSecret from "../partials/support-bundles/_deploy-status-secret.mdx"
-import DeployStatusCr from "../partials/support-bundles/_deploy-status-cr.mdx"
 import NodeResourcesSecret from "../partials/support-bundles/_node-resources-secret.mdx"
-import NodeResourcesCr from "../partials/support-bundles/_node-resources-cr.mdx"
 import LogsSelectorsSecret from "../partials/support-bundles/_logs-selectors-secret.mdx"
-import LogsSelectorsCr from "../partials/support-bundles/_logs-selectors-cr.mdx"
 import LogsLimitsSecret from "../partials/support-bundles/_logs-limits-secret.mdx"
-import LogsLimitsCr from "../partials/support-bundles/_logs-limits-cr.mdx"
 import RedisMysqlSecret from "../partials/support-bundles/_redis-mysql-secret.mdx"
-import RedisMysqlCr from "../partials/support-bundles/_redis-mysql-cr.mdx"
 import RunPodsSecret from "../partials/support-bundles/_run-pods-secret.mdx"
-import RunPodsCr from "../partials/support-bundles/_run-pods-cr.mdx"
 
 # Example support bundle specs
 
@@ -35,14 +24,7 @@ Replicated recommends using the `deploymentStatus` analyzer to check application
 
 For more information, see [Deployment Status](https://troubleshoot.sh/docs/analyze/deployment-status/) and [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) in the Troubleshoot documentation.
 
-<Tabs>
-  <TabItem value="secret" label="Kubernetes Secret" default>
-    <DeployStatusSecret/>
-  </TabItem>
-  <TabItem value="custom-resource" label="SupportBundle Custom Resource">
-    <DeployStatusCr/>
-  </TabItem>
-</Tabs>
+<DeployStatusSecret/>
 
 ## Check HTTP requests
 
@@ -52,14 +34,7 @@ The examples below use the `http` collector and the `textAnalyze` analyzer to ch
 
 For more information, see [HTTP](https://troubleshoot.sh/docs/collect/http/) and [Regular Expression](https://troubleshoot.sh/docs/analyze/regex/) in the Troubleshoot documentation.
 
-<Tabs>
-  <TabItem value="secret" label="Kubernetes Secret" default>
-    <HttpSecret/>
-  </TabItem>
-  <TabItem value="custom-resource" label="SupportBundle Custom Resource">
-    <HttpCr/>
-  </TabItem>
-</Tabs>
+<HttpSecret/>
 
 ## Check Kubernetes version
 
@@ -67,14 +42,7 @@ The examples below use the `clusterVersion` analyzer to check the version of Kub
 
 For more information, see [Cluster Version](https://troubleshoot.sh/docs/analyze/cluster-version/) and [Cluster Info](https://troubleshoot.sh/docs/collect/cluster-info/) in the Troubleshoot documentation.
 
-<Tabs>
-  <TabItem value="secret" label="Kubernetes Secret" default>
-    <K8sVersionSecret/>
-  </TabItem>
-  <TabItem value="custom-resource" label="SupportBundle Custom Resource">
-    <K8sVersionCr/>
-  </TabItem>
-</Tabs> 
+<K8sVersionSecret/>
 
 ## Check node resources
 
@@ -82,14 +50,7 @@ The examples below use the `nodeResources` analyzer to check that the minimum re
 
 For more information, see [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) and [Node Resources](https://troubleshoot.sh/docs/analyze/node-resources/) in the Troubleshoot documentation.
 
-<Tabs>
-  <TabItem value="secret" label="Kubernetes Secret" default>
-    <NodeResourcesSecret/>
-  </TabItem>
-  <TabItem value="custom-resource" label="SupportBundle Custom Resource">
-    <NodeResourcesCr/>
-  </TabItem>
-</Tabs> 
+<NodeResourcesSecret/>
 
 ## Check node status
 
@@ -97,14 +58,7 @@ The following examples use the `nodeResources` analyzers to check the status of 
 
 For more information, see [Node Resources](https://troubleshoot.sh/docs/analyze/node-resources/) and [Cluster Resources](https://troubleshoot.sh/docs/collect/cluster-resources/) in the Troubleshoot documentation.
 
-<Tabs>
-  <TabItem value="secret" label="Kubernetes Secret" default>
-    <NodeStatusSecret/>
-  </TabItem>
-  <TabItem value="custom-resource" label="SupportBundle Custom Resource">
-    <NodeStatusCr/>
-  </TabItem>
-</Tabs> 
+<NodeStatusSecret/>
 
 ## Collect logs using multiple selectors
 
@@ -114,44 +68,23 @@ For more information, see [Pod Logs](https://troubleshoot.sh/docs/collect/logs/)
 
 You can use the `selector` attribute of the `logs` collector to find Pods that have the specified labels. Depending on the complexity of an application's labeling schema, you might need a few different declarations of the logs collector, as shown in the examples below. You can include the `logs` collector as many times as needed.
 
-<Tabs>
-  <TabItem value="secret" label="Kubernetes Secret" default>
-    <LogsSelectorsSecret/>
-  </TabItem>
-  <TabItem value="custom-resource" label="SupportBundle Custom Resource">
-    <LogsSelectorsCr/>
-  </TabItem>
-</Tabs> 
+<LogsSelectorsSecret/>
 
 ## Collect logs using `limits`
 
-The examples below use the `logs` collector to collect Pod logs from the Pod where the application is running. These specifications use the `limits` field to set a `maxAge` and `maxLines` to limit the output provided. 
+The examples below use the `logs` collector to collect Pod logs from the Pod where the application is running. These specifications use the `limits` field to set a `maxAge` and `maxLines` to limit the output provided.
 
 For more information, see [Pod Logs](https://troubleshoot.sh/docs/collect/logs/) in the Troubleshoot documentation.
 
-<Tabs>
-  <TabItem value="secret" label="Kubernetes Secret" default>
-    <LogsLimitsSecret/>
-  </TabItem>
-  <TabItem value="custom-resource" label="SupportBundle Custom Resource">
-    <LogsLimitsCr/>
-  </TabItem>
-</Tabs> 
+<LogsLimitsSecret/>
 
 ## Collect Redis and MySQL server information
 
 The following examples use the `redis` and `mysql` collectors to collect information about Redis and MySQL servers running in the cluster.
 
-For more information, see [Redis](https://troubleshoot.sh/docs/collect/redis/) and [MySQL](https://troubleshoot.sh/docs/collect/mysql/) and in the Troubleshoot documentation.
+For more information, see [Redis](https://troubleshoot.sh/docs/collect/redis/) and [MySQL](https://troubleshoot.sh/docs/collect/mysql/) in the Troubleshoot documentation.
 
-<Tabs>
-  <TabItem value="secret" label="Kubernetes Secret" default>
-    <RedisMysqlSecret/>
-  </TabItem>
-  <TabItem value="custom-resource" label="SupportBundle Custom Resource">
-    <RedisMysqlCr/>
-  </TabItem>
-</Tabs>
+<RedisMysqlSecret/>
 
 ## Run and analyze a pod
 
@@ -159,11 +92,4 @@ The examples below use the `textAnalyze` analyzer to check that a command succes
 
 For more information, see [Run Pods](https://troubleshoot.sh/docs/collect/run-pod/) and [Regular Expression](https://troubleshoot.sh/docs/analyze/regex/) in the Troubleshoot documentation.
 
-<Tabs>
-  <TabItem value="secret" label="Kubernetes Secret" default>
-    <RunPodsSecret/>
-  </TabItem>
-  <TabItem value="custom-resource" label="SupportBundle Custom Resource">
-    <RunPodsCr/>
-  </TabItem>
-</Tabs>
+<RunPodsSecret/>

--- a/styles/config/vocabularies/TechJargon/accept.txt
+++ b/styles/config/vocabularies/TechJargon/accept.txt
@@ -94,3 +94,7 @@ ttl
 keyless
 liveness
 Unmute
+
+subchart
+subcharts
+namespaces


### PR DESCRIPTION
Preflights: https://deploy-preview-4027--replicated-docs.netlify.app/vendor/preflight-defining

Support bundles: https://deploy-preview-4027--replicated-docs.netlify.app/vendor/support-bundle-customizing

Also updated the examples for both to only show examples that use a secret (and remove all the custom resource examples):
* https://deploy-preview-4027--replicated-docs.netlify.app/vendor/preflight-examples
* https://deploy-preview-4027--replicated-docs.netlify.app/vendor/support-bundle-examples