### PR TITLE
Add KOTS availability note recommending Helm for new customers

### DIFF
--- a/docs/enterprise/auth-changing-passwords.md
+++ b/docs/enterprise/auth-changing-passwords.md
@@ -1,3 +1,5 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Change an Admin Console password
 
 When you install for the first time with Replicated kURL, the Replicated KOTS Admin Console is secured with a single shared password that is set automatically for all users. Replicated recommends that you change this to a new, unique password for security purposes as this automated password is displayed to the user in plain text.
@@ -26,3 +28,5 @@ To change your Admin Console password:
    When the password change succeeds, the current session closes and you are redirected to the Log In page.
 
 1. Log in with the new password.
+
+<KotsAvailability/>

--- a/docs/enterprise/auth-configuring-rbac.md
+++ b/docs/enterprise/auth-configuring-rbac.md
@@ -1,3 +1,5 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Configure role-based access control (Beta)
 
 You can regulate access to the Replicated KOTS Admin Console resources based on the roles of individual users within your organization.
@@ -9,6 +11,8 @@ To configure role based access control (RBAC) for the Admin Console:
 1. Click **Add group**.
 
 ![Role Based Access Control](/images/identity-service-kotsadm-rbac.png)
+
+<KotsAvailability/>
 
 ## Admin Console roles
 

--- a/docs/enterprise/auth-identity-provider.md
+++ b/docs/enterprise/auth-identity-provider.md
@@ -1,3 +1,5 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Use an identity provider for user access (Deprecated)
 
 :::note
@@ -11,6 +13,8 @@ Replicated KOTS leverages the open source project Dex as an intermediary to cont
 The identity service has the following limitations:
 * Only available for installations in a cluster created by Replicated kURL.
 * Only available through the Admin Console.
+
+<KotsAvailability/>
 
 ## Prerequisite
 

--- a/docs/enterprise/delete-admin-console.md
+++ b/docs/enterprise/delete-admin-console.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Delete the Admin Console and remove applications
 
 This topic describes how to remove installed applications and delete the Replicated KOTS Admin Console. The information in this topic applies to existing cluster installations with KOTS.
+
+<KotsAvailability/>
 
 ## Remove an application
 

--- a/docs/enterprise/gitops-managing-secrets.mdx
+++ b/docs/enterprise/gitops-managing-secrets.mdx
@@ -1,4 +1,5 @@
 import GitOpsNotRecommended from "../partials/gitops/_gitops-not-recommended.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Manage secrets with KOTS Auto-Gitops (Alpha)
 
