### PR TITLE
Add install method context table to SDK overview

### DIFF
--- a/docs/vendor/replicated-sdk-overview.mdx
+++ b/docs/vendor/replicated-sdk-overview.mdx
@@ -10,7 +10,19 @@ This topic provides an introduction to using the Replicated SDK with your applic
 <SDKOverview/>
 
 For more information about the Replicated SDK API, see [Replicated SDK API](/reference/replicated-sdk-apis).
- 
+
+## How the SDK works across installation methods
+
+The Replicated SDK is deployed as a standard Kubernetes Deployment and Service. Its role and behavior vary depending on the installation method:
+
+| Installation Method | SDK Role | Notable Behavior |
+|---|---|---|
+| **Helm CLI** | Only Replicated component in the cluster | Registers the instance, creates image pull secrets, and sends all telemetry to the Vendor Portal |
+| **KOTS** | Runs alongside the KOTS admin console | Both the SDK and KOTS report telemetry independently. Reports are linked by the `KotsInstallID` header |
+| **Embedded Cluster v2** | Runs alongside KOTS and the EC operator | Same as KOTS, plus reports Embedded Cluster-specific data (cluster ID, version, and node count) |
+| **Embedded Cluster v3** | Runs alongside the EC daemon | Reports Embedded Cluster-specific data. The EC daemon handles registry authentication using a service account token |
+| **Airgap (any method)** | Runs locally without internet access | Serves license and app info from cached values. Stores telemetry in a Kubernetes Secret for collection via support bundles. Update checks and instance tags are unavailable. See [Air Gap Installations with the SDK](/vendor/replicated-sdk-airgap) |
+
 ## SDK resiliency
 
 At startup and when serving requests, the SDK retrieves and caches the latest information from the upstream Replicated APIs, including customer license information.

--- a/docs/vendor/replicated-sdk-overview.mdx
+++ b/docs/vendor/replicated-sdk-overview.mdx
@@ -18,7 +18,7 @@ The Replicated SDK is deployed as a standard Kubernetes Deployment and Service. 
 | Installation Method | SDK Role | Notable Behavior |
 |---|---|---|
 | **Helm CLI** | Only Replicated component in the cluster | Registers the instance, creates image pull secrets, and sends all telemetry to the Vendor Portal |
-| **KOTS** | Runs alongside the KOTS admin console | Both the SDK and KOTS report telemetry independently. Reports are linked by the `KotsInstallID` header |
+| **KOTS** | Runs alongside the KOTS admin console | Both the SDK and KOTS report telemetry independently. Reports are correlated server-side |
 | **Embedded Cluster v2** | Runs alongside KOTS and the EC operator | Same as KOTS, plus reports Embedded Cluster-specific data (cluster ID, version, and node count) |
 | **Embedded Cluster v3** | Runs alongside the EC daemon | Reports Embedded Cluster-specific data. The EC daemon handles registry authentication using a service account token |
 | **Airgap (any method)** | Runs locally without internet access | Serves license and app info from cached values. Stores telemetry in a Kubernetes Secret for collection via support bundles. Update checks and instance tags are unavailable. See [Air Gap Installations with the SDK](/vendor/replicated-sdk-airgap) |


### PR DESCRIPTION
Preview: https://deploy-preview-4177--replicated-docs-upgrade.netlify.app/vendor/replicated-sdk-overview#how-the-sdk-works-across-installation-methods

## Summary
- Adds a new "How the SDK works across installation methods" section to the SDK overview page
- Covers Helm CLI, KOTS, EC v2, EC v3, and airgap contexts with a table explaining the SDK's role and notable behavior in each
- Links to the existing airgap SDK page for details on air gap behavior

Related: [sc-137086](https://app.shortcut.com/replicated/story/137086/update-sdk-overview-with-more-info-about-how-it-works-in-different-contexts)

## Test plan
- [ ] Verify the table renders correctly in the docs site
- [ ] Verify the link to `/vendor/replicated-sdk-airgap` resolves
- [ ] Confirm EC v3 description aligns with current daemon behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)