### PR TITLE
Add .replicated config file reference documentation

### DIFF
--- a/.claude/agents/docs-reviewer.md
+++ b/.claude/agents/docs-reviewer.md
@@ -15,18 +15,22 @@ You are a documentation reviewer ensuring consistent structure, style, tone and 
    - Read `README.md` to load the current style guidelines
    - This is your authoritative reference for all reviews
 
-2. **Identify which file to review**:
+2. **Automation Warning**:
+   - An automation in the `replicatedhq/replicated` repo generates CLI reference docs (`replicated-cli-*.mdx`) by deleting all files matching that pattern except `replicated-cli-installing.mdx`, then regenerating them from the CLI's help text.
+   - If you create a new CLI-related doc that should not be overwritten, name it without the `replicated-cli-` prefix (e.g., `replicated-config-file.mdx`).
+
+3. **Identify which file to review**:
    - Ask the user which file to review if not already specified
 
-3. **Read full context**:
+4. **Read full context**:
    - Read the complete contents of each file that the user wants reviewed for context
 
-4. **Review against the style guide**:
+5. **Review against the style guide**:
    - Check each style guideline from `README.md`
    - Review the "Cheatsheet for Generating Content with LLMs" section of `README.md`
    - Review only the modified content (or entire file if newly created)
 
-5. **Generate and output report**:
+6. **Generate and output report**:
    - Output the report directly
    - You may include 0 to 7 issues in the report
    - If you identify more than 7 issues, tell the user that you found more issues than are listed in this report, and they should review the rest of their doc for similar issue patterns

--- a/docs/reference/replicated-cli-installing.mdx
+++ b/docs/reference/replicated-cli-installing.mdx
@@ -205,3 +205,7 @@ To authenticate using `replicated login`:
 1. <Login/>
 
 1. <Logout/>
+
+## Project configuration
+
+After installing and authenticating the Replicated CLI, create a `.replicated` configuration file at the root of your project repository. For more information, see [.replicated configuration file](replicated-config-file).

--- a/docs/reference/replicated-config-file.mdx
+++ b/docs/reference/replicated-config-file.mdx
@@ -1,17 +1,17 @@
-# .replicated Configuration File
+# .replicated configuration file
 
-The `.replicated` file is a per-project configuration file used by the Replicated CLI. It is located at the root of your project repository and tells the CLI which application, Helm charts, Kubernetes manifests, and preflight checks belong to this project.
+The `.replicated` file is a per-project configuration file that the Replicated CLI uses. Place this file at the root of your project repository. It tells the CLI which application, Helm charts, Kubernetes manifests, and preflight checks belong to this project.
 
-When you run commands like `replicated release create` or `replicated release lint` without explicit flags, the CLI searches for this file in the current directory and continues searching upward through parent directories until it finds one.
+When you run commands like `replicated release create` or `replicated release lint` without explicit flags, the CLI searches for this file in the current directory. It continues searching upward through parent directories.
 
-## File Location and Name
+## File location and name
 
-Place the file at the root of your project. The CLI searches from the current working directory up through parent directories and accepts either of these names:
+Place the file at the root of your project. The CLI searches from the current working directory up through parent directories. It accepts either of these names:
 
 - `.replicated`
 - `.replicated.yaml`
 
-## What It Configures
+## What it configures
 
 The `.replicated` file configures the following:
 
@@ -21,11 +21,11 @@ The `.replicated` file configures the following:
 * **Preflights:** preflight check specs to validate before install
 * **Linting:** local lint tool configuration and version pinning
 
-## Field Reference
+## Field reference
 
 ### `appSlug` (string, optional)
 
