### PR TITLE
Update _velero-compatibility.mdx

### DIFF
--- a/docs/partials/snapshots/_velero-compatibility.mdx
+++ b/docs/partials/snapshots/_velero-compatibility.mdx
@@ -1,5 +1,8 @@
 The following table lists which versions of Velero are compatible with each version of KOTS. For a list of the supported Kubernetes versions for each Velero version, see [Velero compatibility matrix](https://github.com/vmware-tanzu/velero#velero-compatibility-matrix) in the vmware-tanzu/velero repository.
 
+:::note If you're running KOTS with Velero 1.17+, pod volume backups using restic will fail because Velero 1.17 removed the --uploader-type=restic flag. Restores of existing restic backups still work. If you depend on snapshots, stay on Velero 1.16.x until a KOTS update with kopia support ships.
+:::
+
 | KOTS version | Velero version |
 |------|-------------|
 | 1.125.2 and later | 1.11.0 to 1.16.2 |

--- a/docs/partials/snapshots/_velero-compatibility.mdx
+++ b/docs/partials/snapshots/_velero-compatibility.mdx
@@ -1,6 +1,6 @@
 The following table lists which versions of Velero are compatible with each version of KOTS. For a list of the supported Kubernetes versions for each Velero version, see [Velero compatibility matrix](https://github.com/vmware-tanzu/velero#velero-compatibility-matrix) in the vmware-tanzu/velero repository.
 
-:::note If you're running KOTS with Velero 1.17+, pod volume backups using Restic are unavailable.  This is because Velero 1.17 removed the `--uploader-type=restic` flag. Restores of existing restic backups still work. If you depend on snapshots, stay on Velero 1.16.x until a KOTS update with Kopia support ships.
+:::note If you're running KOTS with Velero 1.17+, pod volume backups using Restic are unavailable.  This is because Velero 1.17 removed the `--uploader-type=restic` flag. Restores of existing Restic backups still work. If you depend on snapshots, stay on Velero 1.16.x until a KOTS update with Kopia support ships.
 :::
 
 | KOTS version | Velero version |

--- a/docs/partials/snapshots/_velero-compatibility.mdx
+++ b/docs/partials/snapshots/_velero-compatibility.mdx
@@ -1,6 +1,6 @@
 The following table lists which versions of Velero are compatible with each version of KOTS. For a list of the supported Kubernetes versions for each Velero version, see [Velero compatibility matrix](https://github.com/vmware-tanzu/velero#velero-compatibility-matrix) in the vmware-tanzu/velero repository.
 
-:::note If you're running KOTS with Velero 1.17+, pod volume backups using restic will fail because Velero 1.17 removed the --uploader-type=restic flag. Restores of existing restic backups still work. If you depend on snapshots, stay on Velero 1.16.x until a KOTS update with kopia support ships.
+:::note If you're running KOTS with Velero 1.17+, pod volume backups using Restic are unavailable.  This is because Velero 1.17 removed the `--uploader-type=restic` flag. Restores of existing restic backups still work. If you depend on snapshots, stay on Velero 1.16.x until a KOTS update with Kopia support ships.
 :::
 
 | KOTS version | Velero version |


### PR DESCRIPTION
Add a note explaining that Velero 1.17+ causes backup failures