### PR TITLE
Add headless air-gapped upgrade instructions to EC v3 docs

### DIFF
--- a/embedded-cluster/updating-embedded.mdx
+++ b/embedded-cluster/updating-embedded.mdx
@@ -104,10 +104,20 @@ To perform an upgrade with Embedded Cluster in air-gapped environments:
 
 1. In the **Embedded Cluster install instructions** dialog, enable the air gap option.
 
-1. Run the first command to download the installations assets to a machine with internet access.
+1. Run the first command to download the installation assets to a machine with internet access.
 
 1. Transfer them to the air-gapped host. Run the second command to untar.
 
 1. Copy the `install` command and replace `install` with `upgrade`. For example, `sudo ./app-slug upgrade --license license.yaml`.
 
     Embedded Cluster automatically detects the air gap installation, and performs an air gap upgrade.
+
+### Headless air-gapped upgrade
+
+To perform a headless upgrade in an air-gapped environment, pass `--headless` along with the upgrade command:
+
+```bash
+sudo ./APP_SLUG upgrade --license LICENSE_FILE --headless
+```
+
+Optionally pass `--config-values` with the path to your [ConfigValues](/reference/custom-resource-configvalues) file to change configuration during the upgrade. Embedded Cluster automatically detects the air gap installation.


### PR DESCRIPTION
Preview link: https://deploy-preview-4129--replicated-docs.netlify.app/embedded-cluster/v3/updating-embedded#headless-air-gapped-upgrade

## Summary
- The air-gapped upgrade section only covered the interactive UI flow
- Adds a subsection for headless air-gapped upgrades (`--headless` flag combined with air-gapped upgrade)
- Common automation scenario for air-gapped environments that was missing from the docs

## Test plan
- [ ] Verify the headless air-gapped upgrade command example is accurate
- [ ] Confirm `--config-values` works in headless air-gapped mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)