### PR TITLE
Update EP v2 docs for support bundle limit and invite checklist

### DIFF
--- a/docs/vendor/enterprise-portal-v2-invite.mdx
+++ b/docs/vendor/enterprise-portal-v2-invite.mdx
@@ -27,7 +27,7 @@ To invite a customer's end user to the portal:
 
 You can also enable **Automatically invite customer email to Enterprise Portal on creation** so that every new customer with an email address receives an invite automatically.
 
-When Enterprise Portal is enabled for all customers, the customer creation screen includes a checklist option to send an Enterprise Portal invite as part of customer setup. This lets you create a customer and send their portal invite in a single step.
+For vendors in mixed mode (both Classic and New enabled), the customer creation screen includes a **Use new Enterprise Portal for this customer** checkbox. When checked, the customer is enrolled in the New portal and any auto-invite email points them to the New portal URL instead of Classic. This checkbox is only visible to team admins. When unchecked or not visible, new customers default to Classic.
 
 ## Removing users
 

--- a/docs/vendor/enterprise-portal-v2-invite.mdx
+++ b/docs/vendor/enterprise-portal-v2-invite.mdx
@@ -27,6 +27,8 @@ To invite a customer's end user to the portal:
 
 You can also enable **Automatically invite customer email to Enterprise Portal on creation** so that every new customer with an email address receives an invite automatically.
 
+When Enterprise Portal is enabled for all customers, the customer creation screen includes a checklist option to send an Enterprise Portal invite as part of customer setup. This lets you create a customer and send their portal invite in a single step.
+
 ## Removing users
 
 To remove a user from a customer's portal team:

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -76,7 +76,7 @@ Customer team admins can manage their portal team from the Team Settings page:
 Customers can generate and upload support bundles from the portal:
 
 - **Generate bundles**: Follow the instructions on the Support Bundles page to generate a diagnostic bundle from their Linux or Helm installation
-- **Upload bundles**: Upload an existing bundle file for vendor analysis
+- **Upload bundles**: Upload an existing bundle file for vendor analysis. The maximum upload size is 2 GB. For larger bundles, use the [Replicated SDK API](/reference/replicated-sdk-apis#post-supportbundle) upload endpoint, which has no size restriction.
 - **View history**: See previously uploaded bundles and their status
 
 ## License information


### PR DESCRIPTION
## Summary
- Adds 2 GB upload limit note to the New Enterprise Portal support bundles section, with a fallback reference to the SDK API for larger bundles (reflects #9773 in vandoor)
- Documents the new checklist option for sending EP invites during customer creation (reflects #9796 in vandoor)

## Test plan
- [ ] Verify support bundle section renders correctly on v2-use page
- [ ] Verify invite checklist paragraph reads naturally on v2-invite page
- [ ] Preview build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)