### PR TITLE
Cross-reference SBOM and SDK SLSA validation pages

### DIFF
--- a/docs/enterprise/sbom-validating.md
+++ b/docs/enterprise/sbom-validating.md
@@ -8,9 +8,7 @@ A _software bill of materials_ (SBOM) is an inventory of all components used to 
 
 When you install software, validating an SBOM signature can help you understand exactly what the software package is installing. This information can help you ensure that the files are compatible with your licensing policies and help determine whether there is exposure to CVEs.
 
-:::note
 For information about validating the Replicated SDK, including SLSA provenance, image signatures, and SBOM attestations, see [Validate provenance of releases for the Replicated SDK](/vendor/replicated-sdk-slsa-validating).
-:::
 
 ## Prerequisite
 

--- a/docs/enterprise/sbom-validating.md
+++ b/docs/enterprise/sbom-validating.md
@@ -8,6 +8,10 @@ A _software bill of materials_ (SBOM) is an inventory of all components used to 
 
 When you install software, validating an SBOM signature can help you understand exactly what the software package is installing. This information can help you ensure that the files are compatible with your licensing policies and help determine whether there is exposure to CVEs.
 
+:::note
+For information about validating the Replicated SDK, including SLSA provenance, image signatures, and SBOM attestations, see [Validate provenance of releases for the Replicated SDK](/vendor/replicated-sdk-slsa-validating).
+:::
+
 ## Prerequisite
 
 Before you perform these tasks, you must install cosign. For more information, see the [sigstore repository](https://github.com/sigstore/cosign) in GitHub.

--- a/docs/vendor/replicated-sdk-slsa-validating.md
+++ b/docs/vendor/replicated-sdk-slsa-validating.md
@@ -152,3 +152,5 @@ The script performs the following checks:
    - Validates that the SecureBuild keyless identity signed the SPDX SBOM attestation
 
 For more information about the SDK release process, see [Manage releases with the Vendor Portal](/vendor/releases-creating-releases).
+
+For information about validating SBOM signatures for other Replicated components such as KOTS, kURL, and Troubleshoot, see [Validate SBOM signatures](/enterprise/sbom-validating).


### PR DESCRIPTION
Preview
https://deploy-preview-4060--replicated-docs.netlify.app/enterprise/sbom-validating
https://deploy-preview-4060--replicated-docs.netlify.app/vendor/replicated-sdk-slsa-validating

## Summary
- Adds a note on the SBOM validation page directing readers to the SDK's SLSA/SBOM validation page, since the SDK is a notable omission from that page
- Adds a backlink from the SDK SLSA validation page to the SBOM page for KOTS, kURL, and Troubleshoot

## Test plan
- [ ] Verify the `:::note` admonition renders correctly on the SBOM page
- [ ] Verify both cross-reference links resolve to the correct pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)