-The slug of your Replicated application. Commands that need to know which app to operate on, such as `replicated release create`, use this field. You can also provide this via the `--app` flag or the `REPLICATED_APP` environment variable.
+The slug of your Replicated application. Commands that need to know which app to operate on, such as `replicated release create`, use this field. You can also provide this with the `--app` flag or the `REPLICATED_APP` environment variable.
 
 ```yaml
 appSlug: "my-application"
@@ -33,7 +33,7 @@ appSlug: "my-application"
 
 ### `appId` (string, optional)
 
-The UUID of your Replicated application. Alternative to `appSlug`. If both are present, the CLI prefers `appSlug`.
+The universally unique identifier (UUID) of your Replicated application. Alternative to `appSlug`. If both are present, the CLI prefers `appSlug`.
 
 ```yaml
 appId: "12345678-1234-1234-1234-123456789abc"
@@ -75,7 +75,7 @@ Preflight check specifications to lint and validate. Each entry has the followin
 |-------|------|----------|-------------|
 | `path` | string | Yes | Path to the preflight spec file. |
 | `chartName` | string | No | Explicit chart name to associate with this preflight. |
-| `chartVersion` | string | No | Explicit chart version. Must be provided together with `chartName`. |
+| `chartVersion` | string | No | Explicit chart version. You must provide this together with `chartName`. |
 
 ```yaml
 preflights:
@@ -114,7 +114,7 @@ releaseLabel: "v1.0.0-beta"
 
 ### `repl-lint` (object, optional)
 
-Configuration for the local linting engine. This controls which linters run and which tool versions are used.
+Configuration for the local linting engine. This controls which linters run and which tool versions to use.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -124,7 +124,7 @@ Configuration for the local linting engine. This controls which linters run and 
 
 #### Linter configuration
 
-Each linter under `linters` supports a `disabled` boolean:
+Each linter in `linters` supports a `disabled` boolean:
 
 ```yaml
 repl-lint:
@@ -164,18 +164,18 @@ repl-lint:
 
 Versions must be either a semantic version (`1.2.3` or `v1.2.3`) or the string `latest`.
 
-## App Resolution Precedence
+## App resolution precedence
 
-When a command needs to know which app to target, the value is resolved in this order:
+When a command needs to know which app to target, resolve the value in this order:
 
 1. `--app` flag
 2. `REPLICATED_APP` environment variable
 3. `.replicated` file (`appSlug` or `appId`)
 4. Cached default app from `replicated default app <slug>`
 
-## Monorepo Support
+## Monorepo support
 
-If you have a monorepo with multiple apps, you can place a `.replicated` file in each app subdirectory. The CLI searches upward from the current working directory and merges all found configs:
+If you have a monorepo with multiple apps, you can place a `.replicated` file in each app subdirectory. The CLI searches upward from the current working directory and merges all found configuration files:
 
 - Scalar fields (`appSlug`, `appId`, `releaseLabel`): child overrides parent.
 - Channel arrays (`promoteToChannelIds`, `promoteToChannelNames`): child replaces parent if non-empty.
@@ -186,7 +186,7 @@ This lets you define common settings at the repo root and app-specific settings 
 
 ## Examples
 
-### Minimal Helm-Only Project
+### Minimal Helm-only project
 
 ```yaml
 appSlug: "my-helm-app"
@@ -194,7 +194,7 @@ charts:
   - path: ./chart
 ```
 
-### KOTS Manifests Project
+### KOTS manifests project
 
 ```yaml
 appSlug: "my-kots-app"
@@ -203,7 +203,7 @@ manifests:
   - ./crds/**/*.yaml
 ```
 
-### Multi-Chart Project with Linting
+### Multi-chart project with linting
 
 ```yaml
 appSlug: "my-platform"
@@ -228,7 +228,7 @@ repl-lint:
       disabled: true
 ```
 
-### Monorepo Root Config
+### Monorepo root config
 
 ```yaml
 # At repo root: .replicated
@@ -259,7 +259,7 @@ manifests:
 
 ## Create a config file
 
-Run the interactive initializer to generate a `.replicated` file for your project:
+Run the interactive initialization command to generate a `.replicated` file for your project:
 
 ```bash
 replicated config init

