### PR TITLE
docs(ep-v2): correct frontmatter visible_when gating semantics

### DIFF
--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -597,7 +597,7 @@ Like `channel`, `customer_type` supports both `include` and `exclude` lists.
 
 ### Page-level visibility (frontmatter)
 
-You can also apply `visible_when` in a page's YAML frontmatter. This controls whether the page is accessible to a customer, independent of whether it appears in the navigation.
+You can also apply `visible_when` in a page's YAML frontmatter. This adds a per-page access gate on top of the navigation rules in `toc.yaml`.
 
 ```markdown
 ---
@@ -612,7 +612,9 @@ visible_when:
 Ensure your environment meets these requirements...
 ```
 
-The same `entitlements` conditions available in `toc.yaml` work in frontmatter, including built-in entitlements, custom license fields, and per-user permissions. Use this when you want a page gated even if the `toc.yaml` entry doesn't have its own `visible_when` (for example, a page reachable via internal links but not navigation).
+The same `entitlements` conditions available in `toc.yaml` work in frontmatter, including built-in entitlements, custom license fields, and per-user permissions. Use this when you want to keep the gating condition on the page itself rather than on its `toc.yaml` navigation entry.
+
+Frontmatter `visible_when` is an additional gate, not a replacement for navigation. A page must still be reachable through the navigation (or declared as an `overrides` target) for a customer to access it directly. A page that is not referenced anywhere in `toc.yaml` is not accessible, regardless of its frontmatter.
 
 ## Downloadable assets
 


### PR DESCRIPTION
## Summary

Corrects the EP v2 content docs on page-level (frontmatter) `visible_when` gating. The previous text (added in #4156) said you could use frontmatter entitlements to gate "a page reachable via internal links but not navigation." That is not how the backend behaves.

## What's wrong with the current text

Page access is gated by `CanAccessPage` in vandoor (`pkg/enterprise-portal/visibility/visibility.go`). It builds an allowlist of page paths from the `toc.yaml` navigation (plus `overrides` targets). If the repo has any navigation, that allowlist is **fail-closed**: a path not in it is denied to **every** customer, entitled or not — the frontmatter `visible_when` is never even evaluated. This is covered by a test asserting a premium/fully-entitled customer is still denied a page that isn't in the nav (`not in TOC is fail-closed`).

So:
- A page that **has** a `toc.yaml` nav entry (with no `visible_when` on the entry) → frontmatter gating works. ✅ This is the real use case.
- A page **not in navigation**, reachable only via an internal link → denied to everyone regardless of frontmatter. ❌ Not a supported gating scenario.

The old parenthetical also contradicted the main clause of the same sentence (which assumes the page *has* a `toc.yaml` entry).

## Changes

- Reframe the intro: frontmatter `visible_when` is a per-page gate **on top of** `toc.yaml` navigation rules, not independent of them.
- Replace the incorrect "reachable via internal links but not navigation" example with an accurate note: a page must still be reachable through navigation (or be an `overrides` target); a page not referenced in `toc.yaml` is inaccessible regardless of frontmatter.

Docs-only change.