### PR TITLE
Document defaultTheme branding field for EP v2

### DIFF
--- a/docs/vendor/enterprise-portal-v2-branding.mdx
+++ b/docs/vendor/enterprise-portal-v2-branding.mdx
@@ -27,6 +27,7 @@ branding:
   contact: "support@acme.com"
   supportPortalLink: "https://support.acme.com"
   background: minimal
+  defaultTheme: light
 
   # Login page footer. Customize or remove these to brand your login page.
   # Warning: removing the login footer without a custom domain may cause
@@ -68,6 +69,7 @@ customCSS: |
 | `supportPortalLink` | URL | External support link, max 2048 chars (http/https only) |
 | `loginFooterText` | string | Login page footer text, max 255 chars. Omit to use defaults. Set to empty string to hide. |
 | `loginFooterLinks` | list | Login page footer links. Each item has `label` (string, max 255 chars) and `url` (http/https, max 2048 chars). Omit to use defaults. Set to empty list to hide. |
+| `defaultTheme` | enum | Default color mode for new visitors: `light` or `dark`. When not set, defaults to `dark`. Customers can still toggle between light and dark mode; this setting controls the initial experience before they choose. |
 
 ## Login page footer
 

--- a/docs/vendor/enterprise-portal-v2-branding.mdx
+++ b/docs/vendor/enterprise-portal-v2-branding.mdx
@@ -27,7 +27,7 @@ branding:
   contact: "support@acme.com"
   supportPortalLink: "https://support.acme.com"
   background: minimal
-  defaultTheme: light
+  # defaultTheme: dark  # set to "light" if your branding is designed for light mode
 
   # Login page footer. Customize or remove these to brand your login page.
   # Warning: removing the login footer without a custom domain may cause


### PR DESCRIPTION
## Summary
- Adds `defaultTheme` field (`light` or `dark`) to the branding fields table
- Adds `defaultTheme: light` to the example theme.yaml
- Vendors can now set the default color mode for new visitors who haven't toggled yet

Shipped in vandoor #9995 (v2026.06.11-5). Closes sc-138247.

## Test plan
- [ ] Verify branding fields table renders correctly with new row
- [ ] Verify example theme.yaml includes the new field
- [ ] Preview build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)