--- a/docs/reference/replicated-config-file.mdx
+++ b/docs/reference/replicated-config-file.mdx
@@ -1,4 +1,4 @@
-# .replicated configuration file
+# The .replicated configuration file
 
 The `.replicated` file is a per-project configuration file that the Replicated CLI uses. Place this file at the root of your project repository. It tells the CLI which application, Helm charts, Kubernetes manifests, and preflight checks belong to this project.
 
@@ -75,7 +75,7 @@ Preflight check specifications to lint and validate. Each entry has the followin
 |-------|------|----------|-------------|
 | `path` | string | Yes | Path to the preflight spec file. |
 | `chartName` | string | No | Explicit chart name to associate with this preflight. |
-| `chartVersion` | string | No | Explicit chart version. You must provide this together with `chartName`. |
+| `chartVersion` | string | No | Explicit chart version. Provide this together with `chartName`. |
 
 ```yaml
 preflights:
@@ -166,7 +166,7 @@ Versions must be either a semantic version (`1.2.3` or `v1.2.3`) or the string `
 
 ## App resolution precedence
 
-When a command needs to know which app to target, resolve the value in this order:
+When a command needs to know which app to target, it resolves the value in this order:
 
 1. `--app` flag
 2. `REPLICATED_APP` environment variable

--- a/docs/reference/replicated-config-file.mdx
+++ b/docs/reference/replicated-config-file.mdx
@@ -2,7 +2,9 @@
 
 The `.replicated` file is a per-project configuration file that the Replicated CLI uses. Place this file at the root of your project repository. It tells the CLI which application, Helm charts, Kubernetes manifests, and preflight checks belong to this project.
 
-When you run commands like `replicated release create` or `replicated release lint` without explicit flags, the CLI searches for this file in the current directory. It continues searching upward through parent directories.
+When you run commands like `replicated release create` without explicit flags, the CLI searches for this file in the current directory. It continues searching upward through parent directories.
+
+`replicated release lint` uses `.replicated` only when the release validation v2 feature flag is active or when the `REPLICATED_RELEASE_VALIDATION_V2` environment variable is set to `1`.
 
 ## File location and name
 
@@ -85,33 +87,6 @@ preflights:
     chartVersion: "1.0.0"
 ```
 
-### `promoteToChannelIds` (list of strings, optional)
-
-Channel IDs to automatically promote a release to after creation.
-
-```yaml
-promoteToChannelIds:
-  - "abc123"
-```
-
-### `promoteToChannelNames` (list of strings, optional)
-
-Channel names to automatically promote a release to after creation.
-
-```yaml
-promoteToChannelNames:
-  - "Unstable"
-  - "Beta"
-```
-
-### `releaseLabel` (string, optional)
-
-A label to attach to the release.
-
-```yaml
-releaseLabel: "v1.0.0-beta"
-```
-
 ### `repl-lint` (object, optional)
 
 Configuration for the local linting engine. This controls which linters run and which tool versions to use.
@@ -138,9 +113,9 @@ repl-lint:
       disabled: false        # on by default
     embedded-cluster:
       disabled: true         # off by default (opt-in)
-    kots:
-      disabled: true         # off by default (opt-in)
 ```
+
+The `kots` linter is parsed by the config but is not currently implemented. Enabling it has no effect.
 
 The `embedded-cluster` linter also supports:
 
@@ -159,10 +134,11 @@ repl-lint:
     helm: "3.14.4"
     preflight: "latest"
     support-bundle: "latest"
