### PR TITLE
Add Replicated SDK as prerequisite for Embedded Cluster

### DIFF
--- a/docs/partials/embedded-cluster/v2/_ec-prereqs.mdx
+++ b/docs/partials/embedded-cluster/v2/_ec-prereqs.mdx
@@ -2,4 +2,6 @@
 
 * The application release that you want to install must include an [Embedded Cluster Config](/embedded-cluster/v2/embedded-config).
 
+* The Replicated SDK must be included as a dependency of your application's Helm chart. See [Package a Helm Chart for a Release](/vendor/helm-install-release).
+
 * The license used to install must have the **Embedded Cluster Enabled** license field enabled. See [Create and Manage Customers](/vendor/releases-creating-customer).

--- a/docs/partials/embedded-cluster/v3/_ec-prereqs.mdx
+++ b/docs/partials/embedded-cluster/v3/_ec-prereqs.mdx
@@ -2,4 +2,6 @@
 
 * The application release that you want to install must include an [Embedded Cluster Config](/embedded-cluster/v3/embedded-config).
 
+* The Replicated SDK must be included as a dependency of your application's Helm chart. See [Package a Helm Chart for a Release](/vendor/helm-install-release).
+
 * The license used to install must have the **Embedded Cluster Enabled** license field enabled. See [Create and Manage Customers](/vendor/releases-creating-customer).


### PR DESCRIPTION
## Summary
- Adds the Replicated SDK as an explicit prerequisite in both EC v2 and v3 prerequisite partials
- These partials are shared across all EC install/update docs

## Context
From the audit in sc-138408. Marc confirmed (June 10) that the SDK is required for EC: "we require the SDK. while it's possible for someone to ship without the SDK, it's not following any of our best practices."

The EC prerequisite partials listed only the EC Config, license field, and environment requirements. A vendor going directly to the EC install docs could miss the SDK requirement entirely, since it was only covered in the onboarding flow (Task 3).

## Test plan
- [ ] Verify the SDK prerequisite renders on all pages that import `_ec-prereqs.mdx` for both v2 and v3
- [ ] Verify the link to `/vendor/helm-install-release` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)