### PR TITLE
docs: add persistent admin console (Beta)

### DIFF
--- a/embedded-cluster/embedded-cluster-console.mdx
+++ b/embedded-cluster/embedded-cluster-console.mdx
@@ -1,0 +1,60 @@
+# console (Beta)
+
+This topic describes the options available with the Embedded Cluster `console` command, which manages the optional persistent admin console for browser-driven upgrades and operations. For procedural steps, see [Persistent admin console](embedded-persistent-console).
+
+The `console` command has two subcommands: `install` and `uninstall`.
+
+## console install
+
+Installs the persistent admin console on the controller node where the command is run.
+
+### Usage
+
+```bash
+sudo ./<app-slug> console install [flags]
+```
+
+### Flags
+
+<table>
+  <tr>
+    <th width="30%">Flag</th>
+    <th width="20%">Type</th>
+    <th width="50%">Description</th>
+  </tr>
+  <tr>
+    <td>`--port`</td>
+    <td>int</td>
+    <td>Port the persistent console web service listens on. **Default:** `30080`</td>
+  </tr>
+  <tr>
+    <td>`-h`, `--help`</td>
+    <td></td>
+    <td>Help for `console install`.</td>
+  </tr>
+</table>
+
+## console uninstall
+
+Uninstalls the persistent admin console from the controller node where the command is run. Stops and removes the `<app-slug>-console-web.service` systemd unit. The cluster and application are not otherwise affected.
+
+### Usage
+
+```bash
+sudo ./<app-slug> console uninstall [flags]
+```
+
+### Flags
+
+<table>
+  <tr>
+    <th width="30%">Flag</th>
+    <th width="20%">Type</th>
+    <th width="50%">Description</th>
+  </tr>
+  <tr>
+    <td>`-h`, `--help`</td>
+    <td></td>
+    <td>Help for `console uninstall`.</td>
+  </tr>
+</table>

--- a/embedded-cluster/embedded-overview.mdx
+++ b/embedded-cluster/embedded-overview.mdx
@@ -42,6 +42,12 @@ For more information about how to install with Embedded Cluster, see:
 * [Air Gap Installation with Embedded Cluster](installing-embedded-air-gap)
 * [Install with a customer-managed registry](installing-embedded-byo-registry)
 
+## About upgrading with Embedded Cluster
+
+Upgrades can be performed from the CLI on a controller. Alternatively, an opt-in [persistent admin console](embedded-persistent-console) can be installed on a controller to give end users a browser-driven upgrade experience without SSH access. The persistent admin console is not enabled by default.
+
+For more information, see [Perform updates in embedded clusters](updating-embedded).
+
 ## Embedded Cluster host preflight checks {#about-host-preflight-checks}
 
 During installation, Embedded Cluster automatically runs a default set of _host preflight checks_. The default host preflight checks verify that the installation environment meets the requirements for Embedded Cluster, such as:

--- a/embedded-cluster/embedded-persistent-console.mdx
+++ b/embedded-cluster/embedded-persistent-console.mdx
@@ -4,7 +4,7 @@ This topic describes the persistent admin console for Embedded Cluster 3.x — a
 
 ## Overview
 
-The persistent admin console is an opt-in web service that runs on a controller node and exposes a dashboard at `https://<controller-hostname>:30080/console`. From the dashboard, end users can view the currently installed application version, see any newer versions available on the channel, view release notes, and trigger an upgrade with a single click — without SSH access to the controller.
+The persistent admin console is an opt-in web service that runs on a controller node and exposes a dashboard at `https://<controller-hostname>:30080/console`. From the dashboard, end users can view the currently installed application version, open configured application links, see any newer versions available on the channel, view release notes, and trigger an upgrade with a single click — without SSH access to the controller.
 
 The persistent admin console is **not enabled by default**.
 

--- a/embedded-cluster/embedded-persistent-console.mdx
+++ b/embedded-cluster/embedded-persistent-console.mdx
@@ -42,6 +42,10 @@ For the full set of flags, see [console](embedded-cluster-console).
 
 The console can be installed on any controller node in the cluster. Replicated recommends running it on the primary controller — the first controller node installed in the cluster — because that node is typically the one users already access for cluster operations.
 
