### PR TITLE
docs(ec3): document node taints on custom roles

### DIFF
--- a/docs/release-notes/rn-embedded-cluster-v3.md
+++ b/docs/release-notes/rn-embedded-cluster-v3.md
@@ -12,6 +12,27 @@ Additionally, these release notes list the versions of Kubernetes that are avail
 
 <!--RELEASE_NOTES_PLACEHOLDER-->
 
+## 3.6.0-beta.1
+
+<table>
+  <tr>
+    <th>Version</th>
+    <td id="center">3.6.0-beta.1+k8s-1.34</td>
+    <td id="center">3.6.0-beta.1+k8s-1.33</td>
+    <td id="center">3.6.0-beta.1+k8s-1.32</td>
+  </tr>
+  <tr>
+    <th>Kubernetes Version</th>
+    <td id="center">1.34.4</td>
+    <td id="center">1.33.8</td>
+    <td id="center">1.32.12</td>
+  </tr>
+</table>
+
+### New features {#new-features-3-6-0-beta-1}
+
+* Adds the ability to declare Kubernetes node taints on a custom role. Every node that carries the role receives the taints automatically at install or join time. For more information, see [roles](/embedded-cluster/v3/embedded-config#roles) in _Embedded Cluster Config_.
+
 ## 3.5.0-beta.1
 
 <table>

--- a/embedded-cluster/embedded-config.mdx
+++ b/embedded-cluster/embedded-config.mdx
@@ -114,6 +114,11 @@ spec:
       - name: gpu
         labels:
           gpu: "true" # Label applied to "gpu" nodes
+        taints:
+          # Taint applied to "gpu" nodes so that only pods that tolerate it can be scheduled there.
+          - key: workload
+            value: gpu
+            effect: NoSchedule
 ```
 
 ### Limitations
@@ -136,6 +141,8 @@ In the `roles.controller` key, you can customize the default controller role:
 
 * `labels`: Kubernetes labels that Embedded Cluster applies to every node assigned the controller role.
 
+* `taints`: A list of Kubernetes node taints that Embedded Cluster applies to every node assigned the controller role. Each taint requires `key` and `effect`, with optional `value`. Valid `effect` values are `NoSchedule`, `PreferNoSchedule`, and `NoExecute`.
+
 ### roles.custom
 
 In the `roles.custom` key, you can declare additional roles. Each custom role includes the following fields:
@@ -144,7 +151,9 @@ In the `roles.custom` key, you can declare additional roles. Each custom role in
 
 * `labels`: Kubernetes labels that Embedded Cluster applies to every node assigned the role.
 
-Multiple roles may be assigned to the same node — the joined node carries the union of each role's labels. If two roles define the same label key, the role that appears later in the user's selection wins.
+* `taints`: A list of Kubernetes node taints that Embedded Cluster applies to every node assigned the role. Each taint requires `key` and `effect`, with optional `value`. Valid `effect` values are `NoSchedule`, `PreferNoSchedule`, and `NoExecute`.
+
+Multiple roles may be assigned to the same node — the joined node carries the union of each role's labels and taints. If two roles define the same label key or taint key, the role that appears later in the user's selection wins.
 
 ## domains
 

--- a/embedded-cluster/embedded-config.mdx
+++ b/embedded-cluster/embedded-config.mdx
@@ -129,6 +129,8 @@ spec:
 
 * A node's role assignment cannot be changed after the node is joined to the cluster. To change a node's roles, reset the node and add it again with the new role selection.
 
+* Labels and taints declared on a role are applied only when a node is installed or joined. Changing the `labels` or `taints` for a role in a new release does not update existing nodes on upgrade — only nodes joined after the upgrade use the new values.
+
 ### roles.controller
 
 In the `roles.controller` key, you can customize the default controller role:
@@ -153,7 +155,7 @@ In the `roles.custom` key, you can declare additional roles. Each custom role in
 
 * `taints`: A list of Kubernetes node taints that Embedded Cluster applies to every node assigned the role. Each taint requires `key` and `effect`, with optional `value`. Valid `effect` values are `NoSchedule`, `PreferNoSchedule`, and `NoExecute`.
 
-Multiple roles may be assigned to the same node — the joined node carries the union of each role's labels and taints. If two roles define the same label key or taint key, the role that appears later in the user's selection wins.
+Multiple roles may be assigned to the same node — the joined node carries the union of each role's labels and taints. If two roles define the same label key or taint key, the role listed later in the user's `--roles` selection wins.
 
 ## domains
 


### PR DESCRIPTION
## Summary

Documents the new taint support on Embedded Cluster v3 custom roles. Tracks [replicatedhq/ec#465](https://github.com/replicatedhq/ec/pull/465).

- **`embedded-cluster/embedded-config.mdx`** — adds a `taints:` block to the example YAML under the GPU role, a new `taints` bullet under both `roles.controller` and `roles.custom`, and updates the multi-role merge note to cover taints alongside labels.
- **`docs/release-notes/rn-embedded-cluster-v3.md`** — new 3.6.0-beta.1 section above 3.5.0-beta.1, with a single "New features" bullet linking to the config reference.

## Test plan

- [ ] Preview renders cleanly (anchor `#roles` on the example still resolves; new `taints` bullets nest under their parent sections)
- [ ] K8s version row in 3.6.0-beta.1 matches the actual release (currently mirrors 3.5.0-beta.1: 1.34.4 / 1.33.8 / 1.32.12 — adjust if a k0s patch lands)
- [ ] Version bump (3.6.0-beta.1) is correct — tweak to a patch (3.5.1-beta.1) if the team prefers