### PR TITLE
Add Application CR field guidance to EC v2-to-v3 migration page

### DIFF
--- a/embedded-cluster/embedded-v3-migrate.mdx
+++ b/embedded-cluster/embedded-v3-migrate.mdx
@@ -58,7 +58,6 @@ The following Application spec fields are not used in Embedded Cluster v3:
 |---|---|
 | `allowRollback` | Enabled the rollback button in the Admin Console |
 | `graphs` | Displayed Prometheus metric graphs in the Admin Console |
-| `ports` | Configured port-forward shortcuts in the Admin Console |
 | `minKotsVersion` / `targetKotsVersion` | Gated installations to specific KOTS versions |
 | `requireMinimalRBACPrivileges` / `supportMinimalRBACPrivileges` | Controlled KOTS operator RBAC mode |
 | `proxyPublicImages` | Routed public image pulls through the Replicated proxy registry via KOTS |
@@ -71,6 +70,10 @@ The following Application spec fields **are still used** in Embedded Cluster v3:
 |---|---|
 | `title` | Displayed in the Embedded Cluster install and upgrade wizard header. See [Customize the wizard branding](embedded-using#branding). |
 | `icon` | Displayed next to the title in the wizard. For air gap installations, use a Base64 encoded image since remote URLs are not accessible. See [Customize the wizard branding](embedded-using#branding). |
+| `releaseNotes` | Used as the default release notes for the channel release when no notes are provided at promote time. See [Include release notes](/vendor/releases-creating-cli#release-notes). |
+| `additionalImages` | Images listed here are included in air gap bundles, even if not directly referenced in Helm chart templates. |
+| `excludedImages` | Images listed here are excluded from air gap bundles. |
+| `ports` | Configures port-forward shortcuts in the Embedded Cluster install and upgrade wizard. |
 | `statusInformers` | Injected into the Replicated SDK Helm values for instance reporting in the Vendor Portal. Requires the [Replicated SDK](/vendor/replicated-sdk-overview). |
 
 ## Update your release to Embedded Cluster v3

--- a/embedded-cluster/embedded-v3-migrate.mdx
+++ b/embedded-cluster/embedded-v3-migrate.mdx
@@ -48,6 +48,31 @@ If you have config fields that need to be vendor-controlled and updateable acros
 
 If your application uses the Replicated proxy registry, Embedded Cluster v2 configures the cluster to automatically authenticate to the proxy registry for all pods. This means that it's no longer necessary to manually inject a Replicated pull secret using the ImagePullSecretName template function.
 
+### Changes to Application custom resource fields {#application-cr-changes}
+
+Because Embedded Cluster v3 removes the KOTS Admin Console, several fields in the [Application custom resource](/reference/custom-resource-application) no longer have a meaningful equivalent in v3. These fields can be safely removed from your Application manifest during migration. If left in place, they are silently ignored.
+
+The following Application spec fields are not used in Embedded Cluster v3:
+
+| Field | Purpose in Embedded Cluster v2 (KOTS) |
+|---|---|
+| `allowRollback` | Enabled the rollback button in the Admin Console |
+| `graphs` | Displayed Prometheus metric graphs in the Admin Console |
+| `ports` | Configured port-forward shortcuts in the Admin Console |
+| `minKotsVersion` / `targetKotsVersion` | Gated installations to specific KOTS versions |
+| `requireMinimalRBACPrivileges` / `supportMinimalRBACPrivileges` | Controlled KOTS operator RBAC mode |
+| `proxyPublicImages` | Routed public image pulls through the Replicated proxy registry via KOTS |
+| `consoleFeatureFlags` | Enabled feature flags in the Admin Console UI |
+| `additionalNamespaces` | Granted KOTS cross-namespace RBAC access |
+
+The following Application spec fields **are still used** in Embedded Cluster v3:
+
+| Field | How it is used in Embedded Cluster v3 |
+|---|---|
+| `title` | Displayed in the Embedded Cluster install and upgrade wizard header. See [Customize the wizard branding](embedded-using#branding). |
+| `icon` | Displayed next to the title in the wizard. For air gap installations, use a Base64 encoded image since remote URLs are not accessible. See [Customize the wizard branding](embedded-using#branding). |
+| `statusInformers` | Injected into the Replicated SDK Helm values for instance reporting in the Vendor Portal. Requires the [Replicated SDK](/vendor/replicated-sdk-overview). |
+
 ## Update your release to Embedded Cluster v3
 
 To update a release from Embedded Cluster v2 to v3:


### PR DESCRIPTION
## Summary

- Adds a new "Changes to Application custom resource fields" section to the EC v2-to-v3 migration comparison
- Documents which Application spec fields are silently ignored in EC v3 (KOTS-specific: `allowRollback`, `graphs`, `ports`, version gates, RBAC fields, etc.)
- Documents which fields are still used in EC v3 (`title`, `icon`, `statusInformers`) with links to relevant docs
- Helps vendors understand what they can clean up vs. what they need to keep

## Test plan

- [ ] Verify the page renders correctly, especially the two tables
- [ ] Confirm links to Application CR reference, wizard branding, and SDK overview resolve
- [ ] Review placement within the "Comparison to Embedded Cluster v2" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)