### PR TITLE
Clarify version removal behavior in EP v2 versioned docs

### DIFF
--- a/docs/vendor/enterprise-portal-v2-versioned-docs.mdx
+++ b/docs/vendor/enterprise-portal-v2-versioned-docs.mdx
@@ -92,7 +92,9 @@ When a customer switches versions via the dropdown, the portal swaps the version
 
 ## Removing versions
 
-To unpublish a version from the dropdown, delete the branch. The version disappears after the next sync.
+To remove a version's dedicated content branch, delete the branch from your git repo. The branch disappears from the Content tab after the next sync.
+
+However, if a release with that version label still exists on a customer's channel, the version still appears in the customer's version dropdown. The portal resolves it using the version resolution chain (nearest lower semver branch, then `main` as fallback). To fully remove a version from the customer's dropdown, the release must also be removed from the channel.
 
 ## Overrides
 


### PR DESCRIPTION
## Summary

- Clarifies that deleting a content branch removes the branch from the Content tab but does not remove the version from the customer's dropdown if the release still exists on their channel
- Explains that the version resolution chain (nearest lower branch, then main fallback) handles versions with no exact branch match
- Motivated by ITRS feedback (issue #359, item 3) where a vendor expected deleting a branch would remove the version entirely

## Test plan

- [ ] Verify Docusaurus build passes
- [ ] Review wording for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)