### PR TITLE
docs: clarify persistent console install precondition

### DIFF
--- a/embedded-cluster/embedded-persistent-console.mdx
+++ b/embedded-cluster/embedded-persistent-console.mdx
@@ -10,7 +10,7 @@ The persistent admin console is **not enabled by default**.
 
 ## Install the console
 
-The persistent admin console is installed on a single controller node and exposes its web UI on that controller's hostname.
+Once the application is installed and running, install the persistent admin console on a controller node. The console serves its web UI from that controller's hostname.
 
 1. On a controller node, run the install command:
 


### PR DESCRIPTION
Rewords the "Install the console" intro on the persistent admin console page to be active-voice and lead with the precondition that the cluster's application must already be installed and running.

Before:
> The persistent admin console is installed on a single controller node and exposes its web UI on that controller's hostname.

After:
> Once the application is installed and running, install the persistent admin console on a controller node. The console serves its web UI from that controller's hostname.

🤖 Generated with [Claude Code](https://claude.com/claude-code)