### PR TITLE
Document how to change linked GitHub account for EP v2

### DIFF
--- a/docs/vendor/enterprise-portal-v2-connect-repo.mdx
+++ b/docs/vendor/enterprise-portal-v2-connect-repo.mdx
@@ -20,6 +20,8 @@ If you already have a content repository (or prefer to create one from scratch),
 
 Click **Connect GitHub** and authorize the Replicated GitHub App on your GitHub organization. Creating the repo first (Step 1) ensures it's available to grant access to during this step.
 
+To change the linked GitHub account later (for example, if you move your content repo to a different organization), go to **[Team > GitHub Integration](https://vendor.replicated.com/team/github-integration)** and connect the new account.
+
 :::note
 When installing the Replicated GitHub App, grant access to all repositories you plan to use with Enterprise Portal (content repos AND Terraform module repos). If you need to add access to additional repos later, update the GitHub App's repository permissions in your GitHub org settings (Settings > Integrations > Applications > Replicated > Configure > Repository access).
 :::


### PR DESCRIPTION
## Summary
- Adds a note to the Connect a Git Repo page explaining how to change the linked GitHub account after initial setup (go to Team > GitHub Integration)
- Closes sc-138272

## Test plan
- [ ] Verify the link to vendor.replicated.com renders correctly
- [ ] Preview build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)