### PR TITLE
Clarify persistent console requires CLI access for initial setup

### DIFF
--- a/embedded-cluster/embedded-persistent-console.mdx
+++ b/embedded-cluster/embedded-persistent-console.mdx
@@ -10,7 +10,7 @@ The persistent admin console is **not enabled by default**.
 
 The initial application install and console setup require command-line access to a controller node. Once the console is running, end users can perform upgrades and configuration changes from the browser without command-line access.
 
-:::tip
+:::note
 For automated deployments (such as cloud marketplace offerings using cloud-init or user-data scripts), include `console install` in your provisioning script after the initial install completes. This gives end users browser-based access from first boot without any manual setup.
 :::
 

--- a/embedded-cluster/embedded-persistent-console.mdx
+++ b/embedded-cluster/embedded-persistent-console.mdx
@@ -8,6 +8,12 @@ The persistent admin console is an opt-in web service that runs on a controller 
 
 The persistent admin console is **not enabled by default**.
 
+The initial application install and console setup require command-line access to a controller node. Once the console is running, end users can perform upgrades and configuration changes from the browser without command-line access.
+
+:::tip
+For automated deployments (such as cloud marketplace offerings using cloud-init or user-data scripts), include `console install` in your provisioning script after the initial install completes. This gives end users browser-based access from first boot without any manual setup.
+:::
+
 ## Install the console
 
 Once the application is installed and running, install the persistent admin console on a controller node. The console serves its web UI from that controller's hostname.


### PR DESCRIPTION
Preview link: https://deploy-preview-4133--replicated-docs.netlify.app/embedded-cluster/v3/embedded-persistent-console

## Summary
- Adds a note clarifying that the initial application install and console setup require command-line access to a controller node
- The console removes the CLI access requirement for Day 2 operations (upgrades, config changes), not for initial setup
- Adds a tip for vendors with automated/marketplace deployments (cloud-init, user-data scripts) to include `console install` in provisioning

## Context
The persistent console page implies end users never need CLI access, but someone has to run `ec install` and `ec console install` first. For marketplace flows (like Anaconda's cloud-init scripts), this happens automatically. For manual installs, someone with CLI access has to complete initial setup before handing off to the console.

## Test plan
- [ ] Verify the note renders correctly in the docs preview
- [ ] Confirm the tip is useful for vendors with automated provisioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)