### PR TITLE
Clarify registry auth behavior per install method

### DIFF
--- a/docs/vendor/packaging-private-registry-security.md
+++ b/docs/vendor/packaging-private-registry-security.md
@@ -25,7 +25,7 @@ All accounts with read/write access on the Vendor Portal have full access to all
 
 End customer access to the registry is read-only (pull access only). The specific credential used depends on the installation method:
 
-- **KOTS and Embedded Cluster v2 installations**: The KOTS license ID is used as both the username and password when authenticating to `registry.replicated.com` and `proxy.replicated.com`. Replicated builds the image pull secret (`dockerconfigjson`) automatically and includes it in the release payload delivered to the admin console.
+- **KOTS and Embedded Cluster v2 installations**: The KOTS license ID is used as both the username and password when authenticating to `registry.replicated.com` and `proxy.replicated.com`. Replicated builds the image pull secret (`dockerconfigjson`) automatically and includes it in the release payload delivered to the admin console. Embedded Cluster v2 installations accessed through the Enterprise Portal can also use an enterprise portal service account token.
 
 - **Helm CLI and Embedded Cluster v3 installations**: Customers authenticate using either a license ID or an enterprise portal service account token. The credentials are provided during `helm registry login` or `docker login` before installation.
 

--- a/docs/vendor/packaging-private-registry-security.md
+++ b/docs/vendor/packaging-private-registry-security.md
@@ -25,7 +25,7 @@ All accounts with read/write access on the Vendor Portal have full access to all
 
 End customer access to the registry is read-only (pull access only). The specific credential used depends on the installation method:
 
-- **KOTS and Embedded Cluster v2 installations**: The KOTS license ID is used as both the username and password when authenticating to `registry.replicated.com` and `proxy.replicated.com`. Replicated builds the image pull secret (`dockerconfigjson`) automatically and includes it in the release payload delivered to the admin console. Embedded Cluster v2 installations accessed through the Enterprise Portal can also use an enterprise portal service account token.
+- **KOTS and Embedded Cluster v2 installations**: Replicated builds the image pull secret automatically using credentials derived from the customer's license ID and includes it in the release payload delivered to the admin console. Embedded Cluster v2 installations accessed through the Enterprise Portal can also use an enterprise portal service account token.
 
 - **Helm CLI and Embedded Cluster v3 installations**: Customers authenticate using either a license ID or an enterprise portal service account token. The credentials are provided during `helm registry login` or `docker login` before installation.
 

--- a/docs/vendor/packaging-private-registry-security.md
+++ b/docs/vendor/packaging-private-registry-security.md
@@ -23,7 +23,13 @@ All accounts with read/write access on the Vendor Portal have full access to all
 
 ### End customer authentication
 
-A valid (unexpired) license file has an embedded `registry_token` value. Replicated components shipped to customers use this value to authenticate to the registry. Only pull access is enabled when authenticating using a `registry_token`. A `registry_token` has pull access to all images in the tenant's account. All requests to pull images are denied when a license expires or the expiration date is changed to a past date.
+End customer access to the registry is read-only (pull access only). The specific credential used depends on the installation method:
+
+- **KOTS and Embedded Cluster v2 installations**: The KOTS license ID is used as both the username and password when authenticating to `registry.replicated.com` and `proxy.replicated.com`. Replicated builds the image pull secret (`dockerconfigjson`) automatically and includes it in the release payload delivered to the admin console.
+
+- **Helm CLI and Embedded Cluster v3 installations**: Customers authenticate using either a license ID or an enterprise portal service account token. The credentials are provided during `helm registry login` or `docker login` before installation.
+
+In all cases, pull access is scoped to images belonging to the vendor's account. All requests to pull images are denied when a customer's license expires or the expiration date is changed to a past date.
 
 
 ## Networking and infrastructure

--- a/docs/vendor/private-images-about.md
+++ b/docs/vendor/private-images-about.md
@@ -18,9 +18,13 @@ The following diagram demonstrates how the proxy registry pulls images from your
 
 The proxy registry requires read-only credentials to your private registry to access your application images. See [Add and Manage External Registries](/vendor/packaging-private-images).
 
-After connecting your registry, the steps the enable the proxy registry vary depending on your application deployment method. For more information, see:
-* [Use the Proxy Registry with Replicated Installers](/vendor/private-images-kots)
-* [Use the Proxy Registry with Helm CLI Installations](/vendor/helm-image-registry)
+After connecting your registry, the steps to enable the proxy registry vary depending on your application deployment method:
+
+* **Helm CLI installations**: The Replicated SDK, included as a subchart, creates the image pull secret in the cluster at runtime. Customer credentials are provided during `helm registry login` before installation. For more information, see [Use the Proxy Registry with Helm CLI Installations](/vendor/helm-image-registry).
+
+* **KOTS and Embedded Cluster v2 installations**: Replicated automatically builds an image pull secret using the customer's license ID and includes it in the release payload. Image references in your manifests are rewritten to proxy-prefixed URLs (for example, `proxy.replicated.com/proxy/<app-slug>/gcr.io/my-org/my-app:latest`). For more information, see [Use the Proxy Registry with Replicated Installers](/vendor/private-images-kots).
+
+* **Embedded Cluster v3 installations**: The Embedded Cluster daemon handles registry authentication using an enterprise portal service account token instead of a license ID.
 
 ## About allowing pull-through access of public images
 


### PR DESCRIPTION
Preview links
* https://deploy-preview-4176--replicated-docs-upgrade.netlify.app/vendor/private-images-about#about-enabling-the-proxy-registry
* https://deploy-preview-4176--replicated-docs-upgrade.netlify.app/vendor/packaging-private-registry-security#end-customer-authentication

Tied to https://app.shortcut.com/replicated/story/136977/update-proxy-registry-and-registry-auth-docs-to-explain-how-auth-works-across-install-methods

## Summary
- **Registry security page**: Replaced the generic `registry_token` description with per-install-method breakdown (KOTS/EC v2 use license ID, Helm CLI/EC v3 use license ID or service account token)
- **Proxy registry overview**: Expanded "steps vary by deployment method" into concrete per-method explanations of how pull secrets are created and what credentials are used
- Fixed a typo ("steps the enable" -> "steps to enable")

Related: sc-136977

## Test plan
- [ ] Verify links to existing pages (`/vendor/private-images-kots`, `/vendor/helm-image-registry`, `/vendor/packaging-private-images`) still resolve
- [ ] Review proxy URL example format (`proxy.replicated.com/proxy/<app-slug>/...`) matches actual behavior
- [ ] Confirm EC v3 service account token description aligns with current implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)