+## Application links
+
+If your release includes an `app.k8s.io/v1beta1 Application` resource with `spec.descriptor.links`, those links appear automatically on the console dashboard under **Open &lt;app-name&gt;**. This is the same Application resource used to configure links in the KOTS admin console — no additional configuration is needed for them to surface in the persistent admin console. For more information about defining links, see [Add Buttons and Links to the Admin Console](/vendor/admin-console-adding-buttons-links).
+
 ## Recover or move the console
 
 The console is hosted by a single controller. If the controller hosting the console is lost or the `<app-slug>-console-web.service` becomes unhealthy, rerun the install command on any controller node to bring it back up:

--- a/embedded-cluster/embedded-persistent-console.mdx
+++ b/embedded-cluster/embedded-persistent-console.mdx
@@ -1,0 +1,75 @@
+# Persistent admin console (Beta)
+
+This topic describes the persistent admin console for Embedded Cluster 3.x — an optional, always-on web UI for browser-driven upgrades and operations.
+
+## Overview
+
+The persistent admin console is an opt-in web service that runs on a controller node and exposes a dashboard at `https://<controller-hostname>:30080/console`. From the dashboard, end users can view the currently installed application version, see any newer versions available on the channel, view release notes, and trigger an upgrade with a single click — without SSH access to the controller.
+
+The persistent admin console is **not enabled by default**.
+
+## Install the console
+
+The persistent admin console is installed on a single controller node and exposes its web UI on that controller's hostname.
+
+1. On a controller node, run the install command:
+
+   ```bash
+   sudo ./<app-slug> console install
+   ```
+
+   Replace `<app-slug>` with your application slug.
+
+1. (Optional) Use the `--port` flag to override the default port (`30080`):
+
+   ```bash
+   sudo ./<app-slug> console install --port 30443
+   ```
+
+1. Verify the service is running:
+
+   ```bash
+   sudo systemctl is-active <app-slug>-console-web.service
+   ```
+
+   The output should be `active`.
+
+1. Open the console in your browser at `https://<controller-hostname>:30080/console`.
+
+For the full set of flags, see [console](embedded-cluster-console).
+
+### Choose a controller
+
+The console can be installed on any controller node in the cluster. Replicated recommends running it on the primary controller — the first controller node installed in the cluster — because that node is typically the one users already access for cluster operations.
+
+## Recover or move the console
+
+The console is hosted by a single controller. If the controller hosting the console is lost or the `<app-slug>-console-web.service` becomes unhealthy, rerun the install command on any controller node to bring it back up:
+
+```bash
+sudo ./<app-slug> console install
+```
+
+If the original controller is still healthy and you are recovering an unhealthy service, run the command on the original controller. If the original controller is lost, run the command on any other controller node. The console is stateless — the dashboard reads live data from the daemon, so moving it to a different controller is safe at any time.
+
+## Uninstall the console
+
+To uninstall the console from a controller:
+
+```bash
+sudo ./<app-slug> console uninstall
+```
+
+This stops and removes the `<app-slug>-console-web.service` systemd unit and frees the port. The cluster is not otherwise affected — the application continues running, and users can still upgrade with the `upgrade` command from the CLI. See [Perform updates in embedded clusters](updating-embedded).
+
+## Limitations
+
+The persistent admin console has the following limitations:
+
+* Air gap installations are not supported.
+
+* The console can only be installed on a single controller node at a time. Reinstall on a different controller to move it.
+
+* The console must be installed on a controller node; it cannot run on a worker node.
+
+* The cluster must have TLS configured at install time. The console reuses the cluster's TLS certificate to serve HTTPS on its port.

--- a/embedded-cluster/embedded-persistent-console.mdx
+++ b/embedded-cluster/embedded-persistent-console.mdx
@@ -44,7 +44,11 @@ The console can be installed on any controller node in the cluster. Replicated r
 
 ## Application links
 
