### PR TITLE
Clean up EC v3 docs: remove stale limitations, legacy refs, fix examples

### DIFF
--- a/embedded-cluster/embedded-overview.mdx
+++ b/embedded-cluster/embedded-overview.mdx
@@ -15,9 +15,7 @@ This topic provides an introduction to Replicated Embedded Cluster.
 
 * Embedded Cluster v3 (Beta) does not support disaster recovery.
 
-* Some Replicated template functions are not implemented in Embedded Cluster v3 (Beta). Contact Replicated if a missing template function blocks your release.
-
-* Embedded Cluster v3 (Beta) does not support custom node roles. You can assign nodes the `controller` or `worker` role.
+* The following Replicated template functions are not supported in Embedded Cluster v3: `HasLocalRegistry`, `LocalRegistryAddress`, `LocalRegistryHost`, `LocalRegistryNamespace`, and `LocalImageName`. Use `ReplicatedImageName` and `ReplicatedImageRegistry` instead. See [Template Functions for Embedded Cluster](template-functions).
 
 ## Built-in extensions {#built-in-extensions}
 
@@ -68,7 +66,7 @@ Embedded Cluster host preflight checks have the following limitations:
 
 ## Multi-node installations
 
-Embedded Cluster supports installations in mutli-node clusters. Your end customers can add nodes to a cluster during or after installation from the UI.
+Embedded Cluster supports installations in multi-node clusters. Your end customers can add nodes to a cluster during or after installation from the UI, the CLI, or the [external API](embedded-cluster-external-api).
 
 Embedded Cluster automatically enables high availability (HA) when at least three controller nodes are present in the cluster.
 

--- a/embedded-cluster/embedded-using.mdx
+++ b/embedded-cluster/embedded-using.mdx
@@ -208,25 +208,24 @@ Using the NVIDIA GPU Operator with Embedded Cluster requires configuring the con
 
 ```yaml
 # Embedded Cluster Config
-
+apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: Config
+spec:
   extensions:
-    helm:
-      repositories:
-        - name: nvidia
-          url: https://nvidia.github.io/gpu-operator
-      charts:
-        - name: gpu-operator
-          chartname: nvidia/gpu-operator
-          namespace: gpu-operator
-          version: "v24.9.1"
-          values: |
-            # configure the containerd options
-            toolkit:
-             env:
-             - name: CONTAINERD_CONFIG
-               value: /etc/k0s/containerd.d/nvidia.toml
-             - name: CONTAINERD_SOCKET
-               value: /run/k0s/containerd.sock
+    helmCharts:
+      - chart:
+          name: gpu-operator
+          chartVersion: "v24.9.1"
+        releaseName: gpu-operator
+        namespace: gpu-operator
+        values: |
+          # configure the containerd options
+          toolkit:
+            env:
+            - name: CONTAINERD_CONFIG
+              value: /etc/k0s/containerd.d/nvidia.toml
+            - name: CONTAINERD_SOCKET
+              value: /run/k0s/containerd.sock
 ```
 
 ### containerd known issue

