### PR TITLE
Remove duplicate deprecation note on Replicated registry page

### DIFF
--- a/docs/vendor/private-images-replicated.mdx
+++ b/docs/vendor/private-images-replicated.mdx
@@ -28,15 +28,7 @@ The Replicated registry has the following limitations:
 
 * The ability to push images to the Replicated registry is available only for KOTS-managed installations. Pushing images to the Replicated registry is not supported for Helm installations.
 
-## Push images to the Replicated registry (Deprecated) {#push-images}
-
-:::important
-Replicated has deprecated the ability to push images to the Replicated registry. Images that are already hosted on the Replicated registry will continue to be available for pull access.
-
-Replicated recommends that all software vendors use the Replicated proxy registry instead of the Replicated registry. The proxy registry provides a globally-distributed and highly-performant method to grant pull-through access to application images stored in your own external registry. For more information, see [About the Replicated proxy registry](/vendor/private-images-about).
-
-If you already host any Docker images on the Replicated registry, Replicated recommends that you move your images to an external registry and use the Replicated proxy registry. For more information, see [Migrate from the Replicated registry to the proxy registry](/vendor/private-images-kots#migrate-replicated-registry).
-:::
+## Push images (Deprecated) {#push-images}
 
 <details>
 <summary>View the deprecated push instructions</summary>


### PR DESCRIPTION
## What

On [Push images to the Replicated registry (Deprecated)](https://docs.replicated.com/vendor/private-images-replicated), the deprecation `:::important` block appeared **twice**: once under the page title and again under the `## Push images` section a few lines below, separated only by the short Overview and Limitations sections. The two section headings were also word-for-word identical, which read as a stutter.

## Change

- Remove the second (duplicate) `:::important` deprecation block.
- Rename the section heading from `Push images to the Replicated registry (Deprecated)` to `Push images (Deprecated)` so it no longer restates the page title. The `{#push-images}` anchor is preserved (no inbound links reference it, but no reason to break it), and the section stays clearly marked deprecated via the heading and the "View the deprecated push instructions" summary.

Branched off latest `main`, so this sits on top of the recent Delete-images / Limitations update (#4206).

🤖 Generated with [Claude Code](https://claude.com/claude-code)