### PR TITLE
docs: add instance archive and bulk archive documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 
 # Algolia Search
 .env
+
+# Git worktrees
+.worktrees

--- a/docs/vendor/customer-reporting.md
+++ b/docs/vendor/customer-reporting.md
@@ -91,50 +91,22 @@ For more information about the Enterprise Portal, see [About the Enterprise Port
 
 ### Instances
 
-The **Instances** section displays details about the active application instances associated with the customer.
+The **Instances** section displays details about the active application instances associated with the customer. You can also enable the **Show archived instances** and **Show inactive instances** checkboxes to view archived and inactive instances.
 
-You can click any of the rows in the **Instances** section to open the **Instance details** page. The **Instance details** page displays additional event data and computed metrics to help you understand the performance and status of each active application instance. For more information, see [Instance Details](instance-insights-details).
+From the **Instances** section, you can:
+* Click any of the instances to open its **Instance details** page. For more information, see [Instance Details](instance-insights-details).
+* Bulk archive instances. For more information, see [Bulk archive instances](/vendor/releases-creating-customers#bulk-archive-instances) in _Create and manage customers_.
+* View instances details, including:
+  * The first seven characters of the instance ID
+  * The instance's status. See [Enabling and Understanding Application Status](insights-app-status).
+  * The application version
+  * Details about the cluster where the instance is installed
+  * Instance uptime data. For more information, see [Instance Uptime](instance-insights-details#instance-uptime) in _Instance Details_.
 
 The following shows an example of a row for an active instance in the **Instances** section:
 
 ![Row in the Instances section](/images/instance-row.png)
 [View a larger version of this image](/images/instance-row.png)
-
-The **Instances** section displays the following details about each active instance:
-* The first seven characters of the instance ID.
-* The status of the instance. Possible statuses are Missing, Unavailable, Degraded, Ready, and Updating. For more information, see [Enabling and Understanding Application Status](insights-app-status).
-* The application version.
-* Details about the cluster where the instance is installed, including:
-   * The Kubernetes distribution for the cluster, if applicable.
-   * The Kubernetes version running in the cluster.
-   * Whether the instance is installed in a Replicated kURL cluster.
-   * (kURL Clusters Only) The number of nodes ready in the cluster.
-   * (KOTS Only) The KOTS version running in the cluster.
-   * The Replicated SDK version running in the cluster.
-   * The cloud provider and region, if applicable.
- * Instance uptime data, including:
-    * The timestamp of the last recorded check-in for the instance. For more information about what triggers an instance check-in, see [How the Vendor Portal Collects Instance Data](instance-insights-event-data#about-reporting) in _About Instance and Event Data_.
-    * An uptime graph of the previous two weeks. For more information about how the Vendor Portal determines uptime, see [Instance Uptime](instance-insights-details#instance-uptime) in _Instance Details_.
-    * The uptime ratio in the previous two weeks.
-
-#### Show archived instances
-
-Archived instances are hidden from the **Instances** section by default. To include archived instances in the list, enable the **Show Archived Instances** toggle on the **Customers > Instances** tab.
-
-For more information about archiving and unarchiving individual instances, see [Archive and Unarchive Instances](instance-insights-details#archive-and-unarchive-instances) in _Instance Details_.
-
-#### Bulk archive instances
-
-You can archive multiple instances at once from the **Customers > Instances** tab.
-
-To bulk archive instances:
-
-1. On the **Customers > Instances** tab, click the archive icon in the table toolbar to enable bulk selection mode.
-1. Select the instances that you want to archive by using the checkboxes in each row.
-1. Click **Archive instances**.
-1. In the confirmation dialog, click **Archive**.
-
-The Vendor Portal archives all eligible instances and skips any instances that do not meet the archiving criteria (for example, active production instances). A summary shows how many instances were archived and lists any skipped instances with the reason they were skipped. You can archive up to 100 instances in a single bulk operation.
 
 ### Install attempts (Beta)
 

--- a/docs/vendor/customer-reporting.md
+++ b/docs/vendor/customer-reporting.md
@@ -112,10 +112,29 @@ The **Instances** section displays the following details about each active insta
    * (KOTS Only) The KOTS version running in the cluster.
    * The Replicated SDK version running in the cluster.
    * The cloud provider and region, if applicable.
-* Instance uptime data, including:
-   * The timestamp of the last recorded check-in for the instance. For more information about what triggers an instance check-in, see [How the Vendor Portal Collects Instance Data](instance-insights-event-data#about-reporting) in _About Instance and Event Data_.
-   * An uptime graph of the previous two weeks. For more information about how the Vendor Portal determines uptime, see [Instance Uptime](instance-insights-details#instance-uptime) in _Instance Details_.
-   * The uptime ratio in the previous two weeks.
+ * Instance uptime data, including:
+    * The timestamp of the last recorded check-in for the instance. For more information about what triggers an instance check-in, see [How the Vendor Portal Collects Instance Data](instance-insights-event-data#about-reporting) in _About Instance and Event Data_.
+    * An uptime graph of the previous two weeks. For more information about how the Vendor Portal determines uptime, see [Instance Uptime](instance-insights-details#instance-uptime) in _Instance Details_.
+    * The uptime ratio in the previous two weeks.
+
+#### Show archived instances
+
+Archived instances are hidden from the **Instances** section by default. To include archived instances in the list, enable the **Show Archived Instances** toggle on the **Customers > Instances** tab.
+
+For more information about archiving and unarchiving individual instances, see [Archive and Unarchive Instances](instance-insights-details#archive-and-unarchive-instances) in _Instance Details_.
+
+#### Bulk archive instances
+
+You can archive multiple instances at once from the **Customers > Instances** tab.
+
+To bulk archive instances:
+
+1. On the **Customers > Instances** tab, click the archive icon in the table toolbar to enable bulk selection mode.
+1. Select the instances that you want to archive by using the checkboxes in each row.
+1. Click **Archive instances**.
+1. In the confirmation dialog, click **Archive**.
+
+The Vendor Portal archives all eligible instances and skips any instances that do not meet the archiving criteria (for example, active production instances). A summary shows how many instances were archived and lists any skipped instances with the reason they were skipped. You can archive up to 100 instances in a single bulk operation.
 
 ### Install attempts (Beta)
 

--- a/docs/vendor/instance-insights-details.md
+++ b/docs/vendor/instance-insights-details.md
@@ -1,24 +1,12 @@
 # Instance details
 
 This topic describes using the Replicated Vendor Portal to quickly understand the recent events and performance of application instances installed in your customers' environments.
+
 ## About the instance details page {#about-page}
 
-The Vendor Portal provides insights about the health, status, and performance of the active application instances associated with each customer license on the **Instance details** page. You can use the insights on the **Instance details** page to more quickly troubleshoot issues with your customers' active instances, helping to reduce support burden. 
+The Vendor Portal provides insights about the health, status, and performance of the active application instances associated with each customer license on the **Instance details** page. You can use these insights to more quickly troubleshoot issues with your customers' active instances, helping to reduce support burden.
 
-For example, you can use the **Instance details** page to track the following events for each instance:
-
-* Recent performance degradation or downtime
-* Length of instance downtime
-* Recent changes to the cluster or infrastructure
-* Changes in the number of nodes, such as nodes lost or added
-* Changes in the cluster's Kubernetes version
-* Changes in the application version that the instance is running
-
-To access the **Instance details** page, go to **Customers** and click the **Customer reporting** button for the customer that you want to view:
-
-![Customer reporting button on the Customers page](/images/customer-reporting-button.png)
-
-From the **Reporting** page for the selected customer, click the **View details** button for the desired application instance.
+From the **Instance details** page, you can also archive and unarchive instances. For more information, see [Archive or unarchive an instance](/vendor/releases-creating-customer#archive-instance) in _Create and manage customers_.
 
 The following shows an example of the **Instance details** page:
 
@@ -371,17 +359,3 @@ For more information about configuring custom metrics, see [Configure Custom Met
     </td>
   </tr>
 </table>
-
-## Archive and unarchive instances
-
-You can archive application instances that are inactive, air gap, or installed with a development license. Archiving an instance hides it from all views in the Vendor Portal. You can unarchive an instance at any time to restore it to the active instances list.
-
-To archive or unarchive an instance:
-
-1. From the **Instance details** page for the target instance, click **Archive instance** or **Unarchive instance**.
-
-1. In the confirmation dialog, click **Archive** or **Unarchive**.
-
-:::note
-The **Archive instance** button is visible on the **Instance details** page for all instances, but the backend enforces the eligibility criteria. If the instance is active, online, and installed with a production or trial license, the archive request returns an error.
-:::

--- a/docs/vendor/instance-insights-details.md
+++ b/docs/vendor/instance-insights-details.md
@@ -371,3 +371,17 @@ For more information about configuring custom metrics, see [Configure Custom Met
     </td>
   </tr>
 </table>
+
+## Archive and unarchive instances
+
+You can archive application instances that are inactive, air gap, or installed with a development license. Archiving an instance hides it from all views in the Vendor Portal. You can unarchive an instance at any time to restore it to the active instances list.
+
+To archive or unarchive an instance:
+
+1. From the **Instance details** page for the target instance, click **Archive instance** or **Unarchive instance**.
+
+1. In the confirmation dialog, click **Archive** or **Unarchive**.
+
+:::note
+The **Archive instance** button is visible on the **Instance details** page for all instances, but the backend enforces the eligibility criteria. If the instance is active, online, and installed with a production or trial license, the archive request returns an error.
+:::

--- a/docs/vendor/releases-creating-customer.mdx
+++ b/docs/vendor/releases-creating-customer.mdx
@@ -92,9 +92,9 @@ To edit a locked field:
 
 ## Archive a customer
 
-When you archive a customer in the Vendor Portal, the customer is hidden from search by default and becomes read-only. Archival does not affect the utility of license files downloaded before the customer was archived.
+When you archive a customer in the Vendor Portal, the customer is hidden from search by default and becomes read-only.
 
-To expire a license, set an expiration date and policy in the **Expiration policy** field before you archive the customer.
+Archiving a customer does not change the functionality or utility of licenses downloaded before the customer was archived. To expire a license, set an expiration date and policy in the **Expiration policy** field before you archive the customer.
 
 To archive a customer:
 
@@ -104,26 +104,64 @@ To archive a customer:
 
 You can unarchive by clicking **Unarchive Customer** in the customer's **Manage customer** page.
 
+## Manage customer instances
+
+### Archive or unarchive an instance {#archive-instance}
+
+You can archive application instances that are inactive, air gap, or installed with a Development license. Archiving an instance hides it from all views in the Vendor Portal. You can unarchive an instance at any time to restore it to the active instances list.
+
+To archive or unarchive an instance:
+
+1. From the **Instance details** page for the target instance, click **Archive instance** or **Unarchive instance**.
+   
+   :::note
+   The **Archive instance** button is visible on the **Instance details** page for all instances, but if the instance is active, online, and installed with a production or trial license, the archive request returns an error.
+   :::
+
+1. In the confirmation dialog, click **Archive** or **Unarchive**.
+
+### Bulk archive instances
+
+You can archive up to 100 instances in a single bulk operation.
+
+When you bulk archive, the Vendor Portal archives all eligible instances and skips any instances that do not meet the archiving criteria (for example, active production instances).
+
+To bulk archive instances:
+
+1. On the **Customers > Instances** tab, click the archive icon in the table toolbar to enable bulk selection mode.
+1. Select the instances that you want to archive by using the checkboxes in each row.
+1. Click **Archive instances**.
+1. In the confirmation dialog, click **Archive**.
+
+   A summary shows how many instances were archived and lists any skipped instances with the reason they were skipped.
+
+## Search customers
+
+You can search your customers using filters in the Vendor Portal. If you want to filter using multiple license types or channels, you can download a CSV file instead. For more information, see [Export customer and instance data](#export) on this page.
+
+To filter and search your list of customers:
+
+* On the **Customers** page, use the search box and filters to find customer records. For example, you can filter by active or inactive customer records, license type, release channel, and more.
+
+   To filter customers by custom ID or email, use the search box and prepend your search term with "customId:" (ex: `customId:1234`) or "email:" (ex: `email:bob@replicated.com`).
+
+   <img alt="search box and filters on the customers page" src="/images/customers-filter.png" width="400px"/>
+
+   [View a larger version of this image](/images/customers-filter.png)
+
+## View archived and inactive instances
+
+By default, the Vendor Portal hides archived and inactive instances from each customer's **Instances** list.
+
+To view archived and inactive instances:
+
+* Go to the **Customers** page, select the customer, and go to the **Reporting** tab. Scroll to the **Instances** section and enable the **Show archived instances** or **Show inactive instances** checkboxes.
+
 ## Export customer and instance data {#export}
 
 <Download/>
 
-For more information about the data fields in the CSV downloads, see [Data Dictionary](/vendor/instance-data-export#data-dictionary) in _Export Customers and Instance Data_.
-## Filter and search customers
-
-The **Customers** page provides a search box and filters that help you find customers:
-
-<img alt="search box and filters on the customers page" src="/images/customers-filter.png" width="400px"/>
-
-[View a larger version of this image](/images/customers-filter.png)
-
-You can filter customers based on whether they are active, by license type, and by channel name. You can filter using more than one criteria, such as Active, Paid, and Stable. However, you can select only one license type and one channel at a time.
-
-If there is adoption rate data available for the channel that you are filtering by, you can also filter by current version, previous version, and older versions.
-
-You can also filter customers by custom ID or email address. To filter customers by custom ID or email, use the search box and prepend your search term with "customId:" (ex: `customId:1234`) or "email:" (ex: `email:bob@replicated.com`).
-
-If you want to filter information using multiple license types or channels, you can download a CSV file instead. For more information, see [Export Customer and Instance Data](#export) above.
+For more information about the data fields in the CSV downloads, see [Data Dictionary](/vendor/instance-data-export#data-dictionary) in _Export customer and instance data_.
 
 ## Replace a license in an existing installation
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the instance archive feature, which was previously only mentioned in release notes.

### Changes

**`docs/vendor/instance-insights-details.md`**: Added \"Archive and unarchive instances\" section covering:
- How to archive/unarchive from the Instance details page
- Backend-enforced eligibility criteria (inactive, air gap, or development license)
- Note that the archive button is visible for all instances but the backend validates eligibility

**`docs/vendor/customer-reporting.md`**: Added under the Instances section:
- \"Show archived instances\": How to use the toggle on Customers > Instances
- \"Bulk archive instances\": How to use the toolbar archive icon, select instances, and confirm in the modal. Notes that ineligible instances are skipped with reasons shown, and max 100 per batch.