--- a/embedded-cluster/embedded-using.mdx
+++ b/embedded-cluster/embedded-using.mdx
@@ -204,7 +204,7 @@ The NVIDIA GPU Operator uses the operator framework within Kubernetes to automat
 
 You can include the NVIDIA GPU Operator in your release as an additional Helm chart, or using Embedded Cluster Helm extensions. For information about adding Helm extensions, see [extensions](embedded-config#extensions) in _Embedded Cluster Config_.
 
-Using the NVIDIA GPU Operator with Embedded Cluster requires configuring the containerd options in the operator as follows:
+To use the NVIDIA GPU Operator as a Helm extension, package the GPU Operator chart as a `.tgz` archive and include it in your release. Then configure the containerd options in the Embedded Cluster Config as follows:
 
 ```yaml
 # Embedded Cluster Config

--- a/embedded-cluster/embedded-v3-migrate.mdx
+++ b/embedded-cluster/embedded-v3-migrate.mdx
@@ -46,7 +46,7 @@ If you have config fields that need to be vendor-controlled and updateable acros
 
 ### Automatic authentication to the Replicated proxy registry
 
-If your application uses the Replicated proxy registry, Embedded Cluster v2 configures the cluster to automatically authenticate to the proxy registry for all pods. This means that it's no longer necessary to manually inject a Replicated pull secret using the ImagePullSecretName template function.
+If your application uses the Replicated proxy registry, Embedded Cluster v3 configures the cluster to automatically authenticate to the proxy registry for all pods. This means that it's no longer necessary to manually inject a Replicated pull secret using the ImagePullSecretName template function.
 
 ### Changes to Application custom resource fields {#application-cr-changes}
 
@@ -139,9 +139,17 @@ To update a release from Embedded Cluster v2 to v3:
 
 1. Test the installation using a development customer.
 
+### Installer wizard differences
+
+The Embedded Cluster v3 installer wizard includes a **Set Up** page where end customers provide cluster-level settings such as proxy configuration. In Embedded Cluster v2, these settings were passed as CLI flags at install time.
+
 ## Migrate an installation from Embedded Cluster v2 to Embedded Cluster v3
 
-Embedded Cluster supports upgrading existing installations from v2 to v3 without having to reinstall the application.
+Embedded Cluster supports upgrading existing installations from v2 to v3 without having to reinstall the application. The migration uses the same `upgrade` command as any v3-to-v3 upgrade. The v3 binary automatically detects the v2 installation and handles the migration, prompting the user to confirm.
+
+:::note
+Releases that use Embedded Cluster v3 will not appear as available updates in the Embedded Cluster v2 KOTS Admin Console. This is by design to prevent accidental migrations. Your customers will need to get the v3 release from the [Enterprise Portal](/vendor/enterprise-portal-about) or by downloading the binary directly. Plan to communicate this to your customer base when you promote a v3-enabled release.
+:::
 
 To migrate an existing installation to Embedded Cluster v3:
 

--- a/embedded-cluster/installing-embedded-air-gap.mdx
+++ b/embedded-cluster/installing-embedded-air-gap.mdx
@@ -6,7 +6,7 @@ This topic describes how to install an application with Replicated Embedded Clus
 
 ## Overview
 
-Building an air gap bundle for a release with an Embedded Cluster Config produces both an application air gap bundle and an Embedded Cluster air gap bundle. You can use the application air gap bundle for air gap installations with Replicated kURL or with Replicated KOTS in an existing cluster. Use the Embedded Cluster air gap bundle for air gap installations with Embedded Cluster.
+Building an air gap bundle for a release with an Embedded Cluster Config produces an Embedded Cluster air gap bundle that contains everything needed to install in an air-gapped environment.
 
 The Embedded Cluster air gap bundle contains the assets normally found in an application air gap bundle (`airgap.yaml`, `app.tar.gz`, and an images directory). It also includes an `embedded-cluster` directory with the assets needed to install the infrastructure (Embedded Cluster/k0s and [extensions](embedded-config#extensions)).
 

--- a/embedded-cluster/installing-embedded.mdx
+++ b/embedded-cluster/installing-embedded.mdx
@@ -40,8 +40,6 @@ To install from the Vendor Portal:
 
 1. On a Linux machine, run the three commands from the dialog in order: download the archive, extract it, then run the install command.
 
-   After extraction, you may see additional binaries and artifacts compared to Embedded Cluster 2.x. Embedded Cluster uses these internally. You can ignore them.
-
 1. Complete any prompts from the install command (for example, acceptance of a self-signed certificate and installer password).
 
 1. Open the URL from the install output in a browser to open the installer UI.
@@ -50,7 +48,7 @@ To install from the Vendor Portal:
 
 1. On the **Configure** page, enter the configuration values for your application.
 
-1. On the **Set Up** page, provide any information required for the cluster installation. This corresponds to values you previously passed with install flags in Embedded Cluster 2.x (for example, proxy settings).
+1. On the **Set Up** page, provide any information required for the cluster installation (for example, proxy settings).
 
 1. On the **Run** page, start the installation and wait for it to complete.
 
@@ -77,8 +75,6 @@ To install using the CLI:
 1. In the **Select a version** field (or equivalent), choose the application version you promoted to that channel for testing, or leave the latest version selected if that is what you want to install.
 
 1. On a Linux machine, run the first two commands from the dialog (download the archive, then extract it).
-
-   After extraction, you may see additional binaries and artifacts compared to Embedded Cluster 2.x. Embedded Cluster uses these internally. You can ignore them.
 
 1. For the third command, run `install` with the following flags:
 


### PR DESCRIPTION
## Summary
- Remove stale custom node roles limitation from overview (custom roles with labels and taints have shipped)
- Replace vague "some template functions are not implemented" limitation with the specific list of 5 unsupported legacy functions and point to their replacements
- Remove unnecessary kURL/KOTS reference from air gap install overview
- Remove Embedded Cluster 2.x comparison notes from online install page (confusing for new v3 users who never used v2)
- Move v2 Setup page context to the migration page where v2 users will find it
- Fix multi-node description to include CLI and external API join methods (not just UI)
- Fix NVIDIA GPU operator example to use the v3 `extensions.helmCharts` format instead of the old `extensions.helm.repositories/charts` format
- Fix v2/v3 typo in proxy auth section of migration page ("Embedded Cluster v2 configures" should be "v3")
- Add note to migration page that v3 releases won't appear in the v2 KOTS Admin Console, so vendors need to steer customers to EP or communicate out-of-band
- Clarify that v2-to-v3 migration uses the same `upgrade` command as any v3-to-v3 upgrade

## Test plan
- [ ] Local docs preview renders all changed pages correctly
- [ ] All cross-page links resolve
- [ ] NVIDIA GPU operator example validates against EC Config schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)