-If your release includes an `app.k8s.io/v1beta1 Application` resource with `spec.descriptor.links`, those links appear automatically on the console dashboard under **Open &lt;app-name&gt;**. This is the same Application resource used to configure links in the KOTS admin console — no additional configuration is needed for them to surface in the persistent admin console. For more information about defining links, see [Add Buttons and Links to the Admin Console](/vendor/admin-console-adding-buttons-links).
+If your release includes an `app.k8s.io/v1beta1 Application` resource with `spec.descriptor.links`, those links appear automatically on the console dashboard under **Open &lt;app-name&gt;**. No additional configuration is needed.
+
+:::note
+If you are migrating from Embedded Cluster v2, any existing Application links carry over automatically.
+:::
 
 ## Recover or move the console
 

--- a/embedded-cluster/updating-embedded.mdx
+++ b/embedded-cluster/updating-embedded.mdx
@@ -8,6 +8,20 @@ Each Embedded Cluster binary that you download targets a particular application 
 
 You can upgrade interactively in the browser or headlessly from the command line. To change configuration or redeploy without moving to a newer application version, run `upgrade` using the binary for the version that is already installed.
 
+## Upgrade using the persistent admin console
+
+If the [persistent admin console](embedded-persistent-console) is installed on a controller, end users can upgrade from the browser without SSH access to the controller:
+
+1. Open the console at `https://<controller-hostname>:30080/console` and log in with the installer password.
+
+1. In the **Available updates** section, locate the target version and click **Upgrade**.
+
+   The dashboard handles the fetch, prepare, restart, and binary swap, then redirects into the upgrade configure wizard.
+
+1. Complete the configure and upgrade flow as usual.
+
+The persistent admin console is not enabled by default. For setup instructions, see [Persistent admin console](embedded-persistent-console).
+
 ## Upgrade using the Embedded Cluster UI
 
 ### Use the Enterprise Portal for a guided upgrade

--- a/embedded-cluster/updating-embedded.mdx
+++ b/embedded-cluster/updating-embedded.mdx
@@ -8,20 +8,6 @@ Each Embedded Cluster binary that you download targets a particular application 
 
 You can upgrade interactively in the browser or headlessly from the command line. To change configuration or redeploy without moving to a newer application version, run `upgrade` using the binary for the version that is already installed.
 
-## Upgrade using the persistent admin console
-
-If the [persistent admin console](embedded-persistent-console) is installed on a controller, end users can upgrade from the browser without SSH access to the controller:
-
-1. Open the console at `https://<controller-hostname>:30080/console` and log in with the installer password.
-
-1. In the **Available updates** section, locate the target version and click **Upgrade**.
-
-   The dashboard handles the fetch, prepare, restart, and binary swap, then redirects into the upgrade configure wizard.
-
-1. Complete the configure and upgrade flow as usual.
-
-The persistent admin console is not enabled by default. For setup instructions, see [Persistent admin console](embedded-persistent-console).
-
 ## Upgrade using the Embedded Cluster UI
 
 ### Use the Enterprise Portal for a guided upgrade
@@ -63,6 +49,20 @@ To upgrade more directly from the Vendor Portal:
 1. On the **Upgrade** page, start the upgrade and wait for it to finish.
 
 1. On the **Finish** page, confirm completion. Use the provided links to open your application if needed.
+
+### From the persistent admin console
+
+If the [persistent admin console](embedded-persistent-console) is installed on a controller, end users can upgrade from the browser without SSH access to the controller:
+
+1. Open the console at `https://<controller-hostname>:30080/console` and log in with the installer password.
+
+1. In the **Available updates** section, locate the target version and click **Upgrade**.
+
+   The dashboard handles the fetch, prepare, restart, and binary swap, then redirects into the upgrade configure wizard.
+
+1. Complete the configure and upgrade flow as usual.
+
+The persistent admin console is not enabled by default. For setup instructions, see [Persistent admin console](embedded-persistent-console).
 
 ## Upgrade using the CLI (headless)
 

--- a/embedded-cluster/updating-embedded.mdx
+++ b/embedded-cluster/updating-embedded.mdx
@@ -58,9 +58,13 @@ If the [persistent admin console](embedded-persistent-console) is installed on a
 
 1. In the **Available updates** section, locate the target version and click **Upgrade**.
 
