### PR TITLE
docs(vendor): remove Beta label from the custom metrics page

### DIFF
--- a/docs/vendor/custom-metrics.md
+++ b/docs/vendor/custom-metrics.md
@@ -1,4 +1,4 @@
-# Configure custom metrics (Beta)
+# Configure custom metrics
 
 This topic describes how to configure an application to send custom metrics to the Replicated Vendor Portal.
 


### PR DESCRIPTION
## Summary

- Removes "(Beta)" from the H1 of the [Configure custom metrics](https://docs.replicated.com/vendor/custom-metrics) page (`docs/vendor/custom-metrics.md`). Custom Metrics (via the Replicated SDK) is moving to GA after 2+ years of vendor use.
- The sidebar label derives from the page title, so it updates automatically (no `sidebars.js` change needed).
- Intentionally left unchanged: the SDK version references on the page (`1.0.0-beta.12`, `1.0.0-beta.23` — real version numbers), and the historical "(Beta)" link in `rn-app-manager.md` (a point-in-time release note).

Pairs with the vendor-portal change that removes the matching "Beta" badge from the Custom Metrics card (replicatedhq/vandoor#10071). Shortcut: [sc-133553](https://app.shortcut.com/replicated/story/133553/move-custom-metrics-feature-to-ga-still-beta).

## Test plan

- [x] Verified locally (`npm start`) that `/vendor/custom-metrics` renders the title and sidebar entry without "(Beta)"
- [ ] Confirm GA labeling is approved (per the story's June 18 update)