### PR TITLE
Update Enterprise Portal v2 defaults docs

### DIFF
--- a/docs/vendor/custom-domains-using.md
+++ b/docs/vendor/custom-domains-using.md
@@ -69,6 +69,12 @@ To add and verify a custom domain:
 
 After you add one or more custom domains in the Vendor Portal, you can configure your application to use the domains. 
 
+### Configure Enterprise Portal domains {#enterprise-portal}
+
+The New Enterprise Portal has its own domain settings. To add or manage a custom domain for the New Enterprise Portal, go to **Enterprise Portal > Domains** in the Vendor Portal.
+
+For teams using only the New Enterprise Portal, Download Portal domains are not shown on the **Custom Domains** page. If your team uses both the Classic and New Enterprise Portal, manage Classic Enterprise Portal and Download Portal domains from **Custom Domains**, and manage New Enterprise Portal domains from **Enterprise Portal > Domains**.
+
 ### Configure Embedded Cluster to use custom domains {#ec}
 
 You can configure Replicated Embedded Cluster to use your custom domains for the Replicated proxy registry and Replicated app service. For more information about Embedded Cluster, see [Embedded Cluster Overview](/embedded-cluster/v3/embedded-overview).

--- a/docs/vendor/custom-domains-using.md
+++ b/docs/vendor/custom-domains-using.md
@@ -71,9 +71,9 @@ After you add one or more custom domains in the Vendor Portal, you can configure
 
 ### Configure Enterprise Portal domains {#enterprise-portal}
 
-The New Enterprise Portal has its own domain settings. To add or manage a custom domain for the New Enterprise Portal, go to **Enterprise Portal > Domains** in the Vendor Portal.
+The New Enterprise Portal has its own domain settings. To add or manage a New Enterprise Portal custom domain, go to **Enterprise Portal > Domains**.
 
-For teams using only the New Enterprise Portal, Download Portal domains are not shown on the **Custom Domains** page. If your team uses both the Classic and New Enterprise Portal, manage Classic Enterprise Portal and Download Portal domains from **Custom Domains**, and manage New Enterprise Portal domains from **Enterprise Portal > Domains**.
+Teams that use only the New Enterprise Portal do not see Download Portal domains on the **Custom Domains** page. In mixed mode, use **Custom Domains** for Classic Enterprise Portal and Download Portal domains. Use **Enterprise Portal > Domains** for New Enterprise Portal domains.
 
 ### Configure Embedded Cluster to use custom domains {#ec}
 

--- a/docs/vendor/enterprise-portal-v2-about.mdx
+++ b/docs/vendor/enterprise-portal-v2-about.mdx
@@ -39,7 +39,7 @@ The new Enterprise Portal is a complete rebuild of the customer portal experienc
 
 ## Requirements
 
-The New Enterprise Portal must be enabled for your team. It is enabled by default for new Replicated teams. If your team is already using the Classic Enterprise Portal and you do not see the New Enterprise Portal pages in the Vendor Portal, contact your Replicated account representative.
+Replicated enables the New Enterprise Portal by default for new teams. If your existing team uses the Classic Enterprise Portal, check the Vendor Portal for New Enterprise Portal pages. Contact your Replicated account representative if you do not see them.
 
 Some Enterprise Portal capabilities require additional access:
 
@@ -49,13 +49,13 @@ Some Enterprise Portal capabilities require additional access:
 
 ## For vendors already using the Classic Enterprise Portal
 
-If your team is already using the Classic Enterprise Portal with customers, you can adopt the new Enterprise Portal incrementally without disrupting any existing customer experience by running both portal versions in mixed mode.
+If your team already uses the Classic Enterprise Portal, you can adopt the New Enterprise Portal incrementally. To avoid disrupting existing customers, run both portal versions in mixed mode.
 
 The new Enterprise Portal runs at a different domain (`{appSlug}.enterpriseportal.app`) than Classic (`get.replicated.com/{appSlug}/...`). Both portals share the same backend, so customer data, licenses, and instance information are consistent across both.
 
 ### How to get started
 
