### PR TITLE
Remove KOTS/kURL entitlement note callouts from intro pages

### DIFF
--- a/docs/intro-kots.mdx
+++ b/docs/intro-kots.mdx
@@ -5,10 +5,6 @@ import KotsAvailability from "../docs/partials/kots/_kots-availability.mdx"
 
 This topic provides an introduction to the Replicated KOTS installer, including information about KOTS features, installation options, and user interfaces.
 
-:::note
-The Replicated KOTS entitlement is required to install applications with KOTS. For more information, see [Pricing](https://www.replicated.com/pricing) on the Replicated website.
-:::
-
 <KotsAvailability/>
 
 ## Overview

--- a/docs/partials/kots/_kots-entitlement-note.mdx
+++ b/docs/partials/kots/_kots-entitlement-note.mdx
@@ -1,3 +1,0 @@
-:::note
-The Replicated KOTS entitlement is required to install applications with KOTS. For more information, see [Pricing](https://www.replicated.com/pricing) on the Replicated website.
-:::

--- a/docs/vendor/enterprise-portal-v2-about.mdx
+++ b/docs/vendor/enterprise-portal-v2-about.mdx
@@ -14,7 +14,8 @@ Content is driven by entitlements and channel assignment, so each customer sees 
 
 - **Install and upgrade**: Step-by-step installation instructions for Helm and Embedded Cluster (Linux), with per-instance commands personalized to each customer's license and environment
 - **Manage instances**: View all deployed instances, check for available updates, and follow inline upgrade instructions
-- **Access security data**: Review CVE reports (fixable only) and download SBOMs for each release (when Security Center is enabled)
+- **Download install artifacts**: Download air gap bundles, Helm chart tarballs, and CLI tools directly from the portal. Available artifacts vary by install method and license entitlements
+- **Access security data**: Review CVE reports, filter to fixable vulnerabilities, view per-instance upgrade recommendations, and download SBOMs for each release. Available for Helm and Embedded Cluster installs when Security Center is enabled
 - **View release history**: Browse release notes and track what's changed between versions
 - **Upload support bundles**: Generate and upload diagnostic bundles for faster troubleshooting
 - **Manage their team**: Invite users, create service accounts, and configure SAML SSO
@@ -35,6 +36,7 @@ The new Enterprise Portal is a complete rebuild of the customer portal experienc
 
 - Installation and upgrade instructions are available only for Embedded Cluster and Helm CLI installations. The Enterprise Portal does not provide instructions for KOTS or kURL.
 - Air gap instance records do not appear until the customer creates one from the Instances & Updates page, either by manually entering instance information or by extracting details from an uploaded support bundle.
+- Security Center data (CVE reports and SBOMs) is available for Helm and Embedded Cluster installations only. Security data is not displayed for KOTS or kURL installations.
 - If you have many version branches and need to make a change across all versions, you must update each branch individually.
 
 ## Requirements

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -300,7 +300,7 @@ Props: `installType` (`"linux"` or `"helm"`).
 
 **`<RegistryAccess />`**: Displays registry credentials and pull secret configuration. No props.
 
-**`<LinuxInstallAssets />`**: Renders the full Linux/Embedded Cluster installation command sequence. Adapts to the customer's selected version and network availability. Props: `stepNumber` (optional, starting step number).
+**`<LinuxInstallAssets />`**: Renders the full Linux/Embedded Cluster installation command sequence. Adapts to the customer's selected version and network availability. For air gap installations, includes an optional toggle for private registry image relocation. When enabled, the customer enters their registry hostname and the commands update to include image pull, tag, and push steps targeting that registry. Props: `stepNumber` (optional, starting step number).
 
 **`<HelmInstallAssets />`**: Renders the full Helm installation command sequence. Props: `stepNumber` (optional), `charts` (optional, comma-separated list of chart names to include), `exclude` (optional, comma-separated list of chart names to hide).
 
@@ -363,7 +363,7 @@ Props: `stepNumber`, `title`, `optional` (boolean).
 
 ### Update components
 
-**`<LinuxUpdateAssets />`**: Renders Linux/Embedded Cluster upgrade instructions for the customer's current instance. Props: `stepNumber`.
+**`<LinuxUpdateAssets />`**: Renders Linux/Embedded Cluster upgrade instructions for the customer's current instance. For air gap upgrades, includes a registry hostname input for image relocation when the customer uses a private registry. Props: `stepNumber`.
 
 **`<HelmUpdateAssets />`**: Renders Helm upgrade instructions. Props: `stepNumber`, `charts` (optional), `exclude` (optional).
 
@@ -428,9 +428,9 @@ In this example, a customer on version 1.5.0 would see the "Upgrading from 1.x" 
 
 ### Security components
 
-These components require Security Center to be enabled for the customer. See [Security Center](/vendor/security-center-about) for more information.
+These components require Security Center to be enabled for the customer and are available for Helm and Embedded Cluster installs only. See [Security Center](/vendor/security-center-about) for more information.
 
-**`<CVEReport />`**: Displays CVE vulnerability report for the selected release. No props.
+**`<CVEReport />`**: Displays the CVE vulnerability report for the selected release. Includes a toggle to filter between all vulnerabilities and fixable-only vulnerabilities. No props.
 
 **`<SBOMReport />`**: Displays the Software Bill of Materials for the selected release. No props.
 

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -64,6 +64,18 @@ The **New Installation** button lets customers start new installations, with a d
 
 Air gap customers can create new instance records manually or by extracting details from an uploaded support bundle.
 
+### Downloading install artifacts
+
+Depending on the install method and license entitlements, customers can download artifacts directly from the portal:
+
+- **Air gap bundles**: Available from the Release History page and the install flow for air gap installations. Each release shows a build status (Ready, Building, Failed, or Not built) and a download link when the build is complete.
+- **Helm chart tarballs**: Available during Helm installations when the customer selects limited or no registry access. Download links appear inline in the install and update instructions.
+- **CLI tools**: The preflight plugin binary is available for download in the install flow, regardless of registry access settings.
+
+### Private registry image relocation (Embedded Cluster)
+
+For Embedded Cluster air gap installations, customers using a private registry can enter their registry hostname directly in the install flow. The instructions update to include image pull, tag, and push commands targeting that registry, along with the appropriate `--registry` flags on the install command. This is also available during Embedded Cluster upgrades when the instance was originally installed with a private registry.
+
 ## Team management
 
 Customer team admins can manage their portal team from the Team Settings page:
@@ -80,6 +92,18 @@ Customers can generate and upload support bundles from the portal:
 - **Generate bundles**: Follow the instructions on the Support Bundles page to generate a diagnostic bundle from their Linux or Helm installation
 - **Upload bundles**: Upload an existing bundle file for vendor analysis. The maximum upload size is 2 GB. For larger bundles, use the [Replicated SDK API](/reference/replicated-sdk-apis#post-supportbundle) upload endpoint, which has no size restriction.
 - **View history**: See previously uploaded bundles and their status
+
+## Security
+
+When Security Center is enabled by the vendor, customers with Helm or Embedded Cluster installations can view security data for their releases.
+
+- **CVE reports**: Browse vulnerabilities by severity for the selected release version. A toggle filters between all vulnerabilities and fixable-only vulnerabilities, where fixable means a patched package version is available.
+- **Upgrade recommendations**: CVE entries link to upgrade recommendations for affected instances, showing customers a path to the version that resolves each vulnerability.
+- **SBOMs**: Download the Software Bill of Materials for any release version. SBOMs are accessible to all portal team members regardless of role.
+
+:::note
+Security Center data is available for Helm and Embedded Cluster installations only. Security data is not displayed for KOTS or kURL installations.
+:::
 
 ## License information
 

--- a/docs/vendor/kurl-about.mdx
+++ b/docs/vendor/kurl-about.mdx
@@ -6,10 +6,6 @@ import KurlAvailability from "../partials/kurl/_kurl-availability.mdx"
 
 This topic provides an introduction to the Replicated kURL installer, including information about kURL specifications and installations.
 
-:::note
-The Replicated KOTS entitlement is required to install applications with KOTS and kURL. For more information, see [Pricing](https://www.replicated.com/pricing) on the Replicated website.
-:::
-
 <KurlAvailability/>
 
 ## Overview


### PR DESCRIPTION
## What

Removes the "The Replicated KOTS entitlement is required..." `:::note` callout from the KOTS and kURL intro pages:

- **[Introduction to KOTS](https://docs.replicated.com/intro-kots)** (`docs/intro-kots.mdx`)
- **[Introduction to kURL](https://docs.replicated.com/vendor/kurl-about)** (`docs/vendor/kurl-about.mdx`)

Also deletes `docs/partials/kots/_kots-entitlement-note.mdx`, an orphaned partial that was imported nowhere.

## Why

The entitlement note caused more confusion than it was worth. Anyone who still has access to KOTS or kURL already has the entitlement, so the callout doesn't inform the reader of anything actionable.

## Scope notes

- The second note on these pages (KOTS/kURL availability / Support Lifecycle Policy) is **untouched** — it comes from the `_kots-availability` / `_kurl-availability` partials.
- Factual entitlement references in the license-fields docs (`licenses-install-types.mdx`, `licenses-using-builtin-fields.mdx`) are **left intact**, since they describe built-in license field behavior rather than a redundant access callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)