### PR TITLE
docs(cmx): remove Beta note from VM limitations

### DIFF
--- a/docs/vendor/testing-about.md
+++ b/docs/vendor/testing-about.md
@@ -30,7 +30,6 @@ Otherwise, to request credits, log in to the Vendor Portal and go to [**Compatib
 - Each team has a quota limit on the amount of resources that can be used simultaneously. This limit can be raised by messaging your account representative.
 - Team actions with CMX (for example, creating and deleting clusters and requesting quota increases) are not logged and displayed in the [Vendor Team Audit Log](https://vendor.replicated.com/team/audit-log). 
 - Creating VMs with CMX has the following limitations:
-  - Creating VMs with CMX is a Beta feature.
   - Installing Embedded Cluster on a VM created with CMX is supported for Embedded Cluster versions 1.21.0 or later.
   - [GitHub Actions](/vendor/testing-ci-cd#replicated-github-actions) are not supported for CMX VMs. 
   - The [cluster prepare](/reference/replicated-cli-cluster-prepare) command is not supported for CMX VMs.


### PR DESCRIPTION
## What this PR does

Removes the "Creating VMs with CMX is a Beta feature." bullet from the Compatibility Matrix limitations in `docs/vendor/testing-about.md`. VMs are no longer a beta feature.

## Note on the CLI reference pages

The `replicated-cli-vm-*.mdx` reference pages also say "VMs are currently a beta feature.", but those are **auto-generated** from the CLI command help text and are updated separately by the CLI docs-gen release job (after replicatedhq/replicated#757 merges and the CLI is released). They are intentionally not hand-edited here.

Opened as a draft — will merge after the related changes land.