### PR TITLE
Document V3 Embedded Cluster external API and headless joins

### DIFF
--- a/docs/release-notes/rn-embedded-cluster-v3.md
+++ b/docs/release-notes/rn-embedded-cluster-v3.md
@@ -31,8 +31,8 @@ Additionally, these release notes list the versions of Kubernetes that are avail
 
 ### New features {#new-features-3-1-0-beta-1}
 
-* Adds support for vendor-defined custom node roles. Roles are declared in the EC config under `spec.roles` with associated labels, and one or more roles can be assigned to a node at install or join time.
-* Adds an external HTTP API on port 30081 (configurable with `--api-port`) for headless installs, programmatic node joins, and cluster-state polling.
+* Adds support for vendor-defined custom node roles. Roles are declared in the EC config with associated labels, and one or more roles can be assigned to a node at install or join time. See [roles](/embedded-cluster/v3/embedded-config#roles) in _Embedded Cluster Config_.
+* Adds an external HTTP API on port 30081 (configurable with `--api-port`) for headless installs, programmatic node joins, and cluster-state polling. See [External API](/embedded-cluster/v3/embedded-cluster-external-api).
 * Adds Bring Your Own (BYO) registry support during install.
 * Allows joining new nodes to the cluster during an upgrade.
 * Adds nftables support for Linux kernel 6.17+.

--- a/docs/release-notes/rn-embedded-cluster-v3.md
+++ b/docs/release-notes/rn-embedded-cluster-v3.md
@@ -12,6 +12,41 @@ Additionally, these release notes list the versions of Kubernetes that are avail
 
 <!--RELEASE_NOTES_PLACEHOLDER-->
 
+## 3.1.0-beta.1
+
+<table>
+  <tr>
+    <th>Version</th>
+    <td id="center">3.1.0-beta.1+k8s-1.34</td>
+    <td id="center">3.1.0-beta.1+k8s-1.33</td>
+    <td id="center">3.1.0-beta.1+k8s-1.32</td>
+  </tr>
+  <tr>
+    <th>Kubernetes Version</th>
+    <td id="center">1.34.4</td>
+    <td id="center">1.33.8</td>
+    <td id="center">1.32.12</td>
+  </tr>
+</table>
+
+### New features {#new-features-3-1-0-beta-1}
+
+* Adds support for vendor-defined custom node roles. Roles are declared in the EC config under `spec.roles` with associated labels, and one or more roles can be assigned to a node at install or join time.
+* Adds an external HTTP API on port 30081 (configurable with `--api-port`) for headless installs, programmatic node joins, and cluster-state polling.
+* Adds Bring Your Own (BYO) registry support during install.
+* Allows joining new nodes to the cluster during an upgrade.
+* Adds nftables support for Linux kernel 6.17+.
+
+### Improvements {#improvements-3-1-0-beta-1}
+
+* Unifies runtime suppression of when-gated and readonly config items.
+* Applies templating to status informers.
+
+### Bug fixes {#bug-fixes-3-1-0-beta-1}
+
+* Adds detection of orphaned containerd tmpmounts to upgrade preflights.
+* Verifies the installer UI port is free before prompting on install or upgrade.
+
 ## 3.0.0-beta.4
 
 <table>

--- a/embedded-cluster/embedded-cluster-create-join-bundle.mdx
+++ b/embedded-cluster/embedded-cluster-create-join-bundle.mdx
@@ -1,6 +1,6 @@
 # create-join-bundle (Beta)
 
-This topic describes the options available with the Embedded Cluster `create-join-bundle` command. Use this command to produce a bundle that nodes can use to join the cluster with a given role.
+This topic describes the options available with the Embedded Cluster `create-join-bundle` command. Use this command to produce a bundle that nodes can use to join the cluster with one or more roles.
 
 ## Usage
 
@@ -19,12 +19,12 @@ sudo ./<app-slug> create-join-bundle [flags]
   <tr>
     <td>`--output`</td>
     <td>string</td>
-    <td>Output path for the bundle. **Default:** A path of the form `./cli-join-ROLE-TIMESTAMP.tar.gz` (the CLI fills in the role and timestamp).</td>
+    <td>Output path for the bundle. **Default:** A path of the form `./cli-join-ROLE-TIMESTAMP.tar.gz` (the CLI fills in the first role name and timestamp).</td>
   </tr>
   <tr>
-    <td>`--role`</td>
-    <td>string</td>
-    <td>Node role: `controller` or `worker`. **Required.**</td>
+    <td>`--roles`</td>
+    <td>strings</td>
+    <td>One or more role names to assign to the joining node, comma-separated (for example, `--roles app` or `--roles app,db`). Valid role names are the default controller role and any custom roles declared in the Embedded Cluster Config under [`roles`](embedded-config#roles). **Required.**</td>
   </tr>
   <tr>
     <td>`--ttl`</td>

--- a/embedded-cluster/embedded-cluster-external-api.mdx
+++ b/embedded-cluster/embedded-cluster-external-api.mdx
@@ -1,0 +1,201 @@
+# External API (Beta)
+
+Embedded Cluster exposes a small, stable HTTP API on every controller node for cross-node automation. This API is intended for headless installs, programmatic node joins, and external orchestration.
+
+## Overview
+
+* The API listens on the controller's internal IP on TCP port **30081** by default. Override at install with `--api-port`.
+* All traffic is TLS-encrypted. The certificate is generated at install and is served by the daemon.
+* All non-health endpoints require a JWT bearer token obtained from `POST /v1/auth/token`.
+* The API is reachable from any host in the cluster network — not from outside the cluster unless you explicitly expose it.
+
+The full Embedded Cluster API (used by the local web UI) is served on a Unix socket and is not exposed on the network. Only the endpoints documented below are reachable on port 30081.
+
+## Authentication
+
+Obtain a token using the installer password:
+
+```bash
+curl -X POST https://<controller-ip>:30081/v1/auth/token \
+  -H 'Content-Type: application/json' \
+  -d '{"password":"<installer-password>"}'
+```
+
+Response:
+
+```json
+{ "token": "eyJhbGciOi..." }
+```
+
+The token is a JWT valid for 24 hours. Pass it as `Authorization: Bearer <token>` on subsequent requests.
+
+## Endpoints
+
+### `GET /v1/health`
+
+Liveness probe. No authentication required.
+
+```bash
+curl https://<controller-ip>:30081/v1/health
+```
+
+Response:
+
+```json
+{ "status": "ok" }
+```
+
+### `GET /v1/version`
+
+Returns the running daemon version. No authentication required.
+
+```bash
+curl https://<controller-ip>:30081/v1/version
+```
+
+Response:
+
+```json
+{
+  "version":   "3.0.0",
+  "commit":    "abcdef0",
+  "buildDate": "2026-01-15_12:00:00"
+}
+```
+
+### `POST /v1/auth/token`
+
+See [Authentication](#authentication).
+
+### `GET /v1/nodes`
+
+Returns the list of nodes in the cluster.
+
+Request:
+
+```bash
+curl https://<controller-ip>:30081/v1/nodes \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Response:
+
+```json
+{
+  "nodes": [
+    {
+      "name": "controller-0",
+      "labels": {
+        "node-role.kubernetes.io/control-plane": "",
+        "kots.io/embedded-cluster-role-0": "controller"
+      },
+      "annotations": { ... },
+      "roles": ["controller"],
+      "internalIP": "10.0.0.11",
+      "ready": true
+    }
+  ]
+}
+```
+
+Field reference:
+
+| Field | Description |
+|-------|-------------|
+| `name` | Kubernetes node name. |
+| `labels` | All labels on the node. |
+| `annotations` | All annotations on the node. |
+| `roles` | The vendor-defined role names assigned at join time (from the EC config `spec.roles`). |
+| `internalIP` | The node's internal IP address. |
+| `ready` | `true` when the node's `Ready` condition is `True`. |
+
+Automation should poll this endpoint to verify the cluster is ready to issue join commands. After the k0s install completes, the controller takes a short time to report `Ready` in the cluster. Calls to `POST /v1/create-join-command` fail until at least one controller has `ready: true`, so automation should poll `GET /v1/nodes` first and only request join commands once a `Ready` controller is present.
+
+### `POST /v1/create-join-command`
+
+Returns the shell commands a remote host must run to join the cluster: download a join bundle, extract it, and run `node join`. The download command embeds a short-lived bearer token (1 hour TTL).
+
+Request:
+
+```bash
+curl -X POST https://<controller-ip>:30081/v1/create-join-command \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"roles":["controller"]}'
+```
+
+The `roles` array must contain one or more role names defined in the application's EC config (`spec.roles.controller.name` and `spec.roles.custom[].name`). Multiple roles can be assigned to the same node; the joined node will carry the union of each role's labels.
+
+Response:
+
+```json
+{
+  "joinSteps": [
+    {
+      "description": "Download the join bundle",
+      "command": "curl -H \"Authorization: Bearer ...\" https://10.0.0.11:30081/v1/join-bundle?roles=controller -o APP_SLUG-join-controller-20260115-120000.tar.gz"
+    },
+    {
+      "description": "Extract the bundle",
+      "command": "tar xzf APP_SLUG-join-controller-20260115-120000.tar.gz"
+    },
+    {
+      "description": "Run the join command",
+      "command": "sudo ./APP_SLUG node join"
+    }
+  ]
+}
+```
+
+### `GET /v1/join-bundle?roles=<role1,role2,...>`
+
+Streams a gzip tarball containing everything a new node needs to join the cluster: binaries, EC bundle, license, signed cluster seed, and a k0s join token. The `roles` query parameter accepts a comma-separated list of role names.
+
+```bash
+curl https://<controller-ip>:30081/v1/join-bundle?roles=controller \
+  -H "Authorization: Bearer $TOKEN" \
+  -o APP_SLUG-join-controller.tar.gz
+```
+
+Typically you do not call this endpoint directly — the curl command returned by `POST /v1/create-join-command` calls it for you with a short-lived, audience-scoped token.
+
+The request requires a multi-node-enabled license.
+
+## Headless and automated node joins
+
+This is the recommended flow for joining a node without going through the web UI:
+
+1. On the joining host, fetch a JWT token from a controller:
+
+   ```bash
+   TOKEN=$(curl -X POST https://<controller-ip>:30081/v1/auth/token \
+     -H 'Content-Type: application/json' \
+     -d '{"password":"<installer-password>"}' | jq -r .token)
+   ```
+
+2. Poll [`GET /v1/nodes`](#get-v1nodes) until the controller reports `ready: true`. This is the signal that the cluster is ready to issue join commands:
+
+   ```bash
+   until curl -s https://<controller-ip>:30081/v1/nodes \
+     -H "Authorization: Bearer $TOKEN" \
+     | jq -e '.nodes | map(select(.ready)) | length > 0' >/dev/null; do
+     sleep 5
+   done
+   ```
+
+3. Request the join commands. Pass the desired role names as defined in your EC config:
+
+   ```bash
+   RESPONSE=$(curl -X POST https://<controller-ip>:30081/v1/create-join-command \
+     -H "Authorization: Bearer $TOKEN" \
+     -H 'Content-Type: application/json' \
+     -d '{"roles":["controller"]}')
+   ```
+
+4. Execute each step in the returned `joinSteps` array. The simplest approach evaluates them in order in the same shell:
+
+   ```bash
+   echo "$RESPONSE" | jq -r '.joinSteps[].command' | while IFS= read -r cmd; do
+     eval "$cmd"
+   done
+   ```

--- a/embedded-cluster/embedded-cluster-external-api.mdx
+++ b/embedded-cluster/embedded-cluster-external-api.mdx
@@ -161,41 +161,7 @@ Typically you do not call this endpoint directly — the curl command returned b
 
 The request requires a multi-node-enabled license.
 
-## Headless and automated node joins
+## See also
 
-This is the recommended flow for joining a node without going through the web UI:
-
-1. On the joining host, fetch a JWT token from a controller:
-
-   ```bash
-   TOKEN=$(curl -X POST https://<controller-ip>:30081/v1/auth/token \
-     -H 'Content-Type: application/json' \
-     -d '{"password":"<installer-password>"}' | jq -r .token)
-   ```
-
-2. Poll [`GET /v1/nodes`](#get-v1nodes) until the controller reports `ready: true`. This is the signal that the cluster is ready to issue join commands:
-
-   ```bash
-   until curl -s https://<controller-ip>:30081/v1/nodes \
-     -H "Authorization: Bearer $TOKEN" \
-     | jq -e '.nodes | map(select(.ready)) | length > 0' >/dev/null; do
-     sleep 5
-   done
-   ```
-
-3. Request the join commands. Pass the desired role names as defined in your EC config:
-
-   ```bash
-   RESPONSE=$(curl -X POST https://<controller-ip>:30081/v1/create-join-command \
-     -H "Authorization: Bearer $TOKEN" \
-     -H 'Content-Type: application/json' \
-     -d '{"roles":["controller"]}')
-   ```
-
-4. Execute each step in the returned `joinSteps` array. The simplest approach evaluates them in order in the same shell:
-
-   ```bash
-   echo "$RESPONSE" | jq -r '.joinSteps[].command' | while IFS= read -r cmd; do
-     eval "$cmd"
-   done
-   ```
+* [Headless joins](embedded-manage-nodes#headless-joins) in _Access and manage embedded clusters_ — end-to-end walkthrough that composes these endpoints to join a node without the web UI.
+* [roles](embedded-config#roles) in _Embedded Cluster Config_ — declare the role names used in `POST /v1/create-join-command` and `GET /v1/join-bundle`.

--- a/embedded-cluster/embedded-cluster-external-api.mdx
+++ b/embedded-cluster/embedded-cluster-external-api.mdx
@@ -5,7 +5,7 @@ Embedded Cluster exposes a small, stable HTTP API on every controller node for c
 ## Overview
 
 * The API listens on the controller's internal IP on TCP port **30081** by default. Override at install with `--api-port`.
-* All traffic is TLS-encrypted. The certificate is generated at install and is served by the daemon.
+* All traffic is TLS-encrypted using the certificates configured at install time and is served by the daemon.
 * All non-health endpoints require a JWT bearer token obtained from `POST /v1/auth/token`.
 * The API is reachable from any host in the cluster network — not from outside the cluster unless you explicitly expose it.
 

--- a/embedded-cluster/embedded-config.mdx
+++ b/embedded-cluster/embedded-config.mdx
@@ -84,6 +84,68 @@ Replicated recommends that you update the version frequently to ensure that you 
 
 <DoNotDowngrade/>
 
+## roles (Beta) {#roles}
+
+You can customize node roles in the Embedded Cluster Config using the `roles` key.
+
+A common use case for customizing node roles is to assign workloads to specific nodes. For example, if your application has graphics processing unit (GPU) workloads, you could declare a custom role that applies a `gpu=true` label to any node assigned that role. You can then schedule GPU workloads on nodes labeled `gpu=true`.
+
+When the `roles` key is configured, users select one or more roles to assign to a node when it is installed or joined to the cluster. For more information about assigning roles when joining a node, see [Join nodes](embedded-manage-nodes#add-nodes) in _Access and manage embedded clusters_.
+
+If the `roles` key is _not_ configured, all nodes joined to the cluster are assigned the default `controller` role. The `controller` role designates nodes that run the Kubernetes control plane. Controller nodes can also run other workloads, such as application or KOTS workloads.
+
+### Example
+
+```yaml
+apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: Config
+spec:
+  roles:
+    controller:
+      # Optionally change the display name for the default controller role
+      name: app
+      labels:
+        app: "true" # Label applied to nodes assigned the controller role
+    # Custom roles
+    custom:
+      - name: db
+        labels:
+          db: "true" # Label applied to "db" nodes
+      - name: gpu
+        labels:
+          gpu: "true" # Label applied to "gpu" nodes
+```
+
+### Limitations
+
+* Defining node roles with the `roles` key is Beta.
+
+* The first node added to the cluster must include the controller role. It may additionally be assigned any custom roles.
+
+* A node's role assignment cannot be changed after the node is joined to the cluster. To change a node's roles, reset the node and add it again with the new role selection.
+
+### roles.controller
+
+In the `roles.controller` key, you can customize the default controller role:
+
+* `name`: Sets the display name for the controller role. By default, the controller role is named `controller`.
+
+   :::note
+   If you plan to declare any custom roles, Replicated recommends that you change the default name for the controller role to a term that is easy to understand (such as `app`). When custom roles are present, both the controller role name and any custom role names are displayed to the user when they install or join a node.
+   :::
+
+* `labels`: Kubernetes labels that Embedded Cluster applies to every node assigned the controller role.
+
+### roles.custom
+
+In the `roles.custom` key, you can declare additional roles. Each custom role includes the following fields:
+
+* `name`: (Required) The name of the custom role.
+
+* `labels`: Kubernetes labels that Embedded Cluster applies to every node assigned the role.
+
+Multiple roles may be assigned to the same node — the joined node carries the union of each role's labels. If two roles define the same label key, the role that appears later in the user's selection wins.
+
 ## domains
 
 Configure the `domains` key so that Embedded Cluster uses your custom domains for the Replicated proxy registry and Replicated app service.

--- a/embedded-cluster/embedded-config.mdx
+++ b/embedded-cluster/embedded-config.mdx
@@ -92,7 +92,7 @@ A common use case for customizing node roles is to assign workloads to specific 
 
 When the `roles` key is configured, users select one or more roles to assign to a node when it is installed or joined to the cluster. For more information about assigning roles when joining a node, see [Join nodes](embedded-manage-nodes#add-nodes) in _Access and manage embedded clusters_.
 
-If the `roles` key is _not_ configured, all nodes joined to the cluster are assigned the default `controller` role. The `controller` role designates nodes that run the Kubernetes control plane. Controller nodes can also run other workloads, such as application or KOTS workloads.
+If the `roles` key is _not_ configured, all nodes joined to the cluster are assigned the default `controller` role. The `controller` role designates nodes that run the Kubernetes control plane. Controller nodes can also run other workloads, such as application workloads.
 
 ### Example
 

--- a/embedded-cluster/embedded-manage-nodes.mdx
+++ b/embedded-cluster/embedded-manage-nodes.mdx
@@ -59,6 +59,47 @@ To join a node:
 
 1. Repeat these steps for each node you want to add.
 
+### Headless joins {#headless-joins}
+
+For automation and orchestrated deployments, you can join nodes without going through the web UI by calling the Embedded Cluster [external API](embedded-cluster-external-api) from any host in the cluster network. The flow is:
+
+1. Fetch a JWT token from a controller using the installer password:
+
+   ```bash
+   TOKEN=$(curl -X POST https://<controller-ip>:30081/v1/auth/token \
+     -H 'Content-Type: application/json' \
+     -d '{"password":"<installer-password>"}' | jq -r .token)
+   ```
+
+2. Poll [`GET /v1/nodes`](embedded-cluster-external-api#get-v1nodes) until at least one controller reports `ready: true`. This is the signal that the cluster is ready to issue join commands:
+
+   ```bash
+   until curl -s https://<controller-ip>:30081/v1/nodes \
+     -H "Authorization: Bearer $TOKEN" \
+     | jq -e '.nodes | any(.ready)' >/dev/null; do
+     sleep 5
+   done
+   ```
+
+3. Request the join commands. Pass the desired role names from the [`roles`](embedded-config#roles) key in the Embedded Cluster Config:
+
+   ```bash
+   RESPONSE=$(curl -X POST https://<controller-ip>:30081/v1/create-join-command \
+     -H "Authorization: Bearer $TOKEN" \
+     -H 'Content-Type: application/json' \
+     -d '{"roles":["controller"]}')
+   ```
+
+4. Execute each command in the returned `joinSteps` array on the joining node:
+
+   ```bash
+   echo "$RESPONSE" | jq -r '.joinSteps[].command' | while IFS= read -r cmd; do
+     eval "$cmd"
+   done
+   ```
+
+For the full set of endpoints and response schemas, see [External API](embedded-cluster-external-api).
+
 ## High availability for multi-node clusters {#ha}
 
 Embedded Cluster automatically enables high availability (HA) when at least three `controller` nodes are present in the cluster.

--- a/embedded-cluster/embedded-manage-nodes.mdx
+++ b/embedded-cluster/embedded-manage-nodes.mdx
@@ -22,7 +22,7 @@ Multi-node clusters with Embedded Cluster have the following limitations:
 
 * You should not join more than one controller node at the same time. When joining a controller node, Embedded Cluster prints a warning explaining that you should not attempt to join another node until the controller node joins successfully.
 
-* You cannot change a node's role (`controller` or `worker`) after you join the node. If you need to change a node’s role, reset the node and add it again with the new role.
+* You cannot change a node's role assignment after you join the node. To change a node's roles, reset the node and add it again with the new role selection. For more information about customizing node roles, see [roles](embedded-config#roles) in _Embedded Cluster Config_.
 
 ### Requirement
 
@@ -37,14 +37,14 @@ To join a node:
 1. Run the following command to generate the `.tar.gz` bundle for joining a node:
 
    ```bash
-   sudo ./APP_SLUG create-join-bundle --role [controller | worker]
+   sudo ./APP_SLUG create-join-bundle --roles ROLE[,ROLE...]
    ```
    Where:
    * `APP_SLUG` is the unique slug for the application.
-   * `--role` is the role to assign the node (`controller` or `worker`).
-     
+   * `--roles` is one or more role names to assign the node, comma-separated. Valid role names are the default controller role and any custom roles declared in the Embedded Cluster Config under [roles](embedded-config#roles).
+
      :::note
-     You cannot change the role after you add a node. If you need to change a node’s role, reset the node and add it again with the new role.
+     You cannot change role assignments after a node is joined. To change them, reset the node and add it again with the new role selection.
      :::
 
 1. Use `scp` to copy the `.tar.gz` bundle to the node that you want to join.

--- a/sidebarEmbeddedCluster.js
+++ b/sidebarEmbeddedCluster.js
@@ -19,6 +19,7 @@ module.exports = {
     //REFERENCE DOCS
     { type: "html", value: "<h5>Reference</h5>", defaultStyle: true },
     "embedded-config",
+    "embedded-cluster-external-api",
     "template-functions",
     {
       type: "category",


### PR DESCRIPTION
## Summary

- Adds a new reference page **External API (Beta)** at `embedded-cluster/embedded-cluster-external-api.mdx` covering the cross-node HTTP API exposed on port `30081` (configurable via `--api-port`).
- Documents every reachable endpoint with a curl example and JSON response: `/v1/health`, `/v1/version`, `/v1/auth/token`, `/v1/nodes`, `/v1/create-join-command`, `/v1/join-bundle`.
- Walks through the headless / automated node-join flow, gated on `GET /v1/nodes` controller-readiness polling.
- Registers the page under the Reference section in `sidebarEmbeddedCluster.js`.

Written against the post-custom-roles API shape (replicatedhq/ec#446) — `roles` array, `kots.io/embedded-cluster-role-N` labels, role catalog driven by `spec.roles` in the EC config.

## Test plan

- [x] Build docs locally (`npm start`) and verify the new page renders in the Embedded Cluster sidebar under Reference.
- [x] Click the sidebar entry and confirm links to `embedded-cluster-create-join-bundle`, `embedded-manage-nodes`, and `embedded-config` resolve.
- [x] Visual check that code blocks and tables render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)