-1. **Enable mixed mode.** Contact Replicated to enable the New Enterprise Portal alongside the Classic Enterprise Portal for your team. This has no effect on any customer's portal until you move customers to the new version.
+1. **Enable mixed mode.** Contact Replicated to run the New Enterprise Portal alongside the Classic Enterprise Portal. Customers continue using their current portal until you move them to the new version.
 1. **Connect a content repo.** Follow the setup steps in [Connect a Git Repo](/vendor/enterprise-portal-v2-connect-repo). Connecting a repo has zero effect on any customer's portal version. No customer sees the new portal until you explicitly switch them.
 1. **Test it yourself.** Use the local CLI preview (`replicated enterprise-portal preview`) or open the new portal URL directly to see how your content renders. The Vendor Portal also has a "Login as customer" button on each customer's EP access tab.
 1. **Move individual customers.** On the customer's **Enterprise Portal access** tab in Vendor Portal, set the **Portal Version** toggle to use the new Enterprise Portal. Only that customer is affected.
@@ -63,4 +63,4 @@ The new Enterprise Portal runs at a different domain (`{appSlug}.enterpriseporta
 
 ### Vendor Portal view vs. customer portal version
 
-The **New Portal** / **Classic Portal** toggle at the top of the Enterprise Portal page in Vendor Portal appears only in mixed mode. It controls which view *you* see as a vendor. It does not change which portal your customers see. Customer portal versions are controlled individually via the Portal Version toggle on each customer's EP access tab.
+The **New Portal** / **Classic Portal** toggle appears only in mixed mode. It controls the Vendor Portal view that you see. It does not change which portal your customers see. Use the Portal Version toggle on each customer's EP access tab to change their portal.

--- a/docs/vendor/enterprise-portal-v2-about.mdx
+++ b/docs/vendor/enterprise-portal-v2-about.mdx
@@ -1,7 +1,7 @@
 # About the Enterprise Portal
 
 :::important Alpha Feature
-Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
+Features described on this page are in alpha and subject to change. Some capabilities might require additional access.
 :::
 
 The Enterprise Portal gives your customers one central place to view their install and upgrade instructions for each version of your software, set up their environment, manage their team, and get troubleshooting support by uploading support bundles.
@@ -39,23 +39,23 @@ The new Enterprise Portal is a complete rebuild of the customer portal experienc
 
 ## Requirements
 
-The following feature flags must be enabled by Replicated for your team:
+The New Enterprise Portal must be enabled for your team. It is enabled by default for new Replicated teams. If your team is already using the Classic Enterprise Portal and you do not see the New Enterprise Portal pages in the Vendor Portal, contact your Replicated account representative.
 
-* GitHub App Integration in Vendor Portal
-* Enable Customer Emails in Enterprise Portal
-* Enterprise Portal Customization
-* Enable Security Center in Enterprise Portal
-* Terraform Modules in Enterprise Portal (available to teams on the Business or Enterprise pricing plan)
+Some Enterprise Portal capabilities require additional access:
+
+* Customer email customization
+* Security Center
+* Terraform module distribution, available to teams on the Business or Enterprise pricing plan
 
 ## For vendors already using the Classic Enterprise Portal
 
-If your team is already using the Classic Enterprise Portal with customers, you can adopt the new Enterprise Portal incrementally without disrupting any existing customer experience.
+If your team is already using the Classic Enterprise Portal with customers, you can adopt the new Enterprise Portal incrementally without disrupting any existing customer experience by running both portal versions in mixed mode.
 
 The new Enterprise Portal runs at a different domain (`{appSlug}.enterpriseportal.app`) than Classic (`get.replicated.com/{appSlug}/...`). Both portals share the same backend, so customer data, licenses, and instance information are consistent across both.
 
 ### How to get started
 
-1. **Request the feature flags.** Contact Replicated to enable the new Enterprise Portal flags for your team. This has no effect on any customer's portal.
+1. **Enable mixed mode.** Contact Replicated to enable the New Enterprise Portal alongside the Classic Enterprise Portal for your team. This has no effect on any customer's portal until you move customers to the new version.
 1. **Connect a content repo.** Follow the setup steps in [Connect a Git Repo](/vendor/enterprise-portal-v2-connect-repo). Connecting a repo has zero effect on any customer's portal version. No customer sees the new portal until you explicitly switch them.
 1. **Test it yourself.** Use the local CLI preview (`replicated enterprise-portal preview`) or open the new portal URL directly to see how your content renders. The Vendor Portal also has a "Login as customer" button on each customer's EP access tab.
 1. **Move individual customers.** On the customer's **Enterprise Portal access** tab in Vendor Portal, set the **Portal Version** toggle to use the new Enterprise Portal. Only that customer is affected.
@@ -63,4 +63,4 @@ The new Enterprise Portal runs at a different domain (`{appSlug}.enterpriseporta
 
 ### Vendor Portal view vs. customer portal version
 
-The **New Portal** / **Classic Portal** toggle at the top of the Enterprise Portal page in Vendor Portal controls which view *you* see as a vendor. It does not change which portal your customers see. Customer portal versions are controlled individually via the Portal Version toggle on each customer's EP access tab.
+The **New Portal** / **Classic Portal** toggle at the top of the Enterprise Portal page in Vendor Portal appears only in mixed mode. It controls which view *you* see as a vendor. It does not change which portal your customers see. Customer portal versions are controlled individually via the Portal Version toggle on each customer's EP access tab.

--- a/docs/vendor/enterprise-portal-v2-connect-repo.mdx
+++ b/docs/vendor/enterprise-portal-v2-connect-repo.mdx
@@ -1,10 +1,12 @@
 # Connect a Git Repo
 
 :::important Alpha Feature
-Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
+Features described on this page are in alpha and subject to change. Some capabilities might require additional access.
 :::
 
 Enterprise Portal content is driven by a GitHub repo you control. Connecting a repo is a prerequisite to offer versioned docs, advanced theming, and Terraform module delivery.
+
+The Content tab is available when the New Enterprise Portal is enabled for your team. The same New Enterprise Portal setting also enables the GitHub App workflow used to create, authorize, and link content repositories.
 
 The Vendor Portal walks you through setup in three steps:
 

--- a/docs/vendor/enterprise-portal-v2-connect-repo.mdx
+++ b/docs/vendor/enterprise-portal-v2-connect-repo.mdx
@@ -6,7 +6,7 @@ Features described on this page are in alpha and subject to change. Some capabil
 
 Enterprise Portal content is driven by a GitHub repo you control. Connecting a repo is a prerequisite to offer versioned docs, advanced theming, and Terraform module delivery.
 
-The Content tab is available when the New Enterprise Portal is enabled for your team. The same New Enterprise Portal setting also enables the GitHub App workflow used to create, authorize, and link content repositories.
+The Content tab appears when your team has the New Enterprise Portal. The same setting enables the GitHub App workflow for content repositories. Use this workflow to create, authorize, and link repos.
 
 The Vendor Portal walks you through setup in three steps:
 

--- a/docs/vendor/enterprise-portal-v2-invite.mdx
+++ b/docs/vendor/enterprise-portal-v2-invite.mdx
@@ -14,7 +14,7 @@ For vendors using both Classic and New Enterprise Portal (mixed mode), customer 
 - Team admins can use the **Portal Version** toggle to choose whether the customer sees Classic or New
 - Customers on the New portal access it at `{appSlug}.enterpriseportal.app` (or your custom domain)
 
-For vendors on the New Enterprise Portal only, Enterprise Portal is always enabled for all customers. No app-level or per-customer enable toggle is needed.
+For vendors on the New Enterprise Portal only, all customers can access the portal. You do not need an app-level or per-customer enable toggle.
 
 ## Inviting users
 
@@ -27,7 +27,7 @@ To invite a customer's end user to the portal:
 
 You can also enable **Automatically invite customer email to Enterprise Portal on creation** so that every new customer with an email address receives an invite automatically.
 
-For teams using only the New Enterprise Portal, go to **Enterprise Portal > Customer Access** and enable the automatic invitation setting in the **Customer invitations** section. In mixed mode, automatic invitations require the app-level **Enable Enterprise Portal for all customers** setting.
+For teams using only the New Enterprise Portal, go to **Enterprise Portal > Customer Access**. In the **Customer invitations** section, enable automatic invitations. In mixed mode, automatic invitations require the app-level **Enable Enterprise Portal for all customers** setting.
 
 For vendors in mixed mode (both Classic and New enabled), the customer creation screen includes a **Use new Enterprise Portal for this customer** checkbox. When checked, the customer is enrolled in the New portal and any auto-invite email points them to the New portal URL instead of Classic. This checkbox is only visible to team admins. When unchecked or not visible, new customers default to Classic.
 

--- a/docs/vendor/enterprise-portal-v2-invite.mdx
+++ b/docs/vendor/enterprise-portal-v2-invite.mdx
@@ -1,7 +1,7 @@
 # Manage Customer Access
 
 :::important Alpha Feature
-Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
+Features described on this page are in alpha and subject to change. Some capabilities might require additional access.
 :::
 
 This topic describes how to control which customers can access the new Enterprise Portal and how to manage their portal users from the Vendor Portal.
@@ -11,10 +11,10 @@ This topic describes how to control which customers can access the new Enterpris
 For vendors using both Classic and New Enterprise Portal (mixed mode), customer access is controlled per-customer:
 
 - On the customer's **Enterprise Portal access** tab, toggle **Enable Enterprise Portal for this customer** to grant access
-- Use the **Portal Version** toggle to choose whether the customer sees Classic or New
+- Team admins can use the **Portal Version** toggle to choose whether the customer sees Classic or New
 - Customers on the New portal access it at `{appSlug}.enterpriseportal.app` (or your custom domain)
 
-For vendors on the New Enterprise Portal only, Enterprise Portal is always enabled for all customers. No per-customer enable toggle is needed.
+For vendors on the New Enterprise Portal only, Enterprise Portal is always enabled for all customers. No app-level or per-customer enable toggle is needed.
 
 ## Inviting users
 
@@ -26,6 +26,8 @@ To invite a customer's end user to the portal:
 1. The user receives an email with an invitation link to activate their account
 
 You can also enable **Automatically invite customer email to Enterprise Portal on creation** so that every new customer with an email address receives an invite automatically.
+
+For teams using only the New Enterprise Portal, go to **Enterprise Portal > Customer Access** and enable the automatic invitation setting in the **Customer invitations** section. In mixed mode, automatic invitations require the app-level **Enable Enterprise Portal for all customers** setting.
 
 For vendors in mixed mode (both Classic and New enabled), the customer creation screen includes a **Use new Enterprise Portal for this customer** checkbox. When checked, the customer is enrolled in the New portal and any auto-invite email points them to the New portal URL instead of Classic. This checkbox is only visible to team admins. When unchecked or not visible, new customers default to Classic.
 

--- a/docs/vendor/releases-creating-customer.mdx
+++ b/docs/vendor/releases-creating-customer.mdx
@@ -31,8 +31,10 @@ To create a customer:
 1. (Optional) Disable the **Send Enterprise Portal invite to customer email** checkbox if you don't want the Enterprise Portal to automatically send this customer an invitation. If you disable the checkbox, you can manually invite the customer to the Enterprise Portal later.
 
     :::note
-    The **Send Enterprise Portal invite to customer email** checkbox appears only when the Enterprise Portal is enabled globally for all customers. For more information, see [Automatically invite customers on creation](enterprise-portal-invite#auto-invite) in _Manage Enterprise Portal customer access_.
+    For teams using only the New Enterprise Portal, this checkbox appears because Enterprise Portal access is always enabled for all customers. For teams using the Classic Enterprise Portal or mixed mode, this checkbox appears only when Enterprise Portal is enabled globally for all customers. For more information, see [Automatically invite customers on creation](enterprise-portal-invite#auto-invite) in _Manage Enterprise Portal customer access_ and [Inviting users](/vendor/enterprise-portal-v2-invite#inviting-users) in _Manage Customer Access_.
     :::
+
+1. (Mixed mode only) To enroll this customer in the New Enterprise Portal, enable **Use new Enterprise Portal for this customer**. This option is available only to team admins when both the Classic and New Enterprise Portal are enabled for your team.
 
 1. For **Assigned channel**, assign the customer to one of your channels. You can select any channel that has at least one release. The channel a customer is assigned to determines the application releases that they can install.
 

--- a/docs/vendor/releases-creating-customer.mdx
+++ b/docs/vendor/releases-creating-customer.mdx
@@ -31,10 +31,10 @@ To create a customer:
 1. (Optional) Disable the **Send Enterprise Portal invite to customer email** checkbox if you don't want the Enterprise Portal to automatically send this customer an invitation. If you disable the checkbox, you can manually invite the customer to the Enterprise Portal later.
 
     :::note
-    For teams using only the New Enterprise Portal, this checkbox appears because Enterprise Portal access is always enabled for all customers. For teams using the Classic Enterprise Portal or mixed mode, this checkbox appears only when Enterprise Portal is enabled globally for all customers. For more information, see [Automatically invite customers on creation](enterprise-portal-invite#auto-invite) in _Manage Enterprise Portal customer access_ and [Inviting users](/vendor/enterprise-portal-v2-invite#inviting-users) in _Manage Customer Access_.
+    For teams using only the New Enterprise Portal, this checkbox appears for every customer. For teams using the Classic Enterprise Portal or mixed mode, this checkbox appears only after you enable Enterprise Portal globally for all customers. For more information, see [Automatically invite customers on creation](enterprise-portal-invite#auto-invite) in _Manage Enterprise Portal customer access_. See also [Inviting users](/vendor/enterprise-portal-v2-invite#inviting-users) in _Manage Customer Access_.
     :::
 
-1. (Mixed mode only) To enroll this customer in the New Enterprise Portal, enable **Use new Enterprise Portal for this customer**. This option is available only to team admins when both the Classic and New Enterprise Portal are enabled for your team.
+1. (Mixed mode only) To enroll this customer in the New Enterprise Portal, enable **Use new Enterprise Portal for this customer**. Only team admins see this option.
 
 1. For **Assigned channel**, assign the customer to one of your channels. You can select any channel that has at least one release. The channel a customer is assigned to determines the application releases that they can install.
 
@@ -167,4 +167,4 @@ For more information about the data fields in the CSV downloads, see [Data Dicti
 
 ## Replace a license in an existing installation
 
-Unless the existing customer is using a Community license, it is not possible to replace one license with another license without reinstalling the application. When you need to make changes to a customer's entitlements, Replicated recommends that you edit the customer's license details in the Vendor Portal, rather than issuing a new license. For more information, see [Community Licenses](licenses-about-types).
+You can replace a Community license with another license without reinstalling the application. For other license types, you must reinstall the application to replace a license. To change a customer's entitlements, edit the customer's license details in the Vendor Portal instead of issuing a new license. For more information, see [Community Licenses](licenses-about-types).


### PR DESCRIPTION
  Updates Enterprise Portal docs to match the EP v2 flag cleanup and new-team defaults:

  - Documents that the New Enterprise Portal is enabled by default for new Replicated teams.
  - Removes references to the old separate GitHub App Integration flag and describes repo connection as part of the New Enterprise Portal flow.
  - Clarifies mixed mode behavior for teams using both Classic and New Enterprise Portal.
  - Clarifies New-only behavior for customer access, auto-invites, and custom domains.
  - Points New Enterprise Portal custom domain management to **Enterprise Portal > Domains**.