### PR TITLE
Clarify how users are provisioned under SAML

### DIFF
--- a/docs/vendor/team-management-saml-auth.md
+++ b/docs/vendor/team-management-saml-auth.md
@@ -8,11 +8,24 @@ After starting out with Replicated, most teams grow, adding more developers, sup
 
 Using SAML, everyone on your team logs in with their existing usernames and passwords through your identity provider's dashboard. Users do not need to sign up through the Vendor Portal or log in with a separate Vendor Portal account, simplifying their experience.
 
+### Provisioning users with SAML
+
+When you enable SAML, you do not add new team members with the email invitation flow. Instead, you create new users in one of the following ways. Just-in-time (JIT) provisioning creates a user account automatically the first time the user logs in through your identity provider.
+
+| Method | How you add a new user | Setup |
+| :--- | :--- | :--- |
+| SCIM | Your identity provider creates and deactivates users automatically as you assign or remove the Replicated application. | Optional. Requires SAML. See [Manage SCIM Provisioning (Beta)](team-management-scim-provisioning). |
+| IdP-initiated JIT | The user logs in to the Replicated application from your identity provider dashboard, which JIT provisions their account. | Assign the application to users or groups in your identity provider. |
+| Domain-redirect JIT | The user enters an email address matching your team's domain on the Vendor Portal SAML login page. The Vendor Portal redirects them to your identity provider, which JIT provisions their account on first login. | Contact [Support](https://vendor.replicated.com/support) or your account team to enable domain redirect for your team. This is not self-service. |
+| Email invitation | An administrator invites the user by email. | Available only when you do not enable **Only allow SAML logins**. See [Invite members](team-management#invite-members). |
+
+If a user who does not yet exist in your team logs in and sees the error `No SAML-enabled teams found for email domain`, none of the preceding methods provisioned their account. For more information, see [Troubleshooting](#troubleshooting).
+
 ### Service provider-initiated login
 
 You can start the SAML sign-in flow directly from the Vendor Portal on the SAML login page at `https://vendor.replicated.com/login-saml`. Based on your team's SAML configuration, the Vendor Portal redirects you to your identity provider to complete authentication.
 
-IdP-initiated login from your identity provider dashboard is also supported. By default, this only works for existing and invited users. However, your account team can optionally enable JIT provisioning of users who input email addresses that match your team's domain. This will redirect any email with `@domain.com` to your IDP for authentication.
+You can also support IdP-initiated login from your identity provider dashboard. By default, this works only for users who already exist in your team and for users you assign the Replicated application to in your identity provider. To provision new users automatically by email domain, contact [Support](https://vendor.replicated.com/support) or your account team to enable domain redirect. Domain redirect sends any email address matching your team's domain to your identity provider for authentication. For more information, see [Provisioning users with SAML](#provisioning-users-with-saml).
 
 ### SCIM
 
@@ -126,7 +139,18 @@ To enable SAML enforcement:
 1. (Optional) Set a default policy for new accounts from the drop-down list.
 1. (Optional) Click **Change IdP Metadata** and follow the prompts to upload any changes to your metadata.
 
-You have enabled SAML on your account. For your team to use the SAML login option, you must enable access through your SAML identity provider’s dashboard. For example, if you use Okta, assign the application to users or groups. When a user clicks through to use the application, they gain access as described in [SCIM](#scim).
+You have enabled SAML on your account. For your team to use the SAML login option, you must enable access through your SAML identity provider’s dashboard. For example, if you use Okta, assign the application to users or groups. When a user clicks through to use the application, they gain access. For more information about provisioning new users, see [Provisioning users with SAML](#provisioning-users-with-saml).
+
+## Troubleshooting
+
+### Error: No SAML-enabled teams found for email domain
+
+On the Vendor Portal SAML login page (`https://vendor.replicated.com/login-saml`), a user sees this error when no SAML-enabled team authorizes their email domain. This error usually has one of the following causes:
+
+* The user does not yet exist in your team, and you have not enabled domain-redirect JIT provisioning for the domain. To let new users provision automatically by email domain, contact [Support](https://vendor.replicated.com/support) or your account team. For more information, see [Provisioning users with SAML](#provisioning-users-with-saml).
+* The email domain that the user entered does not match a domain that your team's SAML configuration authorizes. Confirm that the user entered their correct work email address.
+
+If you have assigned the user the Replicated application in your identity provider, the user can also log in from the identity provider dashboard. Your identity provider then JIT provisions their account without domain redirect.
 
 ## Disable SAML enforcement
 

--- a/docs/vendor/team-management.md
+++ b/docs/vendor/team-management.md
@@ -22,7 +22,7 @@ You can enable System for Cross-domain Identity Management (SCIM) for automated 
 By default, team administrators can invite more team members to collaborate. Invited users receive an email to activate their account. The activation link in the email is unique to the invited user. Following the activation link in the email also ensures that the invited user joins the team from which the invitation originated.
 
 :::note
-Teams that have enforced SAML-only authentication do not use the email invitation flow described in this procedure. These teams and their users must log in through their SAML provider.
+Teams that have enforced SAML-only authentication do not use the email invitation flow described in this procedure. Instead, your SAML identity provider provisions new users. For more information about provisioning users with SAML, including SCIM, just-in-time (JIT) provisioning, and domain redirect, see [Provisioning users with SAML](team-management-saml-auth#provisioning-users-with-saml).
 :::
 
 To invite a new team member:


### PR DESCRIPTION
Preview link: https://deploy-preview-4202--replicated-docs.netlify.app/vendor/team-management-saml-auth#provisioning-users-with-saml

## What

Clarifies how new team members are added when a team uses SAML, especially under SAML-only enforcement. Today the docs tell admins that SAML-only teams don't use email invites, but never explain how a brand-new user (one who doesn't yet exist in the team) actually gets created. That gap leads to support escalations.

### Changes

- **New "How users are added to your team under SAML" section** in `team-management-saml-auth.md`, with a table covering the four provisioning paths: SCIM, IdP-initiated JIT, domain-redirect JIT, and email invitation. Defines JIT in plain terms and notes that domain redirect is enabled by Support / the account team rather than self-service.
- **Rewrote the IdP-initiated login paragraph** that previously said it "only works for existing and invited users" without explaining where new users come from under SAML-only.
- **Fixed a broken cross-reference** that pointed readers to the SCIM section for a provisioning explanation it didn't contain.
- **Added a Troubleshooting section** documenting the user-facing login error `No SAML-enabled teams found for email domain`, its causes, and the fix.
- **Linked the SAML-only note** in `team-management.md` to the new provisioning section.

### Verification done

The troubleshooting entry was checked against the backend. The error fires for a not-yet-existing user only when no SAML-enabled team has the user's email domain in its authorized domains. The doc wording matches that behavior.
