### PR TITLE
Document KOTS --wait deadlock with post-install hooks

### DIFF
--- a/docs/partials/helm/_helm-cr-upgrade-flags.mdx
+++ b/docs/partials/helm/_helm-cr-upgrade-flags.mdx
@@ -9,11 +9,23 @@ For more information, see [About Replicated template functions](/reference/templ
 
 For non-boolean flags that require an additional argument, such as `--timeout 1200s`, you must use an equal sign (`=`) or specify the additional argument separately in the array.
 
-#### Example
+:::note
+KOTS passes `--wait` to Helm by default, which means Helm waits for all non-hook resources to reach a Ready state before running post-install or post-upgrade hooks. If a non-hook resource depends on a resource created by a hook (for example, a Deployment with an init container that waits for a database custom resource created by a post-install hook), this creates a circular deadlock. To avoid this, add `--wait=false` and `--wait-for-jobs=false` to `helmUpgradeFlags`. These flags are appended after the defaults and override them.
+:::
+
+#### Examples
 
 ```yaml
 helmUpgradeFlags:
   - --timeout
   - 1200s
   - --history-max=15
+```
+
+Disable the default `--wait` behavior to prevent deadlocks with post-install hooks:
+
+```yaml
+helmUpgradeFlags:
+  - --wait=false
+  - --wait-for-jobs=false
 ```

--- a/docs/vendor/helm-native-about.mdx
+++ b/docs/vendor/helm-native-about.mdx
@@ -92,6 +92,8 @@ The following limitations apply to using hooks with Helm charts deployed by KOTS
 
 * <HookWeightsLimitation/>
 
+* KOTS passes `--wait` to Helm by default, which means all non-hook resources must reach a Ready state before post-install or post-upgrade hooks run. If a non-hook resource depends on a resource created by a hook (for example, a Deployment with an init container that waits for a database custom resource created by a post-install hook), this creates a circular deadlock. To work around this, set `--wait=false` and `--wait-for-jobs=false` in [`helmUpgradeFlags`](/reference/custom-resource-helmchart-v2#helmupgradeflags).
+
 For more information about Helm hooks, see [Chart Hooks](https://helm.sh/docs/topics/charts_hooks/) in the Helm documentation.
 
 ## Air gap installations


### PR DESCRIPTION
## Summary

- Documents a known KOTS behavior where the default `--wait` flag causes a circular deadlock when non-hook resources depend on resources created by post-install hooks (e.g., a Deployment init container waiting for a database CR created by a post-install hook)
- Adds a note + example to the `helmUpgradeFlags` reference showing the `--wait=false` / `--wait-for-jobs=false` workaround
- Adds a limitation bullet to the Helm hooks section in the KOTS Helm overview page

## Context

Ref: https://app.shortcut.com/replicated/story/137158

Plain `helm install` (without `--wait`) does not have this problem. This is KOTS-specific because KOTS passes `--wait` by default.

## Files changed

- `docs/partials/helm/_helm-cr-upgrade-flags.mdx` - Added note and second example for the deadlock workaround
- `docs/vendor/helm-native-about.mdx` - Added limitation bullet under "Support for Helm hooks"

## Test plan

- [ ] Verify the `:::note` admonition renders correctly on the helmUpgradeFlags reference page
- [ ] Verify the new limitation bullet renders correctly on the Helm overview page
- [ ] Confirm cross-link to `helmUpgradeFlags` anchor works from the overview page

🤖 Generated with [Claude Code](https://claude.com/claude-code)