### PR TITLE
docs: document Delivery section on customer Reporting page

### DIFF
--- a/docs/vendor/customer-reporting.md
+++ b/docs/vendor/customer-reporting.md
@@ -86,6 +86,7 @@ From the **Enterprise Portal** section, you can:
 * View the number of install attempts made by the customer. The **Customer Reporting > Install Attempts** section includes additional details about install attempts. For more information, see [Install Attempts](#install-attempts-beta) below.
 * View the number of service accounts created in the Enterprise Portal
 * View the number of support bundles uploaded to the Enterprise Portal
+* View **Delivery** information, including when the customer first accessed the Enterprise Portal and the timestamps of their first and most recent software pulls. Click the **Delivery** row to expand it for additional detail.
 
 For more information about the Enterprise Portal, see [About the Enterprise Portal](/vendor/enterprise-portal-about).
 

--- a/docs/vendor/customer-reporting.md
+++ b/docs/vendor/customer-reporting.md
@@ -86,7 +86,7 @@ From the **Enterprise Portal** section, you can:
 * View the number of install attempts made by the customer. The **Customer Reporting > Install Attempts** section includes additional details about install attempts. For more information, see [Install Attempts](#install-attempts-beta) below.
 * View the number of service accounts created in the Enterprise Portal
 * View the number of support bundles uploaded to the Enterprise Portal
-* View **Delivery** information, including when the customer first accessed the Enterprise Portal and the timestamps of their first and most recent software pulls. Click the **Delivery** row to expand it for additional detail.
+* Open the **Delivery** row to see when the customer first accessed the Enterprise Portal and the timestamps of their first and most recent software pulls
 
 For more information about the Enterprise Portal, see [About the Enterprise Portal](/vendor/enterprise-portal-about).
 


### PR DESCRIPTION
Adds a one-line bullet to the Enterprise Portal section of the Customer Reporting page documenting the new Delivery section that surfaces access and software-pull timestamps. Matches the depth of neighboring bullets.

For [sc-137694](https://app.shortcut.com/replicated/story/137694/surface-delivery-data-in-enterprise-portal-card-on-customer-detail-page).
related: https://github.com/replicatedhq/vandoor/pull/9769 (see screenshots). Note this may require image updates on this page.