@@ -74,3 +75,5 @@ Replace:
   2022/04/20 15:49:58 HTTP server serving on :8080
   ...
   ```
+
+<KotsAvailability/>

--- a/docs/enterprise/gitops-workflow.mdx
+++ b/docs/enterprise/gitops-workflow.mdx
@@ -1,9 +1,12 @@
 import GitOpsLimitation from "../partials/helm/_gitops-limitation.mdx"
 import GitOpsNotRecommended from "../partials/gitops/_gitops-not-recommended.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # KOTS Auto-Gitops workflow
 
 <GitOpsNotRecommended/>
+
+<KotsAvailability/>
 
 ## Overview of the Auto-Gitops workflow
 

--- a/docs/enterprise/image-registry-rate-limits.md
+++ b/docs/enterprise/image-registry-rate-limits.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Avoid Docker Hub rate limits
 
 This topic describes how to avoid rate limiting for anonymous and free authenticated use of Docker Hub by providing a Docker Hub username and password to the `kots docker ensure-secret` command.
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/enterprise/image-registry-settings.mdx
+++ b/docs/enterprise/image-registry-settings.mdx
@@ -1,11 +1,14 @@
 import ImageRegistrySettings from "../partials/image-registry/_image-registry-settings.mdx"
 import DockerCompatibility from "../partials/image-registry/_docker-compatibility.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Configure local image registries
 
 This topic describes how to configure private registry settings in the Replicated KOTS Admin Console.
 
 The information in this topic applies to existing cluster installations with KOTS and installations with Replicated kURL. This topic does _not_ apply to Replicated Embedded Cluster installations.
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/enterprise/installing-existing-cluster-airgapped.mdx
+++ b/docs/enterprise/installing-existing-cluster-airgapped.mdx
@@ -12,12 +12,15 @@ import InstallKotsCliAirGap from "../partials/install/_install-kots-cli-airgap.m
 import PushKotsImages from "../partials/install/_push-kotsadm-images.mdx"
 import PlaceholderRoCreds from "../partials/install/_placeholder-ro-creds.mdx"
 import KotsVersionMatch from "../partials/install/_kots-airgap-version-match.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Air gap installation in existing clusters with KOTS
 
 This topic describes how to use Replicated KOTS to install an application in an existing Kubernetes cluster in an air-gapped environment.
 
 <IntroAirGap/>
+
+<KotsAvailability/>
 
 ## Prerequisites
 

--- a/docs/enterprise/installing-existing-cluster-automation.mdx
+++ b/docs/enterprise/installing-existing-cluster-automation.mdx
@@ -10,10 +10,13 @@ import PushKotsImages from "../partials/install/_push-kotsadm-images.mdx"
 import KotsVersionMatch from "../partials/install/_kots-airgap-version-match.mdx"
 import PlaceholderRoCreds from "../partials/install/_placeholder-ro-creds.mdx"
 import AccessAdminConsole from "../partials/install/_access-admin-console.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Install with the KOTS CLI
 
 This topic describes how to install an application with Replicated KOTS in an existing cluster using the KOTS CLI.
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/enterprise/installing-existing-cluster.mdx
+++ b/docs/enterprise/installing-existing-cluster.mdx
@@ -2,10 +2,13 @@ import PrereqsExistingCluster from "../partials/install/_prereqs-existing-cluste
 import LicenseFile from "../partials/install/_license-file-prereq.mdx"
 import InstallCommandPrompts from "../partials/install/_kots-install-prompts.mdx"
 import AppNameUI from "../partials/install/_placeholder-app-name-UI.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Online installation in existing clusters with KOTS
 
 This topic describes how to use Replicated KOTS to install an application in an existing Kubernetes cluster.
+
+<KotsAvailability/>
 
 ## Prerequisites
 

--- a/docs/enterprise/installing-general-requirements.mdx
+++ b/docs/enterprise/installing-general-requirements.mdx
@@ -2,6 +2,7 @@ import DockerCompatibility from "../partials/image-registry/_docker-compatibilit
 import KubernetesCompatibility from "../partials/install/_kubernetes-compatibility.mdx"
 import FirewallOpeningsIntro from "../partials/install/_firewall-openings-intro.mdx"
 import FirewallOpeningsKots from "../partials/install/_firewall-openings-kots.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # KOTS installation requirements
 
@@ -10,6 +11,8 @@ This topic describes the requirements for installing in a Kubernetes cluster wit
 :::note
 This topic does not include any requirements specific to the application. Ensure that you meet any additional requirements for the application before installing.
 :::
+
+<KotsAvailability/>
 
 ## Supported browsers
 

--- a/docs/enterprise/installing-overview.md
+++ b/docs/enterprise/installing-overview.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Considerations before installing
 
 Before you install an application with KOTS in an existing cluster, consider the following installation options.
+
+<KotsAvailability/>
 
 ## Online (internet-connected) or air gap installations
 

--- a/docs/enterprise/installing-stateful-component-requirements.md
+++ b/docs/enterprise/installing-stateful-component-requirements.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Install KOTS in existing clusters without object storage
 
 This topic describes how to install Replicated KOTS in existing clusters without the default object storage, including limitations of installing without object storage.
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/enterprise/monitoring-access-dashboards.mdx
+++ b/docs/enterprise/monitoring-access-dashboards.mdx
@@ -1,8 +1,12 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Access dashboards using port forwarding
 
 This topic includes information about how to access Prometheus, Grafana, and Alertmanager in Replicated KOTS existing cluster and Replicated kURL installations.
 
 For information about how to configure Prometheus monitoring in existing cluster installations, see [Configure Prometheus Monitoring in Existing Cluster KOTS Installations](monitoring-applications).
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/enterprise/monitoring-applications.mdx
+++ b/docs/enterprise/monitoring-applications.mdx
@@ -1,4 +1,5 @@
 import OverviewProm from "../partials/monitoring/_overview-prom.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Configure Prometheus monitoring in existing cluster KOTS installations
 
@@ -7,6 +8,8 @@ This topic describes how to monitor applications and clusters with Prometheus in
 For information about how to access Prometheus, Grafana, and Alertmanager, see [Access Dashboards Using Port Forwarding](/enterprise/monitoring-access-dashboards).
 
 For information about consuming Prometheus metrics externally in kURL installations, see [Consume Prometheus Metrics Externally](monitoring-external-prometheus).
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/enterprise/snapshots-configuring-hostpath.md
+++ b/docs/enterprise/snapshots-configuring-hostpath.md
@@ -3,6 +3,7 @@ import RegistryCredNote from "../partials/snapshots/_registryCredentialsNote.mdx
 import ResticDaemonSet from "../partials/snapshots/_resticDaemonSet.mdx"
 import UpdateDefaultStorage from "../partials/snapshots/_updateDefaultStorage.mdx"
 import CheckVersion from "../partials/snapshots/_checkVersion.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Configure a host path storage destination
 
@@ -11,6 +12,8 @@ This topic describes how to install Velero and configure a host path as your sto
 :::note
 <UpdateDefaultStorage/>
 :::
+
+<KotsAvailability/>
 
 ## Requirements
 

--- a/docs/enterprise/snapshots-configuring-nfs.md
+++ b/docs/enterprise/snapshots-configuring-nfs.md
@@ -3,6 +3,7 @@ import RegistryCredNote from "../partials/snapshots/_registryCredentialsNote.mdx
 import ResticDaemonSet from "../partials/snapshots/_resticDaemonSet.mdx"
 import UpdateDefaultStorage from "../partials/snapshots/_updateDefaultStorage.mdx"
 import CheckVersion from "../partials/snapshots/_checkVersion.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Configure an NFS storage destination
 
@@ -11,6 +12,8 @@ This topic describes how to install Velero and configure a Network File System (
 :::note
 <UpdateDefaultStorage/>
 :::
+
+<KotsAvailability/>
 
 ## Requirements
 

--- a/docs/enterprise/snapshots-creating.md
+++ b/docs/enterprise/snapshots-creating.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Create and schedule backups
 
 This topic describes how to use the Replicated snapshots feature to create backups. It also includes information about how to use the Replicated KOTS Admin Console create a schedule for automatic backups. For information about restoring, see [Restore from Backups](snapshots-restoring-full).
+
+<KotsAvailability/>
 
 ## Prerequisites
 

--- a/docs/enterprise/snapshots-restoring-full.mdx
+++ b/docs/enterprise/snapshots-restoring-full.mdx
@@ -6,10 +6,13 @@ import Dr from "../partials/snapshots/_limitation-dr.mdx"
 import Os from "../partials/snapshots/_limitation-os.mdx"
 import InstallMethod from "../partials/snapshots/_limitation-install-method.mdx"
 import CliRestores from "../partials/snapshots/_limitation-cli-restores.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Restore from backups
 
 This topic describes how to restore from full or partial backups using Replicated snapshots.
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/enterprise/snapshots-storage-destinations.md
+++ b/docs/enterprise/snapshots-storage-destinations.md
@@ -1,6 +1,7 @@
 import UpdateDefaultStorage from "../partials/snapshots/_updateDefaultStorage.mdx"
 import RegistryCredNote from "../partials/snapshots/_registryCredentialsNote.mdx"
 import CheckVersion from "../partials/snapshots/_checkVersion.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Configure other storage destinations
 
@@ -11,6 +12,8 @@ To configure host path or NFS as a storage destination, see [Configure a Host Pa
 :::note
 <UpdateDefaultStorage/>
 :::
+
+<KotsAvailability/>
 
 ## Prerequisites
 

--- a/docs/enterprise/snapshots-troubleshooting-backup-restore.md
+++ b/docs/enterprise/snapshots-troubleshooting-backup-restore.md
@@ -1,8 +1,11 @@
 import NodeAgentMemLimit from "../partials/snapshots/_node-agent-mem-limit.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Troubleshoot snapshots
 
 When a snapshot fails, a support bundle will be collected and stored automatically. Because this is a point-in-time collection of all logs and system state at the time of the failed snapshot, this is a good place to view the logs.
+
+<KotsAvailability/>
 
 ## Velero is crashing
 

--- a/docs/enterprise/snapshots-updating-with-admin-console.md
+++ b/docs/enterprise/snapshots-updating-with-admin-console.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Update storage settings
 
 This topic describes how to update existing storage destination settings using the Replicated Admin Console.
+
+<KotsAvailability/>
 
 ## Prerequisite
 If you are changing from one provider to another provider, make sure that you meet the prerequisites for the storage destination. For information about prerequisites, see:

--- a/docs/enterprise/snapshots-velero-cli-installing.md
+++ b/docs/enterprise/snapshots-velero-cli-installing.md
@@ -1,3 +1,5 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Install the Velero CLI
 
 You install the Velero CLI before installing Velero and configuring a storage destination for backups.
@@ -5,6 +7,8 @@ You install the Velero CLI before installing Velero and configuring a storage de
 :::note
 For embedded clusters created with Replicated kURL, if the kURL Installer spec included the Velero add-on, then Velero was automatically installed with default internal storage. Replicated recommends that you proceed to change the default internal storage because it is insufficient for disaster recovery. See [Updating Storage Settings in the Admin Console](snapshots-updating-with-admin-console).
 :::
+
+<KotsAvailability/>
 
 ## Install the Velero CLI in an online cluster
 

--- a/docs/enterprise/snapshots-velero-installing-config.mdx
+++ b/docs/enterprise/snapshots-velero-installing-config.mdx
@@ -1,10 +1,13 @@
 import NodeAgentMemLimit from "../partials/snapshots/_node-agent-mem-limit.mdx"
 import KotsadmNamespace from "../partials/kots-cli/_kotsadm-namespace.mdx"
 import KotsadmRegistry from "../partials/kots-cli/_kotsadm-registry.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Configure namespace access and memory limit
 
 This topic describes how to configure namespace access and the memory limit for Velero.
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/enterprise/status-viewing-details.md
+++ b/docs/enterprise/status-viewing-details.md
@@ -1,10 +1,14 @@
 import StatusesTable from "../partials/status-informers/_statusesTable.mdx"
 import AggregateStatus from "../partials/status-informers/_aggregateStatus.mdx"
 import AggregateStatusIntro from "../partials/status-informers/_aggregate-status-intro.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Understand application status details in the Admin Console
 
-This topic describes how to view the status of an application on the Replicated KOTS Admin Console dashboard. It also describes how Replicated KOTS collects and aggregates the application status. 
+This topic describes how to view the status of an application on the Replicated KOTS Admin Console dashboard. It also describes how Replicated KOTS collects and aggregates the application status.
+
+<KotsAvailability/>
+
 ## View status details
 
 The application status displays on the dashboard of the Admin Console. Viewing the status details can be helpful for troubleshooting.

--- a/docs/enterprise/updating-app-manager.mdx
+++ b/docs/enterprise/updating-app-manager.mdx
@@ -4,12 +4,15 @@ import PushKotsImages from "../partials/install/_push-kotsadm-images.mdx"
 import BuildAirGapBundle from "../partials/install/_airgap-bundle-build.mdx"
 import DownloadAirGapBundle from "../partials/install/_airgap-bundle-download.mdx"
 import ViewAirGapBundle from "../partials/install/_airgap-bundle-view-contents.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Perform updates in existing clusters
 
 This topic describes how to perform updates in existing cluster installations with Replicated KOTS. It includes information about how to update applications and the version of KOTS running in the cluster.
 
 It also includes information about how the Admin Console determines version precendence. See [How the Admin Console Determines Version Precendence](/enterprise/updating-app-manager#how-the-admin-console-determines-version-precedence).
+
+<KotsAvailability/>
 
 ## Update an application
 

--- a/docs/enterprise/updating-apps.mdx
+++ b/docs/enterprise/updating-apps.mdx
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Configure automatic updates
 
 This topic describes how to configure automatic updates for applications installed in online (internet-connected) environments.
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/enterprise/updating-licenses.md
+++ b/docs/enterprise/updating-licenses.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Update licenses in the Admin Console
 
 This topic describes how to update a license from the KOTS Admin Console.
+
+<KotsAvailability/>
 
 ## Update online licenses
 

--- a/docs/enterprise/updating-patching-with-kustomize.md
+++ b/docs/enterprise/updating-patching-with-kustomize.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Patch with Kustomize
 
 This topic describes how to use Kustomize to patch an application before deploying.
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/intro-kots.mdx
+++ b/docs/intro-kots.mdx
@@ -1,4 +1,5 @@
 import Kots from "../docs/partials/kots/_kots-definition.mdx"
+import KotsAvailability from "../docs/partials/kots/_kots-availability.mdx"
 
 # Introduction to KOTS
 
@@ -7,6 +8,8 @@ This topic provides an introduction to the Replicated KOTS installer, including 
 :::note
 The Replicated KOTS entitlement is required to install applications with KOTS. For more information, see [Pricing](https://www.replicated.com/pricing) on the Replicated website.
 :::
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/partials/kots/_kots-availability.mdx
+++ b/docs/partials/kots/_kots-availability.mdx
@@ -1,0 +1,5 @@
+:::note
+Replicated KOTS is available only for existing customers. For supporting installations into customer managed clusters, we recommend Helm. For more information, see [About Helm Installations with Replicated](/vendor/helm-install-overview).
+
+KOTS is a Generally Available (GA) product for existing customers. For more information about the Replicated product lifecycle phases, see [Support Lifecycle Policy](/vendor/policies-support-lifecycle).
+:::

--- a/docs/reference/custom-resource-backup.md
+++ b/docs/reference/custom-resource-backup.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Velero Backup resource for snapshots
 
-This topic provides information about the supported fields in the Velero Backup resource for the Replicated KOTS snapshots feature. 
+This topic provides information about the supported fields in the Velero Backup resource for the Replicated KOTS snapshots feature.
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/vendor/admin-console-adding-buttons-links.mdx
+++ b/docs/vendor/admin-console-adding-buttons-links.mdx
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Add links to the dashboard
 
 This topic describes how to use the Kubernetes SIG Application custom resource to add links to the Replicated KOTS Admin Console dashboard.
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/vendor/admin-console-customize-app-icon.md
+++ b/docs/vendor/admin-console-customize-app-icon.md
@@ -1,3 +1,5 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Customize the application icon
 
 You can add a custom application icon that displays in the Replicated Admin Console and the download portal. Adding a custom icon helps ensure that your brand is reflected for your customers.
@@ -5,6 +7,8 @@ You can add a custom application icon that displays in the Replicated Admin Cons
 :::note
 You can also use a custom domain for the download portal. For more information, see [About Custom Domains](custom-domains).
 :::
+
+<KotsAvailability/>
 
 ## Add a custom icon
 

--- a/docs/vendor/admin-console-customize-config-screen.md
+++ b/docs/vendor/admin-console-customize-config-screen.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Create and edit configuration fields
 
 This topic describes how to use the Replicated Config custom resource manifest file to add and edit fields in the KOTS Admin Console configuration screen.
+
+<KotsAvailability/>
 
 ## About the Config custom resource
 

--- a/docs/vendor/admin-console-display-app-status.md
+++ b/docs/vendor/admin-console-display-app-status.md
@@ -2,10 +2,13 @@ import StatusesTable from "../partials/status-informers/_statusesTable.mdx"
 import AggregateStatus from "../partials/status-informers/_aggregateStatus.mdx"
 import AggregateStatusIntro from "../partials/status-informers/_aggregate-status-intro.mdx"
 import SupportedResources from "../partials/instance-insights/_supported-resources-status.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Add resource status informers
 
 This topic describes how to add status informers for your application. Status informers apply only to applications installed with Replicated KOTS. For information about how to collect application status data for applications installed with Helm, see [Enabling and Understanding Application Status](insights-app-status).
+
+<KotsAvailability/>
 
 ## About status informers
 

--- a/docs/vendor/admin-console-port-forward.mdx
+++ b/docs/vendor/admin-console-port-forward.mdx
@@ -7,12 +7,15 @@ import NginxK8sApp from "../partials/application-links/_nginx-k8s-app.mdx"
 import NginxService from "../partials/application-links/_nginx-service.mdx"
 import NginxDeployment from "../partials/application-links/_nginx-deployment.mdx"
 import EcCr from "../partials/getting-started/_slackernews-embedded-cluster.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Port forward services with KOTS
 
 This topic describes how to add one or more ports to the Replicated KOTS port forward tunnel by configuring the `ports` key in the Replicated Application custom resource.
 
 The information in this topic applies to existing cluster installations. For information about exposing services for Replicated kURL or Replicated Embedded Cluster installations, see [Exposing Services Using NodePorts](kurl-nodeport-services).
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/vendor/admin-console-prometheus-monitoring.mdx
+++ b/docs/vendor/admin-console-prometheus-monitoring.mdx
@@ -1,9 +1,12 @@
 import OverviewProm from "../partials/monitoring/_overview-prom.mdx"
 import LimitationEc from "../partials/monitoring/_limitation-ec.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Add custom graphs
 
 This topic describes how to customize the graphs that are displayed on the Replicated Admin Console dashboard.
+
+<KotsAvailability/>
 
 ## Overview of monitoring with Prometheus
 

--- a/docs/vendor/config-screen-about.md
+++ b/docs/vendor/config-screen-about.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # About the configuration screen
 
 This topic describes the configuration screen on the Config tab in the Replicated Admin Console.
+
+<KotsAvailability/>
 
 ## About collecting configuration values
 

--- a/docs/vendor/config-screen-conditional.mdx
+++ b/docs/vendor/config-screen-conditional.mdx
@@ -2,10 +2,13 @@ import IntegerComparison from "../partials/template-functions/_integer-compariso
 import PropertyWhen from "../partials/config/_property-when.mdx"
 import DistroCheck from "../partials/template-functions/_string-comparison.mdx"
 import NeComparison from "../partials/template-functions/_ne-comparison.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Use conditional statements in configuration fields
 
 This topic describes how to use Replicated template functions in the Config custom resource to conditionally show or hide configuration fields for your application on the Replicated KOTS Admin Console **Config** page.
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/vendor/config-screen-map-inputs.md
+++ b/docs/vendor/config-screen-map-inputs.md
@@ -1,8 +1,12 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Map user-supplied values
 
 This topic describes how to map the values that your users provide in the Replicated Admin Console configuration screen to your application.
 
 This topic assumes that you have already added custom fields to the Admin Console configuration screen by editing the Config custom resource. For more information, see [Create and Edit Configuration Fields](admin-console-customize-config-screen).
+
+<KotsAvailability/>
 
 ## Overview of mapping values
 

--- a/docs/vendor/database-config-adding-options.md
+++ b/docs/vendor/database-config-adding-options.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # About managing stateful services
 
 This topic provides recommendations for managing stateful services that you install into existing clusters.
+
+<KotsAvailability/>
 
 ## Preflight checks for stateful services
 

--- a/docs/vendor/helm-native-about.mdx
+++ b/docs/vendor/helm-native-about.mdx
@@ -7,10 +7,13 @@ import Deprecated from "../partials/helm/_replicated-deprecated.mdx"
 import KotsHelmCrDescription from "../partials/helm/_kots-helm-cr-description.mdx"
 import ReplicatedHelmMigration from "../partials/helm/_replicated-helm-migration.mdx"
 import Helm from "../partials/helm/_helm-definition.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # About distributing Helm charts with KOTS
 
 This topic provides an overview of how Replicated KOTS deploys Helm charts, including an introduction to the Replicated HelmChart custom resource, limitations of deploying Helm charts with KOTS, and more.
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/vendor/helm-native-v2-using.mdx
+++ b/docs/vendor/helm-native-v2-using.mdx
@@ -1,8 +1,11 @@
 import KotsHelmCrDescription from "../partials/helm/_kots-helm-cr-description.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Support installations with HelmChart v2
 
 This topic describes how to configure a release to support installations with the Replicated HelmChart custom resource version `kots.io/v1beta2` (HelmChart v2). For more information about HelmChart v2, see [About Distributing Helm Chart with KOTS](/vendor/helm-native-about).
+
+<KotsAvailability/>
 
 ## Configure a release to support HelmChart v2 installations
 

--- a/docs/vendor/helm-v2-migrate.md
+++ b/docs/vendor/helm-v2-migrate.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Migrate existing installations to HelmChart v2
 
 This topic describes how to migrate existing Replicated KOTS installations to the Replicated HelmChart `kots.io/v1beta2` (HelmChart v2) installation method, without having to reinstall the application. It also includes information about how to support both HelmChart v1 and HelmChart v2 installations from a single release, and lists frequently-asked questions (FAQs) related to migrating to HelmChart v2.
+
+<KotsAvailability/>
 
 ## Migrate to HelmChart v2
 

--- a/docs/vendor/operator-defining-additional-images.mdx
+++ b/docs/vendor/operator-defining-additional-images.mdx
@@ -1,8 +1,11 @@
 import AirGapBundle from "../partials/airgap/_airgap-bundle.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Define additional images
 
 This topic describes how to define additional images to be included in the `.airgap` bundle for a release.
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/vendor/operator-packaging-about.md
+++ b/docs/vendor/operator-packaging-about.md
@@ -1,3 +1,5 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # About packaging a Kubernetes operator application
 
 Kubernetes Operators can be packaged and delivered as an application using the same methods as other Kubernetes applications.
@@ -13,3 +15,5 @@ When an Operator creates an object that includes a `PodSpec`, the Operator shoul
 Even environments that aren't air gapped may need access to private images that are included as part of the application at runtime.
 
 An application includes a definition for the developer to list the additional images that are required for the application, and by exposing the local registry details (endpoint, namespace and secrets) to the application so that they can be referenced when creating a `PodSpec` at runtime.
+
+<KotsAvailability/>

--- a/docs/vendor/operator-referencing-images.md
+++ b/docs/vendor/operator-referencing-images.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Reference images
 
 This topic explains how to support the use of private image registries for applications that are packaged with Kubernetes Operators.
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/vendor/orchestrating-resource-deployment.md
+++ b/docs/vendor/orchestrating-resource-deployment.md
@@ -1,10 +1,13 @@
 import WeightLimitation from "../partials/helm/_helm-cr-weight-limitation.mdx"
 import HooksLimitation from "../partials/helm/_hooks-limitation.mdx"
 import HookWeightsLimitation from "../partials/helm/_hook-weights-limitation.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Orchestrate resource deployment
 
 This topic describes how to orchestrate the deployment order of resources deployed as part of your application. The information in this topic applies to Helm chart- and standard manifest-based applications deployed with Replicated KOTS.
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/vendor/packaging-air-gap-excluding-minio.md
+++ b/docs/vendor/packaging-air-gap-excluding-minio.md
@@ -1,3 +1,5 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Exclude minio from air gap bundles (Beta)
 
 The Replicated KOTS Admin Console requires an S3-compatible object store to store application archives and support bundles. By default, KOTS deploys MinIO to satisfy the object storage requirement. For more information about the options for installing without MinIO in existing clusters, see [Installing KOTS in Existing Clusters Without Object Storage](/enterprise/installing-stateful-component-requirements).
@@ -7,6 +9,8 @@ As a software vendor, you can exclude MinIO images from all Admin Console air ga
 :::note
 You can still retrieve a bundle with MinIO images from the KOTS release page in GitHub when this feature is enabled. See [replicatedhq/kots](https://github.com/replicatedhq/kots/releases/) in GitHub.
 :::
+
+<KotsAvailability/>
 
 To exclude MinIO from the `kotsadm.tar.gz` Admin Console air gap bundle:
 

--- a/docs/vendor/packaging-cleaning-up-jobs.md
+++ b/docs/vendor/packaging-cleaning-up-jobs.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Clean up Kubernetes jobs
 
 This topic describes how to use the Replicated KOTS `kots.io/hook-delete-policy` annotation to remove Kubernetes job objects from the cluster after they complete.
+
+<KotsAvailability/>
 
 ## About Kubernetes jobs
 

--- a/docs/vendor/packaging-include-resources.md
+++ b/docs/vendor/packaging-include-resources.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Conditionally include or exclude resources
 
 This topic describes how to conditionally include or exclude application resources from deployments based on one or more conditions.
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/vendor/packaging-ingress.md
+++ b/docs/vendor/packaging-ingress.md
@@ -1,7 +1,11 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Add cluster ingress options
 
 When delivering a configurable application, ingress can be challenging as it is very cluster specific.
 Below is an example of a flexible `ingress.yaml` file designed to work in most Kubernetes clusters, including embedded clusters created with Replicated kURL.
+
+<KotsAvailability/>
 
 ## Example
 

--- a/docs/vendor/packaging-kots-versions.md
+++ b/docs/vendor/packaging-kots-versions.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Set minimum and target versions for KOTS
 
 This topic describes how to set minimum and target version for Replicated KOTS in the KOTS [Application](/reference/custom-resource-application) custom resource.
+
+<KotsAvailability/>
 
 ## Limitation
 

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Configure KOTS RBAC
 
 This topic describes role-based access control (RBAC) for Replicated KOTS in existing cluster installations. It includes information about how to change the default cluster-scoped RBAC permissions granted to KOTS.
+
+<KotsAvailability/>
 
 ## Cluster-scoped RBAC
 

--- a/docs/vendor/resources-annotations-templating.md
+++ b/docs/vendor/resources-annotations-templating.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Template annotations
 
 This topic describes how to use Replicated template functions to template annotations for resources and objects based on user-supplied values.
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/vendor/snapshots-configuring-backups.md
+++ b/docs/vendor/snapshots-configuring-backups.md
@@ -1,8 +1,12 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Configure snapshots
 
 This topic provides information about how to configure the Velero Backup resource to enable Replicated KOTS snapshots for an application.
 
 For more information about snapshots, see [About Backup and Restore with snapshots](/vendor/snapshots-overview).
+
+<KotsAvailability/>
 
 ## Storage class requirement
 

--- a/docs/vendor/snapshots-hooks.md
+++ b/docs/vendor/snapshots-hooks.md
@@ -1,6 +1,10 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Configure backup and restore hooks for snapshots
 
 This topic describes the use of custom backup and restore hooks and demonstrates a common example.
+
+<KotsAvailability/>
 
 ## About backup and restore hooks
 

--- a/docs/vendor/snapshots-overview.mdx
+++ b/docs/vendor/snapshots-overview.mdx
@@ -6,6 +6,7 @@ import Os from "../partials/snapshots/_limitation-os.mdx"
 import InstallMethod from "../partials/snapshots/_limitation-install-method.mdx"
 import CliRestores from "../partials/snapshots/_limitation-cli-restores.mdx"
 import VeleroCompatibility from "../partials/snapshots/_velero-compatibility.mdx"
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # About backup and restore with snapshots
 
@@ -14,6 +15,8 @@ This topic provides an introduction to the Replicated KOTS snapshots feature for
 :::note
 <NoEcSupport/>
 :::
+
+<KotsAvailability/>
 
 ## Overview
 

--- a/docs/vendor/tutorial-adding-db-config.md
+++ b/docs/vendor/tutorial-adding-db-config.md
@@ -1,3 +1,5 @@
+import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+
 # Example: Adding database configuration options
 
 In this tutorial, we'll explore ways to give your end user the option to either embed a database instance with the application, or connect your application to an external database instance that they will manage.
@@ -24,6 +26,8 @@ This guide assumes you have:
 A full example of the code for this guide can be found in the [kotsapps repository](https://github.com/replicatedhq/kotsapps/tree/master/postgres-snapshots).
 
 * * *
+
+<KotsAvailability/>
 
 ## The example application
 


### PR DESCRIPTION
Preview link: https://deploy-preview-4167--replicated-docs.netlify.app/intro-kots

## Summary
- Adds a `KotsAvailability` reusable partial (mirroring the existing `KurlAvailability` pattern on all kURL pages)
- Note informs users that KOTS is available only for existing customers and recommends Helm for installations into customer-managed clusters
- Added to all 60 KOTS section pages across `vendor/`, `enterprise/`, and `reference/` directories

## Note content
> Replicated KOTS is available only for existing customers. For supporting installations into customer managed clusters, we recommend Helm. For more information, see About Helm Installations with Replicated.
>
> KOTS is a Generally Available (GA) product for existing customers. For more information about the Replicated product lifecycle phases, see Support Lifecycle Policy.

## Test plan
- [ ] Preview the docs site and verify the note renders correctly on KOTS pages
- [ ] Verify links to Helm install overview and Support Lifecycle Policy work
- [ ] Spot check a few pages in each section (vendor, enterprise, reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)