### PR TITLE
Add email domain filtering to self-service signup docs

### DIFF
--- a/docs/vendor/enterprise-portal-self-serve-signup.mdx
+++ b/docs/vendor/enterprise-portal-self-serve-signup.mdx
@@ -52,6 +52,26 @@ To add custom signup fields:
 
 When users sign up through the Enterprise Portal, you can view both the built-in and custom field values in the **Pending Trials** list in the Vendor Portal.
 
+## Configure email domain filtering {#email-domain-filtering}
+
+You can restrict which email domains are allowed to sign up through the Enterprise Portal. This helps ensure that only users with work email addresses can create trial accounts.
+
+To configure email domain filtering:
+
+1. In the Vendor Portal, go to **Enterprise Portal > Self Serve Signup**.
+
+1. In the **Email Domain Filtering** section, select one of the following modes:
+
+   - **No filtering**: Any email address can sign up (default).
+   - **Block specific domains**: Block signups from specific email domains. When this option is selected:
+     - (Optional) Select **Block common consumer email domains** to automatically block signups from popular consumer email providers such as gmail.com, yahoo.com, hotmail.com, outlook.com, and others.
+     - (Optional) Enter additional domains to block in the **Additional domains to block** field. Use the format `example.com` (no `https://` or paths). Press Enter or comma to add each domain.
+   - **Allow only specific domains**: Only allow signups from the domains you specify. Enter at least one domain in the **Allowed domains** field.
+
+1. Click **Save**.
+
+When a user tries to sign up with a blocked email domain, they receive an error message asking them to use a work email address. Domain filtering is applied during signup only and does not affect existing customers.
+
 ## Share your sign-up URL {#share-trial-url}
 
 Each application has a dedicated sign-up URL where users can access the self-servive sign up. When a new user naviagtes to the sign-up page and clicks **Create account**, they receive an email with a 12-digit verification code. The following shows an example of a self-service sign-up page for an application:

--- a/docs/vendor/enterprise-portal-v2-self-serve-signup.mdx
+++ b/docs/vendor/enterprise-portal-v2-self-serve-signup.mdx
@@ -31,6 +31,19 @@ Extend the registration form with custom data collection fields to capture infor
 
 Each field is assigned a stable identifier that persists even if you rename the label. This is useful for webhook integrations and event tracking (e.g., routing signups to different Slack channels based on company size).
 
+## Email domain filtering
+
+Restrict which email domains are allowed to sign up to ensure only users with work email addresses can create trial accounts.
+
+1. In the Self-Service Sign-Ups configuration, select a filtering mode in the **Email Domain Filtering** section:
+   - **No filtering**: Any email address can sign up (default)
+   - **Block specific domains**: Block signups from specific email domains. Optionally select **Block common consumer email domains** to automatically block popular consumer providers (gmail.com, yahoo.com, hotmail.com, outlook.com, and others). You can also add additional domains to block.
+   - **Allow only specific domains**: Only allow signups from explicitly listed domains. At least one domain is required.
+
+1. Click **Save**.
+
+When a user tries to sign up with a blocked email domain, they receive an error message asking them to use a work email address. Domain filtering is applied at signup time only and does not affect existing customers.
+
 ## Signup flow (customer experience)
 
 When a customer visits the signup URL:


### PR DESCRIPTION
## Summary
- Adds an "Email Domain Filtering" section to both the EP v1 and EP v2 self-service signup documentation pages
- Documents the three filtering modes (no filtering, block specific domains, allow only specific domains) and the consumer domain blocklist checkbox
- This feature was already shipped but missing from the docs

## Test plan
- [ ] Verify the v1 page renders correctly: `/vendor/enterprise-portal-self-serve-signup`
- [ ] Verify the v2 page renders correctly: `/vendor/enterprise-portal-v2-self-serve-signup`
- [ ] Confirm anchor link `#email-domain-filtering` works on the v1 page

🤖 Generated with [Claude Code](https://claude.com/claude-code)