### PR TITLE
Clarify Terraform module pricing plan requirement

### DIFF
--- a/docs/vendor/enterprise-portal-v2-about.mdx
+++ b/docs/vendor/enterprise-portal-v2-about.mdx
@@ -45,7 +45,7 @@ The following feature flags must be enabled by Replicated for your team:
 * Enable Customer Emails in Enterprise Portal
 * Enterprise Portal Customization
 * Enable Security Center in Enterprise Portal
-* Terraform Modules in Enterprise Portal
+* Terraform Modules in Enterprise Portal (available to teams on the Business or Enterprise pricing plan)
 
 ## For vendors already using the Classic Enterprise Portal
 

--- a/docs/vendor/enterprise-portal-v2-terraform.mdx
+++ b/docs/vendor/enterprise-portal-v2-terraform.mdx
@@ -5,7 +5,7 @@ Features described on this page are in alpha and subject to change. For access, 
 :::
 
 :::note
-Terraform module distribution is a premium feature that requires a separate entitlement and the `Terraform Modules in Enterprise Portal` feature flag enabled for your team. If you don't see the **Terraform** tab in Enterprise Portal, contact your Replicated account representative.
+Terraform module distribution is a premium feature available to teams on the Business or Enterprise pricing plan, and requires the `Terraform Modules in Enterprise Portal` feature flag enabled for your team. If you don't see the **Terraform** tab in Enterprise Portal, contact your Replicated account representative.
 :::
 
 Enterprise Portal provides two complementary capabilities for distributing Terraform modules:


### PR DESCRIPTION
## Summary
- Updates the Terraform modules doc to specify that the feature is available to teams on the **Business or Enterprise** pricing plan
- Replaces the vague "requires a separate entitlement" language with explicit plan tier info

## Test plan
- [ ] Verify the note renders correctly on the docs site preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)