### PR TITLE
Document support bundle uploads from the Embedded Cluster v3 persistent console

### DIFF
--- a/docs/release-notes/rn-embedded-cluster-v3.md
+++ b/docs/release-notes/rn-embedded-cluster-v3.md
@@ -12,6 +12,27 @@ Additionally, these release notes list the versions of Kubernetes that are avail
 
 <!--RELEASE_NOTES_PLACEHOLDER-->
 
+## 3.7.0-beta.1
+
+<table>
+  <tr>
+    <th>Version</th>
+    <td id="center">3.7.0-beta.1+k8s-1.34</td>
+    <td id="center">3.7.0-beta.1+k8s-1.33</td>
+    <td id="center">3.7.0-beta.1+k8s-1.32</td>
+  </tr>
+  <tr>
+    <th>Kubernetes Version</th>
+    <td id="center">1.34.4</td>
+    <td id="center">1.33.8</td>
+    <td id="center">1.32.12</td>
+  </tr>
+</table>
+
+### New features {#new-features-3-7-0-beta-1}
+
+* Adds the ability to upload a generated support bundle directly to the Vendor Portal from the [persistent admin console](/embedded-cluster/v3/embedded-persistent-console), eliminating the need to download and share the bundle manually. For more information, see [Upload to the vendor portal](/embedded-cluster/v3/embedded-persistent-console#upload-to-the-vendor-portal-beta).
+
 ## 3.6.0-beta.1
 
 <table>

--- a/docs/vendor/support-enabling-direct-bundle-uploads.md
+++ b/docs/vendor/support-enabling-direct-bundle-uploads.md
@@ -4,7 +4,7 @@
 Direct bundle uploads is in beta. The functionality, requirements, and limitations of direct bundle uploads are subject to change.
 :::
 
-When this feature is enabled, customers using online KOTS installations can upload support bundles directly through the Admin Console UI, eliminating the need to share the generated bundle with you manually.
+When this feature is enabled, customers using online KOTS or Embedded Cluster installations can upload support bundles directly through the Admin Console UI, eliminating the need to share the generated bundle with you manually.
 
 When enabled, your customers can use the **Send bundle to vendor button** in the Admin Console to upload a generated support bundle.
 
@@ -12,14 +12,14 @@ When enabled, your customers can use the **Send bundle to vendor button** in the
 
 After clicking this button, the bundle will be immediately available under the Troubleshoot tab in the Vendor Portal team account associated with this customer.
 
-For more information on how your customer can use this feature, see [Generate Support Bundles from the Admin Console](/enterprise/troubleshooting-an-app).
+For more information on how your customer can use this feature, see [Generate Support Bundles from the Admin Console](/enterprise/troubleshooting-an-app) (KOTS) or [Persistent admin console](/embedded-cluster/embedded-persistent-console#upload-to-the-vendor-portal-beta) (Embedded Cluster).
 
 ### How to enable direct bundle uploads
 
 Direct bundle uploads are disabled by default. To enable this feature for your customer:
 
 1. Log in to the Vendor Portal and navigate to your customer's **Manage Customer** page.
-1. Under the **License options** section, make sure your customer has **KOTS Install Enabled** checked, and then check the **Support Bundle Upload Enabled (Beta)** option.
+1. Under the **License options** section, check the **Support Bundle Upload Enabled (Beta)** option. For KOTS installations, the customer must also have **KOTS Install Enabled** checked.
    <img alt="Customer license options: configure direct support bundle upload" src="/images/configure-direct-support-bundle-upload.png" width="400px"/>
 
    [View a larger version of this image](/images/configure-direct-support-bundle-upload.png)
@@ -28,5 +28,5 @@ Direct bundle uploads are disabled by default. To enable this feature for your c
 ### Limitations
 
 - You will not receive a notification when a customer sends a support bundle to the Vendor Portal. To avoid overlooking these uploads, activate this feature only if there is a reliable escalation process already in place for the customer license.
-- This feature only supports online KOTS installations. If enabled, but installed in air gap mode, the upload button will not appear.
-- There is a 500 MB limit for support bundles uploaded directly through the Admin Console. For larger bundles, use the [Replicated SDK API](/reference/replicated-sdk-apis#post-supportbundle) upload endpoint, which has no size restriction.
+- The upload button does not appear in air gap installations.
+- For KOTS and Embedded Cluster v2 installations, there is a 500 MB limit for support bundles uploaded directly through the Admin Console. For larger bundles, use the [Replicated SDK API](/reference/replicated-sdk-apis#post-supportbundle) upload endpoint, which has no size restriction.

--- a/docs/vendor/support-enabling-direct-bundle-uploads.md
+++ b/docs/vendor/support-enabling-direct-bundle-uploads.md
@@ -12,7 +12,7 @@ When enabled, your customers can use the **Send bundle to vendor button** in the
 
 After clicking this button, the bundle will be immediately available under the Troubleshoot tab in the Vendor Portal team account associated with this customer.
 
-For more information on how your customer can use this feature, see [Generate Support Bundles from the Admin Console](/enterprise/troubleshooting-an-app) (KOTS) or [Persistent admin console](/embedded-cluster/embedded-persistent-console#upload-to-the-vendor-portal-beta) (Embedded Cluster).
+For more information on how your customer can use this feature, see [Generate Support Bundles from the Admin Console](/enterprise/troubleshooting-an-app) (KOTS or Embedded Cluster v2) or [Persistent admin console](/embedded-cluster/embedded-persistent-console#upload-to-the-vendor-portal-beta) (Embedded Cluster v3).
 
 ### How to enable direct bundle uploads
 
@@ -29,4 +29,4 @@ Direct bundle uploads are disabled by default. To enable this feature for your c
 
 - You will not receive a notification when a customer sends a support bundle to the Vendor Portal. To avoid overlooking these uploads, activate this feature only if there is a reliable escalation process already in place for the customer license.
 - The upload button does not appear in air gap installations.
-- For KOTS and Embedded Cluster v2 installations, there is a 500 MB limit for support bundles uploaded directly through the Admin Console. For larger bundles, use the [Replicated SDK API](/reference/replicated-sdk-apis#post-supportbundle) upload endpoint, which has no size restriction.
+- For KOTS and Embedded Cluster v2 installations, there is a 500 MB limit for support bundles uploaded directly through the Admin Console. For larger bundles, use the [Replicated SDK API](/reference/replicated-sdk-apis#post-supportbundle) upload endpoint, which has no size restriction. Embedded Cluster v3 installations leverage the SDK upload endpoint.

--- a/embedded-cluster/embedded-persistent-console.mdx
+++ b/embedded-cluster/embedded-persistent-console.mdx
@@ -69,7 +69,19 @@ The console dashboard includes a **Generate support bundle** button that creates
 
 The generated bundle is stored in the Embedded Cluster data directory. Ensure the filesystem hosting the data directory has sufficient free space for bundle generation. The data directory is also used for application images and persistent volume data, so large bundles on a constrained filesystem could impact available disk space.
 
-After generation, the bundle can be downloaded from the console for sharing with your vendor's support team.
+After generation, the bundle can be downloaded from the console for sharing with the vendor's support team, or uploaded directly to the Vendor Portal from the console. See [Upload to the vendor portal](#upload-to-the-vendor-portal-beta) below.
+
+### Upload to the vendor portal (Beta)
+
+The console dashboard includes a **Share** button that sends a generated support bundle directly to the Vendor Portal, eliminating the need to download and share the bundle manually. After upload, the bundle is immediately available under the Troubleshoot tab in the Vendor Portal team account associated with the customer.
+
+The **Share** button appears in the console only when all of the following are true:
+
+* The customer's license has **Support Bundle Upload Enabled (Beta)** turned on. For instructions, see [Enable support bundle uploads](/vendor/support-enabling-direct-bundle-uploads).
+* The installation is online. The button does not appear in air gap installations.
+* The application includes the [Replicated SDK](/vendor/replicated-sdk-overview) version 1.17.0 or later as a chart dependency, and the SDK pod is running and reachable in the cluster. The console uploads bundles through the in-cluster SDK service, which exposes the upload endpoint starting in 1.17.0. If the SDK pod is unhealthy or unreachable, the **Share** button is hidden until the SDK becomes available again.
+
+If any of these requirements are not met, the **Share** button is hidden and the bundle can still be downloaded from the console for manual sharing.
 
 ## Recover or move the console
 
@@ -100,5 +112,3 @@ The persistent admin console has the following limitations:
 * The console must be installed on a controller node; it cannot run on a worker node.
 
 * The cluster must have TLS configured at install time. The console reuses the cluster's TLS certificate to serve HTTPS on its port.
-
-* Support bundle upload to the vendor portal is not yet supported from the console. Bundles can be generated and downloaded, then shared manually.


### PR DESCRIPTION
## Summary
- Add `Upload to the vendor portal (Beta)` subsection under Support bundles in the EC persistent console doc, with the gating requirements (license flag, online, SDK ≥ 1.17.0 + healthy)
- Remove the stale "not yet supported from the console" limitation that PR #4161 added
- Extend `support-enabling-direct-bundle-uploads.md` to cover EC alongside KOTS (intro, see-also link, KOTS-Install-Enabled scoped to KOTS only, 500 MB limit scoped to KOTS + EC v2)
- Add `3.7.0-beta.1` release notes entry calling out the feature

## Test plan
- [ ] Local docs preview renders the new subsection and anchor link works
- [ ] All cross-page links resolve (KOTS, EC, SDK overview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)