-    embedded-cluster: "latest"
 ```
 
 Versions must be either a semantic version (`1.2.3` or `v1.2.3`) or the string `latest`.
+
+The `embedded-cluster` linter discovers its version from the manifests instead of the `tools` map. Setting it in `.replicated` has no effect.
 
 ## App resolution precedence
 
@@ -177,8 +153,7 @@ When a command needs to know which app to target, it resolves the value in this 
 
 If you have a monorepo with multiple apps, you can place a `.replicated` file in each app subdirectory. The CLI searches upward from the current working directory and merges all found configuration files:
 
-- Scalar fields (`appSlug`, `appId`, `releaseLabel`): child overrides parent.
-- Channel arrays (`promoteToChannelIds`, `promoteToChannelNames`): child replaces parent if non-empty.
+- Scalar fields (`appSlug`, `appId`): child overrides parent.
 - Resource arrays (`charts`, `preflights`, `manifests`): accumulate from all levels.
 - `repl-lint`: child overrides parent settings.
 

--- a/docs/reference/replicated-config-file.mdx
+++ b/docs/reference/replicated-config-file.mdx
@@ -33,7 +33,7 @@ appSlug: "my-application"
 
 ### `appId` (string, optional)
 
-The universally unique identifier (UUID) of your Replicated application. Alternative to `appSlug`. If both are present, the CLI prefers `appSlug`.
+The UUID of your Replicated application. Alternative to `appSlug`. If both are present, the CLI prefers `appSlug`.
 
 ```yaml
 appId: "12345678-1234-1234-1234-123456789abc"

