### PR TITLE
Add cgroups v2 requirement for Kubernetes 1.35+ in Embedded Cluster v2/v3

### DIFF
--- a/docs/partials/embedded-cluster/v2/_requirements.mdx
+++ b/docs/partials/embedded-cluster/v2/_requirements.mdx
@@ -1,5 +1,7 @@
 * Linux operating system
 
+* cgroups v2 (required for Kubernetes versions 1.35 and later)
+
 * x86-64 architecture
 
 * systemd

--- a/docs/partials/embedded-cluster/v3/_requirements.mdx
+++ b/docs/partials/embedded-cluster/v3/_requirements.mdx
@@ -1,5 +1,7 @@
 * Linux operating system
 
+* cgroups v2 (required for Kubernetes versions 1.35 and later)
+
 * x86-64 architecture
 
 * systemd


### PR DESCRIPTION
Adds a note that cgroups v2 is required when using Kubernetes versions 1.35 and later, for both Embedded Cluster v2 and v3 system requirements.