### PR TITLE
Fix v2026.05.27-0 release note wording for portal version checkbox

### DIFF
--- a/docs/release-notes/rn-vendor-platform.md
+++ b/docs/release-notes/rn-vendor-platform.md
@@ -16,7 +16,7 @@ Released on May 27, 2026
 
 ### New Features {#new-features-v2026-05-27-0}
 * Improved new Enterprise Portal repo relinking with easier template access and clearer repo selectors.
-* Adds a checklist to add new customers to the new Enterprise Portal for auto invites.
+* Adds a portal version checkbox to the customer creation screen so vendors in mixed mode can enroll new customers in the New Enterprise Portal at creation time.
 * Redirects licenses to enabled enterprise portal version.
 
 ### Improvements {#improvements-v2026-05-27-0}


### PR DESCRIPTION
## Summary
- Clarifies that the checklist feature (#9796) adds a portal version selector for mixed-mode vendors, not a duplicate of the existing auto-invite checkbox
- The existing auto-invite checkbox controls *whether* an invite is sent; the new checkbox controls *which portal version* the customer is enrolled in

## Test plan
- [ ] Verify release note reads clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)