--- a/docs/reference/replicated-config-file.mdx
+++ b/docs/reference/replicated-config-file.mdx
@@ -1,0 +1,272 @@
+# .replicated Configuration File
+
+The `.replicated` file is a per-project configuration file used by the Replicated CLI. It is located at the root of your project repository and tells the CLI which application, Helm charts, Kubernetes manifests, and preflight checks belong to this project.
+
+When you run commands like `replicated release create` or `replicated release lint` without explicit flags, the CLI searches for this file in the current directory and continues searching upward through parent directories until it finds one.
+
+## File Location and Name
+
+Place the file at the root of your project. The CLI searches from the current working directory up through parent directories and accepts either of these names:
+
+- `.replicated`
+- `.replicated.yaml`
+
+## What It Configures
+
+The `.replicated` file configures the following:
+
+* **Application identity:** which Replicated app this project belongs to
+* **Charts:** Helm charts to package as part of a release
+* **Manifests:** raw Kubernetes YAML files to include in a release
+* **Preflights:** preflight check specs to validate before install
+* **Linting:** local lint tool configuration and version pinning
+
+## Field Reference
+
+### `appSlug` (string, optional)
+
+The slug of your Replicated application. Commands that need to know which app to operate on, such as `replicated release create`, use this field. You can also provide this via the `--app` flag or the `REPLICATED_APP` environment variable.
+
+```yaml
+appSlug: "my-application"
+```
+
+### `appId` (string, optional)
+
+The UUID of your Replicated application. Alternative to `appSlug`. If both are present, the CLI prefers `appSlug`.
+
+```yaml
+appId: "12345678-1234-1234-1234-123456789abc"
+```
+
+### `charts` (list, optional)
+
+Helm charts to package when creating a release. Each entry is a chart with the following fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | string | Yes | Path to the chart directory. Can be a glob pattern. Resolved relative to the `.replicated` file. |
+| `chartVersion` | string | No | Override the chart version. |
+| `appVersion` | string | No | Override the application version. |
+
+```yaml
+charts:
+  - path: ./chart
+  - path: ./charts/backend
+    chartVersion: "1.2.3"
+    appVersion: "v2.0.0"
+```
+
+### `manifests` (list of strings, optional)
+
+Glob patterns that match Kubernetes manifest YAML files to include in the release. Resolve these patterns relative to the `.replicated` file.
+
+```yaml
+manifests:
+  - ./manifests/*.yaml
+  - ./crds/**/*.yaml
+```
+
+### `preflights` (list, optional)
+
+Preflight check specifications to lint and validate. Each entry has the following fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | string | Yes | Path to the preflight spec file. |
+| `chartName` | string | No | Explicit chart name to associate with this preflight. |
+| `chartVersion` | string | No | Explicit chart version. Must be provided together with `chartName`. |
+
+```yaml
+preflights:
+  - path: ./preflight.yaml
+  - path: ./preflights/ha-checks.yaml
+    chartName: my-app
+    chartVersion: "1.0.0"
+```
+
+### `promoteToChannelIds` (list of strings, optional)
+
+Channel IDs to automatically promote a release to after creation.
+
+```yaml
+promoteToChannelIds:
+  - "abc123"
+```
+
+### `promoteToChannelNames` (list of strings, optional)
+
+Channel names to automatically promote a release to after creation.
+
+```yaml
+promoteToChannelNames:
+  - "Unstable"
+  - "Beta"
+```
+
+### `releaseLabel` (string, optional)
+
+A label to attach to the release.
+
+```yaml
+releaseLabel: "v1.0.0-beta"
+```
+
+### `repl-lint` (object, optional)
+
+Configuration for the local linting engine. This controls which linters run and which tool versions are used.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | integer | Lint config schema version. Defaults to `1`. |
+| `linters` | object | Toggle individual linters on or off. |
+| `tools` | map | Pin tool versions (e.g. `helm: "3.14.4"`). Defaults to `"latest"`. |
+
+#### Linter configuration
+
+Each linter under `linters` supports a `disabled` boolean:
+
+```yaml
+repl-lint:
+  version: 1
+  linters:
+    helm:
+      disabled: false        # on by default
+    preflight:
+      disabled: false        # on by default
+    support-bundle:
+      disabled: false        # on by default
+    embedded-cluster:
+      disabled: true         # off by default (opt-in)
+    kots:
+      disabled: true         # off by default (opt-in)
+```
+
+The `embedded-cluster` linter also supports:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `disable-checks` | list of strings | Checker IDs to skip. Defaults to `["helmchart-archive", "ecconfig-helmchart-archive"]`. |
+| `binary-path` | string | Path to a custom embedded-cluster binary. |
+
+#### Tool version pinning
+
+You can pin the versions of external tools that the linters use:
+
+```yaml
+repl-lint:
+  tools:
+    helm: "3.14.4"
+    preflight: "latest"
+    support-bundle: "latest"
+    embedded-cluster: "latest"
+```
+
+Versions must be either a semantic version (`1.2.3` or `v1.2.3`) or the string `latest`.
+
+## App Resolution Precedence
+
+When a command needs to know which app to target, the value is resolved in this order:
+
+1. `--app` flag
+2. `REPLICATED_APP` environment variable
+3. `.replicated` file (`appSlug` or `appId`)
+4. Cached default app from `replicated default app <slug>`
+
+## Monorepo Support
+
+If you have a monorepo with multiple apps, you can place a `.replicated` file in each app subdirectory. The CLI searches upward from the current working directory and merges all found configs:
+
+- Scalar fields (`appSlug`, `appId`, `releaseLabel`): child overrides parent.
+- Channel arrays (`promoteToChannelIds`, `promoteToChannelNames`): child replaces parent if non-empty.
+- Resource arrays (`charts`, `preflights`, `manifests`): accumulate from all levels.
+- `repl-lint`: child overrides parent settings.
+
+This lets you define common settings at the repo root and app-specific settings in subdirectories.
+
+## Examples
+
+### Minimal Helm-Only Project
+
+```yaml
+appSlug: "my-helm-app"
+charts:
+  - path: ./chart
+```
+
+### KOTS Manifests Project
+
+```yaml
+appSlug: "my-kots-app"
+manifests:
+  - ./manifests/*.yaml
+  - ./crds/**/*.yaml
+```
+
+### Multi-Chart Project with Linting
+
+```yaml
+appSlug: "my-platform"
+charts:
+  - path: ./charts/api
+  - path: ./charts/worker
+manifests:
+  - ./manifests/*.yaml
+  - ./configmaps/*.yaml
+preflights:
+  - path: ./preflights/cluster-checks.yaml
+    chartName: api
+    chartVersion: "1.0.0"
+repl-lint:
+  version: 1
+  linters:
+    helm:
+      disabled: false
+    preflight:
+      disabled: false
+    support-bundle:
+      disabled: true
+```
+
+### Monorepo Root Config
+
+```yaml
+# At repo root: .replicated
+repl-lint:
+  version: 1
+  linters:
+    helm:
+      disabled: false
+```
+
+```yaml
+# At apps/frontend/.replicated
+appSlug: "frontend-app"
+charts:
+  - path: ./chart
+manifests:
+  - ./manifests/*.yaml
+```
+
+```yaml
+# At apps/backend/.replicated
+appSlug: "backend-app"
+charts:
+  - path: ./chart
+manifests:
+  - ./manifests/*.yaml
+```
+
+## Create a config file
+
+Run the interactive initializer to generate a `.replicated` file for your project:
+
+```bash
+replicated config init
+```
+
+For non-interactive environments (e.g., CI):
+
+```bash
+replicated config init --non-interactive
+```

