### PR TITLE
Add install-method labels to conditional resources page and link from EC v3

### DIFF
--- a/docs/vendor/packaging-include-resources.md
+++ b/docs/vendor/packaging-include-resources.md
@@ -13,7 +13,7 @@ For applications distributed with Replicated, there are options for explicitly i
 | Method | Applies to |
 |--------|-----------|
 | [Helm optional dependencies](#helm-optional-dependencies) | All install methods |
-| [HelmChart `exclude` field](#helmchart-exclude-field) | Embedded Cluster, KOTS existing cluster |
+| [HelmChart `exclude` field](#helmchart-exclude-field) | Embedded Cluster v2, KOTS existing cluster |
 | [`kots.io/installer-only` annotation](#installer-only) | All install methods (controls Helm CLI vs. installer behavior) |
 | [`kots.io/exclude` and `kots.io/when` annotations](#include-or-exclude-kubernetes-manifests) | KOTS existing cluster only |
 

--- a/docs/vendor/packaging-include-resources.md
+++ b/docs/vendor/packaging-include-resources.md
@@ -1,6 +1,6 @@
 # Conditionally include or exclude resources
 
-This topic describes how to use Replicated `kots.io` annotations to explicitly include or exclude application resources from deployments based on one or more conditions.
+This topic describes how to conditionally include or exclude application resources from deployments based on one or more conditions.
 
 ## Overview
 
@@ -9,6 +9,13 @@ Software vendors often need a way to conditionally deploy one or more applicatio
 Another common use case is needing to explicitly include or exclude a resource from a customer deployment depending on if they install with the Helm CLI or with a Replicated installer. For example, some vendors provide additional services when the user deploys with a Replicated installer like Embedded Cluster, but do not want those services included when users deploy with the Helm CLI.
 
 For applications distributed with Replicated, there are options for explicitly including and excluding entire Helm charts, resources within a Helm chart's templates, and resources defined by standalone Kubernetes manifests.
+
+| Method | Applies to |
+|--------|-----------|
+| [Helm optional dependencies](#helm-optional-dependencies) | All install methods |
+| [HelmChart `exclude` field](#helmchart-exclude-field) | Embedded Cluster, KOTS existing cluster |
+| [`kots.io/installer-only` annotation](#installer-only) | All install methods (controls Helm CLI vs. installer behavior) |
+| [`kots.io/exclude` and `kots.io/when` annotations](#include-or-exclude-kubernetes-manifests) | KOTS existing cluster only |
 
 ## Include or exclude Helm charts
 

--- a/embedded-cluster/embedded-using.mdx
+++ b/embedded-cluster/embedded-using.mdx
@@ -37,6 +37,8 @@ To create an application release that supports installation with Embedded Cluste
        chartVersion: 3.1.7
    ```    
 
+1. (Optional) To conditionally include or exclude Helm charts or resources based on the install method or user configuration, see [Conditionally include or exclude resources](/vendor/packaging-include-resources).
+
 1. If you support air gap installations, update all image references so they resolve correctly in both online and air gap installations. See [Add support for air gap installations](#local-image-registry) on this page.
 
 1. Add an [Embedded Cluster Config](embedded-config) manifest to the release. At minimum, the Config must specify the Embedded Cluster version to use.


### PR DESCRIPTION
Preview links
* https://deploy-preview-4109--replicated-docs.netlify.app/vendor/packaging-include-resources
* https://deploy-preview-4109--replicated-docs.netlify.app/embedded-cluster/v3/embedded-using#create-a-release-with-embedded-cluster-v3

## Summary
Instead of relocating `packaging-include-resources` (which would break discoverability for active KOTS users), this PR:

- Adds a summary table at the top showing which methods apply to which install types (All, Embedded Cluster + KOTS, KOTS only)
- Updates the intro to be install-method-neutral
- Adds a cross-link from the EC v3 "Configure Embedded Cluster" page so EC v3 users can discover this content

Part of KOTS de-emphasis Phase 3 (epic [137935](https://app.shortcut.com/replicated/epic/137935), story [sc-137948](https://app.shortcut.com/replicated/story/137948)).

## Test plan
- [ ] Verify table renders correctly on preview at `/vendor/packaging-include-resources`
- [ ] Verify cross-link from `/embedded-cluster/v3/embedded-using` resolves
- [ ] Confirm page is still accessible from KOTS sidebar location

🤖 Generated with [Claude Code](https://claude.com/claude-code)