### PR TITLE
Improve onboarding docs for release packaging and SDK guidance

### DIFF
--- a/docs/partials/replicated-sdk/_dependency-yaml.mdx
+++ b/docs/partials/replicated-sdk/_dependency-yaml.mdx
@@ -3,7 +3,7 @@
 dependencies:
 - name: replicated
   repository: oci://registry.replicated.com/library
-  version: 1.19.4
+  version: 1.19.6
 ```
 
 For the latest version information for the Replicated SDK, see the [replicated-sdk repository](https://github.com/replicatedhq/replicated-sdk/releases) in GitHub.

--- a/docs/vendor/helm-install-release.md
+++ b/docs/vendor/helm-install-release.md
@@ -10,7 +10,7 @@ This topic describes how to package a Helm chart and the Replicated SDK into a c
 
 To add a Helm chart to a release, you first add the Replicated SDK as a dependency of the Helm chart and then package the chart and its dependencies as a `.tgz` chart archive.
 
-The Replicated SDK is a Helm chart can be installed as a small service alongside your application. The SDK provides access to key Replicated features, such as support for collecting custom metrics on application instances. For more information, see [About the Replicated SDK](replicated-sdk-overview). 
+The Replicated SDK is a Helm chart that can be installed as a small service alongside your application. The SDK is required for Embedded Cluster installations and provides access to key Replicated functionality including instance telemetry, license verification, and an in-cluster API. For more information, see [About the Replicated SDK](replicated-sdk-overview).
 
 ## Requirements and recommendations
 

--- a/docs/vendor/helm-install-release.md
+++ b/docs/vendor/helm-install-release.md
@@ -10,7 +10,7 @@ This topic describes how to package a Helm chart and the Replicated SDK into a c
 
 To add a Helm chart to a release, you first add the Replicated SDK as a dependency of the Helm chart and then package the chart and its dependencies as a `.tgz` chart archive.
 
-The Replicated SDK is a Helm chart that can be installed as a small service alongside your application. The SDK provides access to key Replicated functionality including instance telemetry, license verification, and an in-cluster API. For more information, see [About the Replicated SDK](replicated-sdk-overview).
+The Replicated SDK is a Helm chart that should be installed as a small service alongside your application. The SDK provides access to key Replicated functionality including instance telemetry, license verification, and an in-cluster API. For more information, see [About the Replicated SDK](replicated-sdk-overview).
 
 ## Requirements and recommendations
 

--- a/docs/vendor/helm-install-release.md
+++ b/docs/vendor/helm-install-release.md
@@ -10,7 +10,7 @@ This topic describes how to package a Helm chart and the Replicated SDK into a c
 
 To add a Helm chart to a release, you first add the Replicated SDK as a dependency of the Helm chart and then package the chart and its dependencies as a `.tgz` chart archive.
 
-The Replicated SDK is a Helm chart that can be installed as a small service alongside your application. The SDK is required for Embedded Cluster installations and provides access to key Replicated functionality including instance telemetry, license verification, and an in-cluster API. For more information, see [About the Replicated SDK](replicated-sdk-overview).
+The Replicated SDK is a Helm chart that can be installed as a small service alongside your application. The SDK is required for Embedded Cluster installations and strongly recommended for Helm CLI installations. It provides access to key Replicated functionality including instance telemetry, license verification, and an in-cluster API. For more information, see [About the Replicated SDK](replicated-sdk-overview).
 
 ## Requirements and recommendations
 

--- a/docs/vendor/helm-install-release.md
+++ b/docs/vendor/helm-install-release.md
@@ -10,7 +10,7 @@ This topic describes how to package a Helm chart and the Replicated SDK into a c
 
 To add a Helm chart to a release, you first add the Replicated SDK as a dependency of the Helm chart and then package the chart and its dependencies as a `.tgz` chart archive.
 
-The Replicated SDK is a Helm chart that can be installed as a small service alongside your application. The SDK is required for Embedded Cluster installations and strongly recommended for Helm CLI installations. It provides access to key Replicated functionality including instance telemetry, license verification, and an in-cluster API. For more information, see [About the Replicated SDK](replicated-sdk-overview).
+The Replicated SDK is a Helm chart that can be installed as a small service alongside your application. The SDK provides access to key Replicated functionality including instance telemetry, license verification, and an in-cluster API. For more information, see [About the Replicated SDK](replicated-sdk-overview).
 
 ## Requirements and recommendations
 

--- a/docs/vendor/releases-creating-releases.mdx
+++ b/docs/vendor/releases-creating-releases.mdx
@@ -20,6 +20,14 @@ To create and promote a release in the Vendor Portal:
 
 1. Add your files to the release. You can do this by dragging and dropping files to the file directory in the YAML editor or clicking the plus icon to add a new, untitled YAML file.
 
+   :::note
+   New applications include example Kubernetes manifests (such as a ConfigMap, Deployment, and Service) and Replicated custom resource scaffolding (Application, Config, preflight, and support bundle specs) in the draft release.
+
+   To package your application for distribution, replace the example manifests with your Helm chart `.tgz` archive and the Replicated SDK as a subchart dependency. Keep and customize the Replicated custom resources to configure the Admin Console experience for your customers.
+
+   If this is your first release, see [Onboard to the Replicated Platform (Embedded Cluster v2)](/vendor/replicated-onboarding) for step-by-step instructions on packaging your Helm chart with the Replicated SDK and creating your first release.
+   :::
+
 1. Click **Save release**. This saves a draft that you can continue to edit until you promote it.
    
 1. Click **Promote**. In the **Promote Release** dialog, edit the fields:


### PR DESCRIPTION
## Summary
- Adds a callout note to the Vendor Portal release creation page (`releases-creating-releases.mdx`) explaining that new apps include example scaffolding that should be replaced with the vendor's Helm chart and the Replicated SDK
- Links first-time vendors to the onboarding guide for step-by-step instructions
- Strengthens the SDK description in `helm-install-release.md` to note it is required for Embedded Cluster installations (best practice decision on June 10) 
- Updates the SDK dependency version in the shared partial from 1.19.4 to 1.19.6

## Context
We recently updated the default app experience when creating your first release under a new application.

The default release for new apps contains KOTS resource scaffolding and example manifests but no application Helm chart and no SDK. The docs didn't mention this new scaffolding change or guide vendors through replacing it, and the SDK description undersold its importance.

## Test plan
- [ ] Verify the note renders correctly on the "Manage releases with the Vendor Portal" page
- [ ] Verify the SDK version 1.19.6 renders in all pages that import `_dependency-yaml.mdx`
- [ ] Verify the updated SDK description in "Package a Helm chart for a release" reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)