### PR TITLE
docs(cmx): remove AlmaLinux from supported VM types

### DIFF
--- a/docs/vendor/testing-supported-clusters.md
+++ b/docs/vendor/testing-supported-clusters.md
@@ -499,7 +499,6 @@ CMX supports the following VM types:
 | Distribution | Versions     | Instance Types                                                                                 |
 | :----------- | :----------- | :--------------------------------------------------------------------------------------------- |
 | ubuntu       | 24.04, 22.04 | r1.small, r1.medium, r1.large, r1.xlarge, r1.2xlarge. See [Replicated Instance Types](#types). |
-| almalinux    | 8, 9, 10     | r1.small, r1.medium, r1.large, r1.xlarge, r1.2xlarge. See [Replicated Instance Types](#types). |
 
 ## Replicated instance types {#types}
 


### PR DESCRIPTION
## What this PR does

Removes AlmaLinux from the **Supported VM types** table in `docs/vendor/testing-supported-clusters.md`. AlmaLinux is no longer offered as a VM distribution in Compatibility Matrix — only Ubuntu is supported for new VMs.

Part of the cross-repo AlmaLinux removal:
- **reliability-matrix** — disable (merged) + code/image teardown (separate PR)
- **vendor-api** — no change needed (the distro list is provisioner-driven)
- **this PR** — docs

## Note on timing

The removal is rolled out at the provisioner first and reaches production via a tag push. To keep the docs consistent with what's live, this should **merge with or after the production rollout** of the AlmaLinux disable — not before (otherwise the docs would say "not supported" while prod still offers it).

## Preview

`/vendor/testing-supported-clusters#supported-vm-types` — the table now lists only `ubuntu`.
