### PR TITLE
Add multi-team access and shared credentials docs to Enterprise Portal

### DIFF
--- a/docs/vendor/enterprise-portal-use.mdx
+++ b/docs/vendor/enterprise-portal-use.mdx
@@ -64,6 +64,12 @@ The first time that you attempt to log in with SAML using your SSO credentials, 
 * IdP-initiated SAML login attempts always allow for JIT user provisioning
 * Enterprise Portal-initiated SAML login attempts allow for JIT user provisioning if your email address has already been invited to the team. See [Invite or Delete Users](#invite-or-delete-users) below.
 
+## Access with multiple teams
+
+If your email address has been invited to more than one customer team, you can switch between teams in the Enterprise Portal. To switch teams, click your name in the top right of the page and select a different team from the list. Each team has its own license, pull tokens, and portal content based on its assigned channel.
+
+All users invited to the same customer team share access to the same pull tokens, license credentials, and portal content.
+
 ## View install and update instructions
 
 This section describes how to view install and update instructions in the Enterprise Portal.

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -20,6 +20,14 @@ Customers can access the Enterprise Portal through several methods:
 
 **SAML SSO (Alpha):** When SAML is configured by the vendor and the customer's team admin, customers can log in using their corporate identity provider credentials. Accounts are provisioned automatically on first SAML login if the email matches a pending invitation.
 
+## Access with multiple teams
+
+If your email address has been invited to more than one customer team, you can switch between teams in the Enterprise Portal. To switch teams, click your name in the header and select a different team from the list. Each team has its own license, pull tokens, and portal content based on its assigned channel.
+
+When you first log in, if you have pending invites to additional teams, the portal displays a pending invites section prompting you to accept them. After accepting, you can switch between all of your teams at any time.
+
+All users invited to the same customer team share access to the same pull tokens, license credentials, and portal content.
+
 ## Portal navigation
 
 Once logged in, customers see a sidebar with the navigation defined by the vendor's `toc.yaml`. The default template organizes content into:


### PR DESCRIPTION
Preview link: https://deploy-preview-4087--replicated-docs-upgrade.netlify.app/vendor/enterprise-portal-v2-use#access-with-multiple-teams

## Summary
- Adds a new "Access with multiple teams" section to both EP v1 and v2 end user experience docs
- Clarifies that users invited to multiple customer records can switch between teams by clicking their name in the portal
- Documents that all users invited to the same customer team share the same pull tokens and license credentials
- v2 doc additionally mentions the pending invites prompt on first login

Context: These gaps were identified from an internal Slack thread where a partner asked how multi-customer access works. The existing docs didn't cover team switching or shared credentials from the end user perspective.

## Test plan
- [ ] Verify the new sections render correctly on the docs site
- [ ] Confirm the team switching description matches current EP v1 and v2 UI behavior
- [ ] Review wording with someone familiar with the EP multi-team UX

🤖 Generated with [Claude Code](https://claude.com/claude-code)