### PR TITLE
Remove unverified note about upstream image names in additionalImages

### DIFF
--- a/docs/vendor/operator-defining-additional-images.mdx
+++ b/docs/vendor/operator-defining-additional-images.mdx
@@ -21,9 +21,6 @@ KOTS supports including the following types of images in the `additionalImages` 
 
 * Public images referenced by the docker pullable image name.
 * Images pushed to a private registry that was configured in the Vendor Portal, referenced by the docker-pullable, upstream image name. For more information about configuring private registries, see [Add and Manage External Registries](/vendor/packaging-private-images).
-     :::note
-     If you use the [Replicated proxy registry](/vendor/private-images-about) for online (internet-connected) installations, be sure to use the _upstream_ image name in the `additionalImages` field, rather than referencing the location of the image at `proxy.replicated.com`.
-     :::
 * Images pushed to the Replicated registry referenced by the `registry.replicated.com` name.
 
 The following example demonstrates adding multiple images to `additionalImages`:


### PR DESCRIPTION
The behavior described in the note could not be reproduced, so removing it to avoid steering users away from `proxy.replicated.com` references that may actually work.