### PR TITLE
docs(ec3): document airgap upload in persistent admin console

### DIFF
--- a/embedded-cluster/embedded-persistent-console.mdx
+++ b/embedded-cluster/embedded-persistent-console.mdx
@@ -80,8 +80,6 @@ This stops and removes the `<app-slug>-console-web.service` systemd unit and fre
 
 The persistent admin console has the following limitations:
 
-* Air gap installations are not supported.
-
 * The console can only be installed on a single controller node at a time. Reinstall on a different controller to move it.
 
 * The console must be installed on a controller node; it cannot run on a worker node.

--- a/embedded-cluster/updating-embedded.mdx
+++ b/embedded-cluster/updating-embedded.mdx
@@ -152,6 +152,26 @@ To perform an upgrade with Embedded Cluster in air-gapped environments:
 
     Embedded Cluster automatically detects the air gap installation, and performs an air gap upgrade.
 
+### From the persistent admin console
+
+If the [persistent admin console](embedded-persistent-console) is installed on a controller, you can perform air gap upgrades from the browser without SSH access:
+
+1. Open the console at `https://<controller-hostname>:30080/console` and log in with the installer password.
+
+1. In the **Available updates** section, upload the release archive (`.tgz`). The console validates the archive against the installed license, uploads it, and adds the new release to the list.
+
+   Uploads are resumable across browser sessions. If you close or refresh the browser mid-upload, the dashboard prompts you to resume the next time you open it — re-picking the same file continues from where the upload left off.
+
+1. Click **Upgrade** on the new release row to run through the standard upgrade wizard.
+
+#### Re-upload the current release
+
+The currently-installed release can also be updated from the dashboard. Two common reasons to do this:
+
+* **To update the license.** Re-upload the release archive containing the new license, then click **Redeploy** to apply it.
+
+* **To enable redeploy.** Redeploy requires a local copy of the release archive. If that copy is missing, re-upload to restore it.
+
 ### Headless air-gapped upgrade
 
 To perform a headless upgrade in an air-gapped environment, pass `--headless` along with the upgrade command:


### PR DESCRIPTION
## Summary
- Removes the "air gap installations are not supported" limitation on the persistent admin console page (no longer true)
- Adds a **From the persistent admin console** subsection under **Upgrade in air-gapped environments** covering the in-browser upload + upgrade flow, plus a re-upload subsection for license updates and redeploy

## Test plan
- [ ] Render preview and confirm the new subsection appears under air-gap upgrades
- [ ] Verify the persistent admin console page no longer lists air gap as unsupported

🤖 Generated with [Claude Code](https://claude.com/claude-code)