### PR TITLE
Add release notes section to CLI releases doc

### DIFF
--- a/docs/vendor/releases-creating-cli.mdx
+++ b/docs/vendor/releases-creating-cli.mdx
@@ -91,8 +91,6 @@ To create and promote a release:
 
 Release notes are associated with a release when it is promoted to a channel. There are two ways to include release notes:
 
-### Pass release notes with the CLI {#release-notes-cli}
-
 Use the `--release-notes` flag when creating or promoting a release. This works for all release types, including KOTS, Helm, Embedded Cluster v2, and Embedded Cluster v3.
 
 ```bash
@@ -113,38 +111,4 @@ replicated release create --yaml-dir PATH_TO_RELEASE_DIR --promote CHANNEL --rel
 
 For more information, see [release create](/reference/replicated-cli-release-create) and [release promote](/reference/replicated-cli-release-promote).
 
-### Include release notes in the Application manifest {#release-notes-manifest}
-
-If your release includes a `kots.io/v1beta1` Application custom resource, you can add a `releaseNotes` field to the spec. This applies to KOTS, kURL, and Embedded Cluster v2 releases.
-
-```yaml
-apiVersion: kots.io/v1beta1
-kind: Application
-metadata:
-  name: my-app
-spec:
-  title: My App
-  releaseNotes: |
-    ## 1.2.0
-    ### Features
-    * Added new dashboard widget
-    ### Fixes
-    * Resolved timeout issue on large imports
-```
-
 When a release is promoted without explicit release notes (no `--release-notes` flag and no notes entered in the Vendor Portal), the release notes are automatically populated from this field.
-
-For more information about the Application custom resource, see [Application](/reference/custom-resource-application).
-
-:::note
-The `releaseNotes` field in the Application manifest is only available for releases that include a `kots.io/v1beta1` Application custom resource. For Helm-only and Embedded Cluster v3 releases, release notes must be provided using the `--release-notes` CLI flag or entered in the Vendor Portal UI.
-:::
-
-### Priority order
-
-When release notes are provided through multiple methods, the following priority applies:
-
-1. Notes passed with the `--release-notes` CLI flag or entered in the Vendor Portal UI (highest priority)
-1. Notes from the `releaseNotes` field in the Application custom resource (automatic fallback)
-
-This means you can set default notes in the Application manifest and override them at promote time when needed.

--- a/docs/vendor/releases-creating-cli.mdx
+++ b/docs/vendor/releases-creating-cli.mdx
@@ -86,3 +86,65 @@ To create and promote a release:
           -  `CHANNEL` is the channel ID or the case sensitive name of the channel.
 
           For more information, see [release promote](/reference/replicated-cli-release-promote).
+
+## Include release notes {#release-notes}
+
+Release notes are associated with a release when it is promoted to a channel. There are two ways to include release notes:
+
+### Pass release notes with the CLI {#release-notes-cli}
+
+Use the `--release-notes` flag when creating or promoting a release. This works for all release types, including KOTS, Helm, Embedded Cluster v2, and Embedded Cluster v3.
+
+```bash
+replicated release promote SEQUENCE CHANNEL --release-notes "Bug fixes and performance improvements"
+```
+
+To pass multiline notes from a file:
+
+```bash
+replicated release promote SEQUENCE CHANNEL --release-notes "$(cat release-notes.md)"
+```
+
+The `--release-notes` flag is also available on `release create` when creating and promoting in a single step:
+
+```bash
+replicated release create --yaml-dir PATH_TO_RELEASE_DIR --promote CHANNEL --release-notes "$(cat release-notes.md)"
+```
+
+For more information, see [release create](/reference/replicated-cli-release-create) and [release promote](/reference/replicated-cli-release-promote).
+
+### Include release notes in the Application manifest {#release-notes-manifest}
+
+If your release includes a `kots.io/v1beta1` Application custom resource, you can add a `releaseNotes` field to the spec. This applies to KOTS, kURL, and Embedded Cluster v2 releases.
+
+```yaml
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  title: My App
+  releaseNotes: |
+    ## 1.2.0
+    ### Features
+    * Added new dashboard widget
+    ### Fixes
+    * Resolved timeout issue on large imports
+```
+
+When a release is promoted without explicit release notes (no `--release-notes` flag and no notes entered in the Vendor Portal), the release notes are automatically populated from this field.
+
+For more information about the Application custom resource, see [Application](/reference/custom-resource-application).
+
+:::note
+The `releaseNotes` field in the Application manifest is only available for releases that include a `kots.io/v1beta1` Application custom resource. For Helm-only and Embedded Cluster v3 releases, release notes must be provided using the `--release-notes` CLI flag or entered in the Vendor Portal UI.
+:::
+
+### Priority order
+
+When release notes are provided through multiple methods, the following priority applies:
+
+1. Notes passed with the `--release-notes` CLI flag or entered in the Vendor Portal UI (highest priority)
+1. Notes from the `releaseNotes` field in the Application custom resource (automatic fallback)
+
+This means you can set default notes in the Application manifest and override them at promote time when needed.


### PR DESCRIPTION
## Summary

- Adds a new "Include release notes" section to the [Manage releases with the CLI](/vendor/releases-creating-cli) page
- Documents two methods: the `--release-notes` CLI flag (works for all release types) and the `releaseNotes` field in the Application manifest (KOTS, kURL, EC v2 only)
- Clarifies the priority order when both methods are used
- Calls out that Helm-only and Embedded Cluster v3 releases must use the CLI flag or Vendor Portal UI since there is no manifest-based fallback

## Context

A vendor reported friction around having to manually paste release notes into the Vendor Portal UI for each promote. This doc update makes the automation options more discoverable.

## Test plan

- [ ] Verify the page renders correctly locally
- [ ] Confirm links to `release create`, `release promote`, and `Application` CR reference resolve
- [ ] Review the note callout about EC v3 / Helm-only limitations

🤖 Generated with [Claude Code](https://claude.com/claude-code)