### PR TITLE
Add HelmReleaseImages and LicenseDownload to EP v2 component docs

### DIFF
--- a/docs/release-notes/rn-vendor-platform.md
+++ b/docs/release-notes/rn-vendor-platform.md
@@ -15,7 +15,7 @@ This topic contains release notes for the Replicated Vendor Platform, which incl
 Released on May 28, 2026
 
 ### New Features {#new-features-v2026-05-28-6}
-* Adds <LicenseDownload /> component to the new Enterprise Portal to allow customers to download their licenses.
+* Adds `LicenseDownload` component to the new Enterprise Portal to allow customers to download their licenses.
 
 ### Bug Fixes {#bug-fixes-v2026-05-28-6}
 * Makes magic links are aware of being requested by Classic Enterprise Portal or New Enterprise Portal.

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -312,6 +312,8 @@ Props: `title` (optional, defaults to "Name Your Instance"), `method` (optional)
 
 **`<AdminConsoleUrl />`**: Displays the admin console URL for Embedded Cluster installations. No props.
 
+**`<HelmReleaseImages />`**: Lists all container images included in a Helm release for the selected version. Includes a copy button for the full image list. Props: `title` (optional, defaults to "Helm images"), `emptyText` (optional, message when no images are found).
+
 **`<InstallStep>`**: Wraps content in a numbered step container.
 
 ```markdown
@@ -391,6 +393,8 @@ In this example, a customer on version 1.5.0 would see the "Upgrading from 1.x" 
 **`<HelmBundles />`**: Helm-specific support bundle generation instructions. No props.
 
 **`<ContactInfo />`**: Displays the support contact information configured in `theme.yaml`. No props.
+
+**`<LicenseDownload />`**: Renders a button that lets customers download their license file. No props.
 
 **`<InstancesAndUpdates />`**: Renders the full instances and updates management page inline. No props.
 


### PR DESCRIPTION
## Summary
- Adds `<HelmReleaseImages />` to the installation components section (vandoor #9864) - lists container images in a Helm release with copy button
- Adds `<LicenseDownload />` to the portal components section (vandoor #9869) - lets customers download their license file (v1 parity gap fix)

## Test plan
- [ ] Verify component reference renders correctly on the content page
- [ ] Preview build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)