### PR TITLE
Add guidance for choosing Support Bundle Analyzed over Uploaded

### DIFF
--- a/docs/reference/notifications-events-filters.md
+++ b/docs/reference/notifications-events-filters.md
@@ -634,7 +634,7 @@ When a customer pulls a release asset (Helm chart, Embedded Cluster bundle, or p
 ## Support events
 
 :::note
-Use **Support Bundle Uploaded** when you need an immediate notification that a bundle has arrived. Use **Support Bundle Analyzed** when you need to filter or route based on instance tags, bundle metadata, or bundle name. The Analyzed event fires after the bundle is extracted and the instance is identified, so it has richer context and supports instance tag filtering. If you are unsure which to use, start with Support Bundle Analyzed.
+Use **Support Bundle Uploaded** when you need an immediate notification that a bundle has arrived. Use **Support Bundle Analyzed** when you need to filter or route based on instance tags, bundle metadata, or bundle name. The Analyzed event fires after the bundle is extracted, so it can resolve the instance and evaluate tags when that information is available. Not all bundles will have a resolved instance or tags, but only the Analyzed event supports instance tag filtering. If you are unsure which to use, start with Support Bundle Analyzed.
 :::
 
 ### Support Bundle Uploaded

--- a/docs/reference/notifications-events-filters.md
+++ b/docs/reference/notifications-events-filters.md
@@ -633,6 +633,10 @@ When a customer pulls a release asset (Helm chart, Embedded Cluster bundle, or p
 
 ## Support events
 
+:::tip Choosing between Uploaded and Analyzed
+Use **Support Bundle Uploaded** when you need an immediate notification that a bundle has arrived. Use **Support Bundle Analyzed** when you need to filter or route based on instance tags, bundle metadata, or bundle name. The Analyzed event fires after the bundle is extracted and the instance is identified, so it has richer context and supports instance tag filtering. If you are unsure which to use, start with Support Bundle Analyzed.
+:::
+
 ### Support Bundle Uploaded
 
 When a support bundle is uploaded.

--- a/docs/reference/notifications-events-filters.md
+++ b/docs/reference/notifications-events-filters.md
@@ -633,7 +633,7 @@ When a customer pulls a release asset (Helm chart, Embedded Cluster bundle, or p
 
 ## Support events
 
-:::tip Choosing between Uploaded and Analyzed
+:::note
 Use **Support Bundle Uploaded** when you need an immediate notification that a bundle has arrived. Use **Support Bundle Analyzed** when you need to filter or route based on instance tags, bundle metadata, or bundle name. The Analyzed event fires after the bundle is extracted and the instance is identified, so it has richer context and supports instance tag filtering. If you are unsure which to use, start with Support Bundle Analyzed.
 :::
 

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -107,7 +107,7 @@ Every item also supports `icon` and `visible_when` (see [Visibility](#visibility
 The `toc.yaml` acts as an allowlist: pages that exist in your repo but are not listed in `toc.yaml` are not reachable through the portal navigation or direct URL. This means you can hide a page by simply omitting it from `toc.yaml`.
 
 :::note
-Pages configured as `overrides` targets (such as `overrides.home`) bypass the TOC allowlist and remain accessible even if they are not listed in `toc.yaml`. If you need to hide an override page, use `visible_when` in the page's frontmatter instead.
+The `overrides.home` page bypasses the TOC allowlist and remains accessible even if it is not listed in `toc.yaml`. If you need to hide the home page, use `visible_when` in its frontmatter instead.
 :::
 
 Supported icon values: `rocket`, `download`, `cloud`, `settings`, `wrench`, `life-buoy`, `file-text`, `star`, `book`, `shield`, `package`, `refresh-cw`, `database`, `key`. If omitted, defaults to `book`.

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -545,13 +545,13 @@ The following permissions are available:
 
 | Permission | Description |
 | :--- | :--- |
-| `canViewSecurity` | Can view Security Center (CVE reports, SBOMs). Resolves based on the customer's Security Center entitlement and the user's role. |
+| `canViewSecurity` | Can view Security Center (CVE reports, SBOMs). Resolves based on the customer's Security Center entitlement. |
 | `canInviteUser` | Can invite users to the portal team |
 | `canRemoveUser` | Can remove users from the portal team |
 | `canManageServiceAccts` | Can create or revoke service accounts |
 | `canUploadBundles` | Can upload support bundles |
 
-Permissions are folded into the `entitlements` namespace, so they work in both `visible_when` conditions and `\{\{ entitlements.canViewSecurity \}\}` template expressions. They resolve to the authenticated user's actual role-based permissions, so the same page can show for an admin but hide for a viewer if the permission differs by role.
+Permissions are folded into the `entitlements` namespace, so they work in both `visible_when` conditions and `\{\{ entitlements.canViewSecurity \}\}` template expressions. Currently, `canViewSecurity` is the most useful permission for content gating because it resolves based on whether Security Center is enabled for the customer. The other four permissions resolve to `true` for all portal users.
 
 ### Page-level visibility (frontmatter)
 

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -527,6 +527,8 @@ Apply `visible_when` on any navigation item in `toc.yaml`:
 
 All three filter types (`entitlements`, `channel`, and `customer_type`) are fully evaluated server-side. Unrecognized filter dimensions are rejected (fail closed).
 
+To hide a page entirely, you can also omit it from `toc.yaml`. Pages not listed in the TOC are not reachable through navigation or direct URL (see [Table of contents](#table-of-contents) above).
+
 #### Per-user permissions in visible_when
 
 In addition to license entitlements, you can gate content on per-user permissions by referencing them in the `entitlements` list:
@@ -602,9 +604,13 @@ The tag expands to a URL that authenticates the customer via their session and s
 
 The path inside the tag is relative to the repo root and must start with `assets/`.
 
+:::note
+Any asset referenced by an `\{\{asset\}\}` tag on a page that a customer can see is downloadable by that customer. Asset access is controlled by the visibility of the page that references them, not by the file path or directory structure. If you need to restrict an asset to specific customers, use template conditionals (like `\{\{#ifEquals customer.name\}\}`) around the asset reference, or place the asset reference on a page gated with `visible_when`. See the example below.
+:::
+
 ### Per-customer asset delivery
 
-Combine `\{\{asset\}\}` with template conditionals to show different downloads to different customers:
+To deliver different assets to different customers, combine `\{\{asset\}\}` with template conditionals. The conditional controls which customers see the download link, and only customers who can see the link can download the file:
 
 ```text
 ## Resources
@@ -624,6 +630,8 @@ Combine `\{\{asset\}\}` with template conditionals to show different downloads t
 
 - [Onboarding Checklist]({{asset "assets/onboarding-checklist.pdf"}})
 ```
+
+In this example, only Acme Corp can download their deployment guide, and only customers with the `isAWSEnabled` entitlement can download the AWS script. The onboarding checklist is available to all customers because it is not wrapped in a conditional.
 
 This lets you maintain one content repo with assets for all customers. Each customer only sees the downloads that apply to them. Unconditioned assets (like the onboarding checklist) appear for everyone.
 

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -104,6 +104,12 @@ The `toc.yaml` file at the root of your repo defines the sidebar navigation. Eac
 
 Every item also supports `icon` and `visible_when` (see [Visibility](#visibility) below).
 
+The `toc.yaml` acts as an allowlist: pages that exist in your repo but are not listed in `toc.yaml` are not reachable through the portal navigation or direct URL. This means you can hide a page by simply omitting it from `toc.yaml`.
+
+:::note
+Pages configured as `overrides` targets (such as `overrides.home`) bypass the TOC allowlist and remain accessible even if they are not listed in `toc.yaml`. If you need to hide an override page, use `visible_when` in the page's frontmatter instead.
+:::
+
 Supported icon values: `rocket`, `download`, `cloud`, `settings`, `wrench`, `life-buoy`, `file-text`, `star`, `book`, `shield`, `package`, `refresh-cw`, `database`, `key`. If omitted, defaults to `book`.
 
 ### Complete example
@@ -519,7 +525,31 @@ Apply `visible_when` on any navigation item in `toc.yaml`:
       include: [paid]
 ```
 
-All three filter types (`entitlements`, `channel`, and `customer_type`) are fully evaluated on both the server and the client.
+All three filter types (`entitlements`, `channel`, and `customer_type`) are fully evaluated server-side. Unrecognized filter dimensions are rejected (fail closed).
+
+#### Per-user permissions in visible_when
+
+In addition to license entitlements, you can gate content on per-user permissions by referencing them in the `entitlements` list:
+
+```yaml
+- title: Security Reports
+  page: pages/security.md
+  visible_when:
+    entitlements:
+      - canViewSecurity
+```
+
+The following permissions are available:
+
+| Permission | Description |
+| :--- | :--- |
+| `canViewSecurity` | Can view Security Center (CVE reports, SBOMs). Resolves based on the customer's Security Center entitlement and the user's role. |
+| `canInviteUser` | Can invite users to the portal team |
+| `canRemoveUser` | Can remove users from the portal team |
+| `canManageServiceAccts` | Can create or revoke service accounts |
+| `canUploadBundles` | Can upload support bundles |
+
+Permissions are folded into the `entitlements` namespace, so they work in both `visible_when` conditions and `\{\{ entitlements.canViewSecurity \}\}` template expressions. They resolve to the authenticated user's actual role-based permissions, so the same page can show for an admin but hide for a viewer if the permission differs by role.
 
 ### Page-level visibility (frontmatter)
 

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -56,6 +56,8 @@ The install commands are personalized to the selected installation and include t
 
 For upgrades, customers use the **Instances & Updates** page to view available updates and follow inline upgrade instructions. Each instance card shows the current version, install method, and update status. Clicking an instance with an available update expands inline upgrade instructions. Instructions remain expanded until the instance reports back with the upgraded version, at which point the card updates in place and collapses.
 
+Instances that are already on the latest version show an **Up to date** badge. Customers can still expand these cards to view the install/upgrade commands for their current version. This is useful for re-running a partially failed upgrade, copying commands to another node, or referencing what was deployed.
+
 If a vendor marks a release as required, it is visually flagged with a **Required** badge and pre-selected as the upgrade target. Customers can still choose a later version.
 
 The **New Installation** button lets customers start new installations, with a dropdown showing the install methods their license allows (Helm, Helm Air Gap, Linux/Embedded Cluster).

--- a/docs/vendor/event-notifications-create.mdx
+++ b/docs/vendor/event-notifications-create.mdx
@@ -152,7 +152,7 @@ As a Customer Success Manager, I want to be notified when a support bundle from 
   - License Field Condition: `tier` equals "Enterprise" AND `seats` greater than or equal to 100
 - **Delivery Method:** Email to your work email (or team email alias)
 
-:::tip
+:::note
 Support Bundle Analyzed provides more context than Support Bundle Uploaded, including bundle metadata and bundle name. It also supports instance tag filtering, which lets you scope alerts to specific environments (for example, production only). Use Support Bundle Uploaded only if you need the earliest possible notification that a bundle arrived, without filtering by instance.
 :::
 

--- a/docs/vendor/event-notifications-create.mdx
+++ b/docs/vendor/event-notifications-create.mdx
@@ -141,16 +141,20 @@ To create an event notification subscription with the Replicated CLI:
 
 The following are example event notifications based on common use cases.
 
-### Customer success manager: Support bundle uploaded
+### Customer success manager: Support bundle analyzed
 
-As a Customer Success Manager, I want to be notified if one of my key customers uploads a support bundle.
+As a Customer Success Manager, I want to be notified when a support bundle from one of my key customers is analyzed, so I can review the results and follow up.
 
-- **Event Type:** Support Bundle Uploaded
+- **Event Type:** Support Bundle Analyzed
 - **Configuration:**
   - Filter - Application: Select your production application
   - Filter - Customer: Select your key enterprise customer (for example, "Acme Corp", "GlobalTech Inc")
   - License Field Condition: `tier` equals "Enterprise" AND `seats` greater than or equal to 100
 - **Delivery Method:** Email to your work email (or team email alias)
+
+:::tip
+Support Bundle Analyzed provides more context than Support Bundle Uploaded, including bundle metadata and bundle name. It also supports instance tag filtering, which lets you scope alerts to specific environments (for example, production only). Use Support Bundle Uploaded only if you need the earliest possible notification that a bundle arrived, without filtering by instance.
+:::
 
 ### Sales manager: Trial license expiration
 

--- a/docs/vendor/event-notifications.mdx
+++ b/docs/vendor/event-notifications.mdx
@@ -67,7 +67,7 @@ When you specify multiple tag conditions, all conditions must match for the noti
 
 Instance tag filters are available on all instance-scoped events except Instance Created. The Instance Created event fires on the instance's first check-in, before tags have been applied, so a tag filter would never match. If you want to be notified about a new instance coming online and need tag-based filtering, use the Instance Ready event instead.
 
-For support bundle events, instance tag filters are available on **Support Bundle Analyzed** but not on Support Bundle Uploaded. The Uploaded event fires when the bundle is received, before the instance has been identified from the bundle contents. The Analyzed event fires after extraction, when the instance is resolved and tags can be evaluated.
+For support bundle events, instance tag filters are available on **Support Bundle Analyzed** but not on Support Bundle Uploaded. The Uploaded event fires when the Vendor Portal receives the bundle, before it extracts the bundle contents and identifies the instance. The Analyzed event fires after extraction, so it can resolve the instance and evaluate tags when that information is available. Not all bundles will have a resolved instance or tags, but only the Analyzed event supports tag-based filtering.
 
 Tags can be set on an instance from the Vendor Portal, by the Replicated SDK on heartbeat, or by the Replicated CLI. For information about instance tags, see [`instance tag`](/reference/replicated-cli-instance-tag) in _Replicated CLI reference_.
 

--- a/docs/vendor/event-notifications.mdx
+++ b/docs/vendor/event-notifications.mdx
@@ -67,6 +67,8 @@ When you specify multiple tag conditions, all conditions must match for the noti
 
 Instance tag filters are available on all instance-scoped events except Instance Created. The Instance Created event fires on the instance's first check-in, before tags have been applied, so a tag filter would never match. If you want to be notified about a new instance coming online and need tag-based filtering, use the Instance Ready event instead.
 
+For support bundle events, instance tag filters are available on **Support Bundle Analyzed** but not on Support Bundle Uploaded. The Uploaded event fires when the bundle is received, before the instance has been identified from the bundle contents. The Analyzed event fires after extraction, when the instance is resolved and tags can be evaluated.
+
 Tags can be set on an instance from the Vendor Portal, by the Replicated SDK on heartbeat, or by the Replicated CLI. For information about instance tags, see [`instance tag`](/reference/replicated-cli-instance-tag) in _Replicated CLI reference_.
 
 ## RBAC requirements


### PR DESCRIPTION
Preview links
* https://deploy-preview-4148--replicated-docs.netlify.app/reference/notifications-events-filters#support-events
* https://deploy-preview-4148--replicated-docs.netlify.app/vendor/event-notifications-create#customer-success-manager-support-bundle-analyzed
* https://deploy-preview-4148--replicated-docs.netlify.app/vendor/event-notifications#instance-tag-filters

## Summary

- Adds a tip callout to the events/filters reference explaining when to use Analyzed vs Uploaded
- Changes the CSM example notification from "Support Bundle Uploaded" to "Support Bundle Analyzed" with a tip explaining why Analyzed is the better default for most workflows
- Documents in the instance tag filters section that tag filtering is available on Analyzed but not Uploaded, and why

## Context

Vendors tend to default to the Support Bundle Uploaded event without realizing that Analyzed provides richer context (metadata, bundle name, resolved instance identity) and is the only support bundle event that supports instance tag filtering. The Uploaded event fires before extraction, so for manual, Enterprise Portal, and vendor upload paths, the instance hasn't been identified yet and tag-based routing won't apply.

Related: [sc-137964](https://app.shortcut.com/replicated/story/137964)

## Test plan

- [ ] Verify the tip callout renders correctly on the events/filters reference page
- [ ] Verify the updated CSM example reads clearly on the create subscriptions page
- [ ] Verify the new paragraph in the instance tag filters section flows with the existing content

🤖 Generated with [Claude Code](https://claude.com/claude-code)