### PR TITLE
Add Enterprise Portal steps to EC v2 install and upgrade docs

### DIFF
--- a/embedded-cluster_versioned_docs/version-2.0.0/installing-embedded-air-gap.mdx
+++ b/embedded-cluster_versioned_docs/version-2.0.0/installing-embedded-air-gap.mdx
@@ -32,7 +32,17 @@ Before you install, complete the following prerequisites:
 
 ## Install
 
-To install with Embedded Cluster in an air gap environment:
+### Use the Enterprise Portal for a guided install
+
+To use the guided install experience in the Enterprise Portal:
+
+1. Log in to the [Replicated Enterprise Portal](/vendor/enterprise-portal-about) with a user for your test customer.
+
+1. Follow the Linux install instructions for Embedded Cluster in an air gap environment.
+
+### Install using instructions from the Vendor Portal
+
+To install from the Vendor Portal:
 
 1. In the [Vendor Portal](https://vendor.replicated.com), go the channel where the target release was promoted to build the air gap bundle. Do one of the following:
      * If the **Automatically create airgap builds for newly promoted releases in this channel** setting is enabled on the channel, watch for the build status to complete.

--- a/embedded-cluster_versioned_docs/version-2.0.0/installing-embedded.mdx
+++ b/embedded-cluster_versioned_docs/version-2.0.0/installing-embedded.mdx
@@ -16,7 +16,17 @@ Before you install, complete the following prerequisites:
 
 ## Install
 
-To install an application with Embedded Cluster:
+### Use the Enterprise Portal for a guided install
+
+To use the guided install experience in the Enterprise Portal:
+
+1. Log in to the [Replicated Enterprise Portal](/vendor/enterprise-portal-about) with a user for your test customer.
+
+1. Follow the Linux install instructions for Embedded Cluster.
+
+### Install using instructions from the Vendor Portal
+
+To install from the Vendor Portal:
 
 1. In the [Vendor Portal](https://vendor.replicated.com), go to **Customers** and click on the target customer. Click **Install instructions > Embedded Cluster**.
 

--- a/embedded-cluster_versioned_docs/version-2.0.0/updating-embedded.mdx
+++ b/embedded-cluster_versioned_docs/version-2.0.0/updating-embedded.mdx
@@ -22,7 +22,17 @@ As shown in the diagram above, users check for available updates from the KOTS A
 
 ## Update in online clusters
 
-To perform an update with Embedded Cluster:
+### Use the Enterprise Portal for a guided upgrade
+
+To use the guided upgrade experience in the Enterprise Portal:
+
+1. Log in to the [Replicated Enterprise Portal](/vendor/enterprise-portal-about) with a user for your test customer.
+
+1. Open the **Update** tab and follow the instructions to upgrade the instance.
+
+### Update from the Admin Console
+
+To perform an update from the Admin Console:
 
 1. In the Admin Console, go to the **Version history** tab.
 


### PR DESCRIPTION
## Summary
- Add "Use the Enterprise Portal for a guided install" subsection to the v2 online install page
- Add "Use the Enterprise Portal for a guided install" subsection to the v2 air gap install page
- Add "Use the Enterprise Portal for a guided upgrade" subsection to the v2 upgrade page
- Matches the pattern already established in the v3 docs, where EP is listed as the first option before the Vendor Portal path

Closes https://app.shortcut.com/replicated/story/134233

## Test plan
- [ ] Local docs preview renders the v2 pages correctly
- [ ] EP links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)