### PR TITLE
Add config value mapping examples to Config CR reference

### DIFF
--- a/docs/reference/custom-resource-config.mdx
+++ b/docs/reference/custom-resource-config.mdx
@@ -96,6 +96,67 @@ The following images show how this Config custom resource renders in the Embedde
 
 [View a larger version of this image](/images/config-screen-example-embedded-postgres.png)
 
+## Use config values in your Helm chart {#use-config-values}
+
+After defining config fields, you map the user-supplied values to your Helm chart using the [HelmChart v2 custom resource](/reference/custom-resource-helmchart-v2). In the HelmChart CR's `values` key, use the `ConfigOption` template function to reference config field values by name.
+
+### Example: Map config values to Helm chart values
+
+Given the Config example on this page, the following HelmChart CR maps the database configuration to Helm values:
+
+```yaml
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: my-app
+spec:
+  chart:
+    name: my-app
+    chartVersion: 1.0.0
+  values:
+    postgresql:
+      type: 'repl{{ ConfigOption "postgres_type" }}'
+      host: 'repl{{ ConfigOption "external_postgres_host" }}'
+      port: 'repl{{ ConfigOption "external_postgres_port" }}'
+      database: 'repl{{ ConfigOption "external_postgres_database" }}'
+      username: 'repl{{ ConfigOption "external_postgres_username" }}'
+      password: 'repl{{ ConfigOption "external_postgres_password" }}'
+      embeddedPassword: 'repl{{ ConfigOption "embedded_postgres_password" }}'
+    hostname: 'repl{{ ConfigOption "hostname" }}'
+```
+
+The template functions are evaluated at install and upgrade time. The resulting values are passed to your Helm chart as if they were set in `values.yaml`.
+
+### Common patterns
+
+The following are common patterns for using config values:
+
+- **Conditional Helm values**: Use `ConfigOptionEquals` to set values based on a selection:
+  ```yaml
+  values:
+    postgresql:
+      enabled: 'repl{{ ConfigOptionEquals "postgres_type" "embedded_postgres" }}'
+  ```
+
+- **Generated secrets**: Config fields with a `value` using `RandomString` generate a value on first install and persist it across upgrades:
+  ```yaml
+  # In the Config CR
+  - name: session_secret
+    title: Session Secret
+    type: password
+    hidden: true
+    value: 'repl{{ RandomString 32 }}'
+  ```
+
+- **Boolean fields**: Use `ConfigOptionEquals` to convert a bool field to a Helm value:
+  ```yaml
+  values:
+    features:
+      enableFeatureX: 'repl{{ ConfigOptionEquals "enable_feature_x" "1" }}'
+  ```
+
+For more information about template functions for config values, see [Config Context](/reference/template-functions-config-context).
+
 ## Group properties
 
 Groups have a `name`, `title`, `description` and an array of `items`.

--- a/embedded-cluster/embedded-using.mdx
+++ b/embedded-cluster/embedded-using.mdx
@@ -110,6 +110,8 @@ During upgrades, the wizard pre-populates the Configure screen with the customer
 
 For the complete field reference, see [Config custom resource](/reference/custom-resource-config).
 
+To learn how to map customer-provided config values to your Helm chart using the HelmChart CR and template functions, see [Use config values in your Helm chart](/reference/custom-resource-config#use-config-values).
+
 ## Customize the wizard branding {#branding}
 
 You can customize the appearance of the Embedded Cluster install and upgrade wizard using the [Application custom resource](/reference/custom-resource-application) in your release. The Application custom resource lets you set a custom title and icon that appear throughout the wizard.


### PR DESCRIPTION
Preview link https://deploy-preview-4106--replicated-docs.netlify.app/reference/custom-resource-config#use-config-values

## Summary
Adds a "Use config values in your Helm chart" section to the Config custom resource reference page, showing:

- How to map Config CR fields to Helm chart values using the HelmChart v2 CR and `ConfigOption` template function
- A worked example mapping database config fields from the existing page example
- Common patterns: conditional Helm values, generated secrets, boolean fields

This absorbs the most useful content from `config-screen-map-inputs` (KOTS section) so that EC v3 users can learn how config values flow to their Helm chart without visiting the KOTS docs.

Part of KOTS de-emphasis Phase 2 (epic [137934](https://app.shortcut.com/replicated/epic/137934), story [sc-137944](https://app.shortcut.com/replicated/story/137944)).

## Test plan
- [ ] Verify section renders correctly on preview at `/reference/custom-resource-config#use-config-values`
- [ ] Confirm YAML examples render properly
- [ ] Verify cross-links to HelmChart v2 CR, Config Context, and template functions docs resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)