### PR TITLE
Update kURL support for Kubernetes 1.35

### DIFF
--- a/docs/vendor/policies-support-lifecycle.md
+++ b/docs/vendor/policies-support-lifecycle.md
@@ -129,4 +129,4 @@ Replicated support for end-customer installations is limited to those installs u
 
 The information contained herein is believed to be accurate as of the date of publication, but updates and revisions may be posted periodically and without notice.
 
-Last modified 2026 April 20.
+Last modified 2026 May 19.

--- a/docs/vendor/policies-support-lifecycle.md
+++ b/docs/vendor/policies-support-lifecycle.md
@@ -98,7 +98,7 @@ The End of Replicated Support date is the End Of Life (EOL) date for the Kuberne
     <td>1.35</td>
     <td>NA</td>
     <td>1.129.4 and later</td>
-    <td>NA</td>
+    <td>v2026.05.18-0 and later</td>
     <td>2027 February 28</td>
   </tr>
   <tr>

--- a/docs/vendor/policies-support-lifecycle.md
+++ b/docs/vendor/policies-support-lifecycle.md
@@ -95,6 +95,13 @@ The End of Replicated Support date is the End Of Life (EOL) date for the Kuberne
     <th>End of Replicated Support</th>
   </tr>
   <tr>
+    <td>1.36</td>
+    <td>NA</td>
+    <td>NA</td>
+    <td>NA</td>
+    <td>2027 June 28</td>
+  </tr>
+  <tr>
     <td>1.35</td>
     <td>NA</td>
     <td>1.129.4 and later</td>


### PR DESCRIPTION
## Summary
- Adds kURL `v2026.05.18-0` as the minimum supported version for Kubernetes 1.35 in the support lifecycle table (previously listed as NA)

## Test plan
- [ ] Verify the support lifecycle table renders correctly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)