-   The dashboard handles the fetch, prepare, restart, and binary swap, then redirects into the upgrade configure wizard.
+   The dashboard handles the fetch, prepare, restart, and binary swap, then redirects into the upgrade wizard.
 
-1. Complete the configure and upgrade flow as usual.
+1. On the **Configure** page, change any application configuration you need.
+
+1. On the **Upgrade** page, start the upgrade and wait for it to finish.
+
+1. On the **Finish** page, confirm completion. This redirects back to the dashboard page.
 
 The persistent admin console is not enabled by default. For setup instructions, see [Persistent admin console](embedded-persistent-console).
 
@@ -97,9 +101,27 @@ To redeploy or reconfigure an instance without upgrading, include the installati
 
 ### UI-based upgrade
 
-To change an application's configuration without upgrading the application version:
+To change an application's configuration without upgrading the application version, follow the path that matches your setup:
 
-* In the Embedded Cluster UI, change the target values on the **Configure** page. Then, follow the interactive upgrade process in the UI. 
+#### If the persistent admin console is **not** installed
+
+1. Run `upgrade` using the binary for the application version that you already have installed (not a newer version). For example, if you installed 1.2.3, download and run `upgrade` with the 1.2.3 assets:
+
+   ```bash
+   sudo ./APP_SLUG upgrade --license LICENSE_FILE
+   ```
+
+1. When prompted, log in with the installer password.
+
+1. On the **Configure** page, change the target values, then follow the interactive upgrade process to apply the new configuration.
+
+#### If the persistent admin console is installed
+
+1. Open the console at `https://<controller-hostname>:30080/console`.
+
+1. On the dashboard, click **Redeploy** next to the current version.
+
+1. Follow the interactive upgrade process to apply the new configuration.
 
 ### Headless upgrade
 

--- a/sidebarEmbeddedCluster.js
+++ b/sidebarEmbeddedCluster.js
@@ -16,6 +16,7 @@ module.exports = {
     },
     "embedded-manage-nodes",
     "updating-embedded",
+    "embedded-persistent-console",
     "embedded-troubleshooting",
     //REFERENCE DOCS
     { type: "html", value: "<h5>Reference</h5>", defaultStyle: true },
@@ -27,6 +28,7 @@ module.exports = {
       label: "Embedded Cluster Commands",
       items: [
         "embedded-cluster-completion",
+        "embedded-cluster-console",
         "embedded-cluster-create-join-bundle",
         "embedded-cluster-create-upgrade-bundle",
         "embedded-cluster-enable-ha",


### PR DESCRIPTION
## Summary

Adds documentation for the new opt-in persistent admin console feature in Embedded Cluster 3.x (PR replicatedhq/ec#456). The persistent admin console runs `<app-slug>-console-web.service` on a controller and gives end users a browser-driven upgrade experience without needing SSH access.

### New pages

- **`embedded-cluster/embedded-persistent-console.mdx`** — procedural topic: overview, install (with `--port`), choose-a-controller guidance, upgrade-from-the-dashboard flow, recover/move the console, uninstall, and limitations
- **`embedded-cluster/embedded-cluster-console.mdx`** — command reference for `console install` and `console uninstall`

### Edits

- **`embedded-cluster/embedded-overview.mdx`** — adds an "About upgrading" section noting the console is an opt-in alternative to the CLI
- **`embedded-cluster/updating-embedded.mdx`** — adds an "Upgrade using the persistent admin console" section near the top
- **`sidebarEmbeddedCluster.js`** — adds both new pages to the sidebar

### Key points emphasized

- Feature is **opt-in / not enabled by default** — requires `console install` to enable
- Can be installed on any controller, **primary recommended**
- Air gap not supported (limitation)
- Recovery story: rerun `console install` on any controller to move it (or on the same controller to recover an unhealthy service)

## Test plan

- [ ] Visual review of the rendered Docusaurus pages
- [ ] Sidebar entries appear in the right place (under "Perform updates" and under "Embedded Cluster Commands")
- [ ] Internal links resolve (`embedded-persistent-console` ↔ `embedded-cluster-console` ↔ `updating-embedded`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)