### PR TITLE
Update support bundle notification guidance and document customer_type visibility

### DIFF
--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -571,6 +571,30 @@ Only customers whose license has `hasAdvancedReporting` set to `true` will see t
 
 For information about creating custom license fields, see [Manage custom license fields](/vendor/licenses-adding-custom-fields#manage-custom-license-fields).
 
+#### License type visibility (customer_type)
+
+Use `customer_type` to show or hide content based on the customer's license type. Valid values are `community`, `trial`, and `paid`.
+
+This is useful when you have different content needs for different tiers. For example, you might show upgrade prompts to trial users, or restrict advanced documentation to paid customers only.
+
+```yaml
+# Show only to paid customers
+- title: Production Deployment Guide
+  page: pages/production-deploy.md
+  visible_when:
+    customer_type:
+      include: [paid]
+
+# Show to trial and community customers
+- title: Upgrade to Paid
+  page: pages/upgrade.md
+  visible_when:
+    customer_type:
+      include: [trial, community]
+```
+
+Like `channel`, `customer_type` supports both `include` and `exclude` lists.
+
 ### Page-level visibility (frontmatter)
 
 You can also apply `visible_when` in a page's YAML frontmatter. This controls whether the page is accessible to a customer, independent of whether it appears in the navigation.

--- a/docs/vendor/support-enabling-direct-bundle-uploads.md
+++ b/docs/vendor/support-enabling-direct-bundle-uploads.md
@@ -27,6 +27,6 @@ Direct bundle uploads are disabled by default. To enable this feature for your c
 
 ### Limitations
 
-- You will not receive a notification when a customer sends a support bundle to the Vendor Portal. To avoid overlooking these uploads, activate this feature only if there is a reliable escalation process already in place for the customer license.
+- By default, you will not receive a notification when a customer sends a support bundle to the Vendor Portal. To get notified of uploads, configure a **Support Bundle Uploaded** notification event. See [Support Events](/reference/notifications-events-filters#support-events).
 - The upload button does not appear in air gap installations.
 - For KOTS and Embedded Cluster v2 installations, there is a 500 MB limit for support bundles uploaded directly through the Admin Console. For larger bundles, use the [Replicated SDK API](/reference/replicated-sdk-apis#post-supportbundle) upload endpoint, which has no size restriction. Embedded Cluster v3 installations leverage the SDK upload endpoint.


### PR DESCRIPTION
## Summary
- **Support bundle uploads**: Replace outdated "no notification" limitation with guidance to configure a `Support Bundle Uploaded` notification event via [Support Events](https://docs.replicated.com/reference/notifications-events-filters#support-events)
- **EP v2 content visibility**: Add dedicated `customer_type` section documenting `community`, `trial`, and `paid` gating with `include`/`exclude` examples, giving it parity with the existing `entitlements` and `channel` filter docs

## Test plan
- [ ] Verify support bundle uploads page renders correctly
- [ ] Verify EP v2 content page renders the new `customer_type` section with code examples
- [ ] Confirm internal links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)