### PR TITLE
Bump @types/react from 19.2.15 to 19.2.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@docusaurus/preset-classic": "3.10.0",
         "@mdx-js/react": "^3.1.1",
         "@types/node": "25.9.1",
-        "@types/react": "19.2.15",
+        "@types/react": "19.2.16",
         "clsx": "^2.1.1",
         "immer": "^11.1.8",
         "loader-utils": "3.3.1",
@@ -6049,9 +6049,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.15",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
-      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "version": "19.2.16",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
+      "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@docusaurus/preset-classic": "3.10.0",
     "@mdx-js/react": "^3.1.1",
     "@types/node": "25.9.1",
-    "@types/react": "19.2.15",
+    "@types/react": "19.2.16",
     "clsx": "^2.1.1",
     "immer": "^11.1.8",
     "loader-utils": "3.3.1",


### PR DESCRIPTION
## Summary
- Bumps `@types/react` from 19.2.15 to 19.2.16 (patch update)
- Replaces Dependabot PR #4122 which could not rebase cleanly after merging #4123, #4124, and #4125

## Test plan
- [ ] Netlify deploy preview builds successfully
- [ ] No type errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)