--- a/docs/reference/replicated-config-file.mdx
+++ b/docs/reference/replicated-config-file.mdx
@@ -1,4 +1,4 @@
-# The .replicated configuration file
+# Replicated CLI project configuration
 
 The `.replicated` file is a per-project configuration file that the Replicated CLI uses. Place this file at the root of your project repository. It tells the CLI which application, Helm charts, Kubernetes manifests, and preflight checks belong to this project.
 
@@ -203,7 +203,7 @@ repl-lint:
       disabled: true
 ```
 
-### Monorepo root config
+### Monorepo root configuration
 
 ```yaml
 # At repo root: .replicated
@@ -232,7 +232,7 @@ manifests:
   - ./manifests/*.yaml
 ```
 
-## Create a config file
+## Create a configuration file
 
 Run the interactive initialization command to generate a `.replicated` file for your project:
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -592,6 +592,7 @@ const sidebars = {
     label: "Replicated CLI", // This label is generated. Do not edit.
     items: [ // This list is generated. Do not edit.
       "reference/replicated-cli-installing",
+      "reference/replicated-config-file",
       "reference/replicated",
       "reference/replicated-cli-api",
       "reference/replicated-cli-api-get",

--- a/styles/Replicated/Acronyms.yml
+++ b/styles/Replicated/Acronyms.yml
@@ -64,6 +64,7 @@ exceptions:
   - URL
   - USB
   - UTF
+  - UUID
   - VXLAN
   - XML
   - XSS

--- a/styles/Replicated/Headings.yml
+++ b/styles/Replicated/Headings.yml
@@ -138,3 +138,4 @@ exceptions:
   - Windows
   - YAML
   - Yarn
+  - ".replicated"

--- a/styles/Replicated/Headings.yml
+++ b/styles/Replicated/Headings.yml
@@ -139,3 +139,4 @@ exceptions:
   - YAML
   - Yarn
   - ".replicated"
+  - "replicated"

--- a/styles/config/vocabularies/TechJargon/accept.txt
+++ b/styles/config/vocabularies/TechJargon/accept.txt
@@ -56,6 +56,7 @@ SSL
 subnet
 subnets
 TLS
+UUID
 VCPU
 VCPUs
 VM
@@ -121,3 +122,5 @@ stdout
 firehose
 discoverability
 idempotently
+monorepo
+Monorepo


### PR DESCRIPTION
Adds a new reference doc for the .replicated configuration file, including field descriptions, app resolution precedence, monorepo support, examples, and how to create a config file. Named replicated-config-file.mdx to avoid deletion by the automated CLI docs generation pipeline (which removes all replicated-cli-*.mdx files on release).

Also adds a project configuration section to the CLI installing doc with a cross-link to the new reference, updates the sidebar, and adds an automation warning to the docs-reviewer agent.