### PR TITLE
Document pods/exec RBAC requirement for SDK support bundle collectors

### DIFF
--- a/docs/vendor/support-bundle-customizing.mdx
+++ b/docs/vendor/support-bundle-customizing.mdx
@@ -51,6 +51,24 @@ To add the default support bundle spec to a release for your application:
 
 1. Add the chart archive to a new release. Promote the release to an internal development channel, and install the release in a development environment to test your changes.
 
+## RBAC requirements for exec collectors {#exec-rbac}
+
+The Replicated SDK includes a built-in support bundle spec that uses `exec` collectors to call internal SDK API endpoints (such as `/api/v1/app/info` and `/api/v1/license/info`). These collectors retrieve application and license information that appears as `app-info.json` and `license.yaml` in the generated bundle.
+
+For these `exec` collectors to work, the service account running the support bundle must have `pods/exec` with the `create` verb in its RBAC Role or ClusterRole. For example:
+
+```yaml
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+```
+
+Without this permission, the `exec` collectors fail silently. The support bundle is still generated and can be uploaded to the Vendor Portal, but `app-info.json` and `license.yaml` will be missing. The Vendor Portal displays warnings such as "No app-info file found" and "No license file found" when these files are absent.
+
+:::note
+KOTS installations include `pods/exec` permissions in the default kotsadm Role. For Helm CLI installations, you must ensure the service account used to run `kubectl support-bundle` has this permission.
+:::
+
 ## (Recommended) Customize the default support bundle spec {#customize-the-spec}
 
 You can customize the support bundle spec by:

--- a/docs/vendor/support-bundle-generating.mdx
+++ b/docs/vendor/support-bundle-generating.mdx
@@ -24,3 +24,27 @@ Run the following command:
 ```bash
 kubectl support-bundle https://raw.githubusercontent.com/replicatedhq/troubleshoot-specs/main/in-cluster/default.yaml
 ```
+
+## Troubleshoot
+
+### Support bundle is missing app-info or license data
+
+#### Symptom
+
+After uploading a support bundle to the Vendor Portal, you see warnings: "No app-info file found" or "No license file found."
+
+#### Cause
+
+The Replicated SDK's built-in support bundle spec uses `exec` collectors to retrieve application and license information from the SDK pod. If the service account running the support bundle does not have `pods/exec` permissions with the `create` verb, these collectors fail silently and the data is not included in the bundle.
+
+#### Solution
+
+Add `pods/exec` permissions to the RBAC Role or ClusterRole for the service account running the support bundle:
+
+```yaml
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+```
+
+For more information, see [RBAC requirements for exec collectors](/vendor/support-bundle-customizing#exec-rbac).


### PR DESCRIPTION
## Summary

- Adds an **RBAC requirements for exec collectors** section to the [support bundle customizing](https://docs.replicated.com/vendor/support-bundle-customizing) page, explaining that the SDK's built-in support bundle spec uses `exec` collectors requiring `pods/exec` with `create` verb
- Adds a **troubleshooting entry** to the [support bundle generating](https://docs.replicated.com/vendor/support-bundle-generating) page for the "No app-info file found" / "No license file found" Vendor Portal warnings
- Documents that KOTS installations already include the needed RBAC, while Helm CLI installations require vendors to ensure the permission exists

Closes sc-136407

## Context

The SDK's default support bundle spec calls internal API endpoints (`/api/v1/app/info`, `/api/v1/license/info`) via exec collectors. When `pods/exec` RBAC is missing, these collectors fail silently and the bundle uploads without `app-info.json` or `license.yaml`. The only indication is VP warnings after upload.

## Test plan

- [ ] Verify the new section renders correctly on the customizing page
- [ ] Verify the troubleshooting entry renders correctly on the generating page
- [ ] Confirm the `#exec-rbac` anchor link from the generating page resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)