### PR TITLE
EP v2: Add GitHub requirement and template update adoption docs

### DIFF
--- a/docs/vendor/enterprise-portal-v2-about.mdx
+++ b/docs/vendor/enterprise-portal-v2-about.mdx
@@ -41,6 +41,8 @@ The new Enterprise Portal is a complete rebuild of the customer portal experienc
 
 ## Requirements
 
+* **GitHub organization**: Enterprise Portal uses a GitHub App integration to sync content from your repo. A GitHub organization is required. GitLab, Bitbucket, and other git providers are not currently supported.
+
 Replicated enables the New Enterprise Portal by default for new teams. If your existing team uses the Classic Enterprise Portal, check the Vendor Portal for New Enterprise Portal pages. Contact your Replicated account representative if you do not see them.
 
 Some Enterprise Portal capabilities require additional access:

--- a/docs/vendor/enterprise-portal-v2-about.mdx
+++ b/docs/vendor/enterprise-portal-v2-about.mdx
@@ -41,7 +41,7 @@ The new Enterprise Portal is a complete rebuild of the customer portal experienc
 
 ## Requirements
 
-* **GitHub organization**: Enterprise Portal uses a GitHub App integration to sync content from your repo. A GitHub organization is required. GitLab, Bitbucket, and other git providers are not currently supported.
+* **GitHub organization**: Enterprise Portal uses a GitHub App integration to sync content from your repo. You must have a GitHub organization. GitLab, Bitbucket, and other git providers are not supported.
 
 Replicated enables the New Enterprise Portal by default for new teams. If your existing team uses the Classic Enterprise Portal, check the Vendor Portal for New Enterprise Portal pages. Contact your Replicated account representative if you do not see them.
 

--- a/docs/vendor/enterprise-portal-v2-about.mdx
+++ b/docs/vendor/enterprise-portal-v2-about.mdx
@@ -41,7 +41,7 @@ The new Enterprise Portal is a complete rebuild of the customer portal experienc
 
 ## Requirements
 
-* **GitHub organization**: Enterprise Portal uses a GitHub App integration to sync content from your repo. You must have a GitHub organization. GitLab, Bitbucket, and other git providers are not supported.
+Enterprise Portal uses a GitHub App integration to sync content from your repo. You must have a GitHub organization. GitLab, Bitbucket, and other git providers are not supported.
 
 Replicated enables the New Enterprise Portal by default for new teams. If your existing team uses the Classic Enterprise Portal, check the Vendor Portal for New Enterprise Portal pages. Contact your Replicated account representative if you do not see them.
 

--- a/docs/vendor/enterprise-portal-v2-connect-repo.mdx
+++ b/docs/vendor/enterprise-portal-v2-connect-repo.mdx
@@ -7,7 +7,7 @@ Features described on this page are in alpha and subject to change. Some capabil
 Enterprise Portal content is driven by a GitHub repo you control. Connecting a repo is a prerequisite to offer versioned docs, advanced theming, and Terraform module delivery.
 
 :::note
-Enterprise Portal requires a GitHub organization. The content repo integration uses the Replicated GitHub App for syncing and webhooks. GitLab, Bitbucket, and other git providers are not currently supported.
+Enterprise Portal requires a GitHub organization. The content repo integration uses the Replicated GitHub App for syncing and webhooks. GitLab, Bitbucket, and other git providers are not supported.
 :::
 
 The Content tab appears when your team has the New Enterprise Portal. The same setting enables the GitHub App workflow for content repositories. Use this workflow to create, authorize, and link repos.
@@ -66,9 +66,9 @@ Content branches must be named with semver versions (e.g., 1.0.0) that match you
 
 ## Adopting template updates
 
-Your content repo is created from the [replicatedhq/enterprise-portal-content](https://github.com/replicatedhq/enterprise-portal-content) template. Because the repo is cloned rather than forked, it diverges from the template as soon as you start customizing content, branding, and navigation.
+You create your content repo from the [replicatedhq/enterprise-portal-content](https://github.com/replicatedhq/enterprise-portal-content) template. Because you clone the template rather than fork it, your repo diverges as soon as you start customizing content, branding, and navigation.
 
-When Replicated publishes improvements to the template (new MDX components, updated default pages, navigation changes), the Vendor Portal notifies you on the **Content** tab with a banner showing how many updates are available since your last review.
+When Replicated publishes improvements to the template (new MDX components, updated default pages, navigation changes), the Vendor Portal shows a banner on the **Content** tab with the number of updates available since your last review.
 
 ### Reviewing updates
 
@@ -77,11 +77,11 @@ Click **Review** on the Content tab banner to open the template updates modal. E
 - **Title and date**: What changed and when
 - **Impact level**: `required`, `recommended`, or `optional`, indicating how important the update is for your portal
 - **Summary**: A brief description of the change and its effect on your customers' portal experience
-- **Affected areas**: Tags showing which parts of the template are affected (for example, installation instructions, navigation, troubleshooting content)
+- **Affected areas**: Tags showing which parts of the template the update touches (for example, installation instructions, navigation, troubleshooting content)
 - **Guide link**: Opens the full adoption guide on GitHub with step-by-step instructions for applying the change to your repo
 
 ### Applying an update
 
-Template updates are not applied automatically. Each update's guide describes what files to copy or modify and what to verify after making the change. Because your repo has diverged from the template, updates are designed as targeted adoption steps rather than wholesale merges.
+Template updates do not apply automatically. Each update's guide describes what files to copy or modify and what to verify after making the change. Because your repo has diverged from the template, each guide provides targeted adoption steps rather than a wholesale merge.
 
-After reviewing the available updates, click **Mark reviewed** to acknowledge them. The banner clears until the next template update is published. Marking updates as reviewed is per-user, so other team members continue to see the banner until they review it themselves.
+After reviewing the available updates, click **Mark reviewed** to acknowledge them. The banner clears until Replicated publishes the next template update. Marking updates as reviewed is per-user, so other team members continue to see the banner until they review it themselves.

--- a/docs/vendor/enterprise-portal-v2-connect-repo.mdx
+++ b/docs/vendor/enterprise-portal-v2-connect-repo.mdx
@@ -4,11 +4,11 @@
 Features described on this page are in alpha and subject to change. Some capabilities might require additional access.
 :::
 
-Enterprise Portal content is driven by a GitHub repo you control. Connecting a repo is a prerequisite to offer versioned docs, advanced theming, and Terraform module delivery.
-
 :::note
 Enterprise Portal requires a GitHub organization. The content repo integration uses the Replicated GitHub App for syncing and webhooks. GitLab, Bitbucket, and other git providers are not supported.
 :::
+
+Enterprise Portal content is driven by a GitHub repo you control. Connecting a repo is a prerequisite to offer versioned docs, advanced theming, and Terraform module delivery.
 
 The Content tab appears when your team has the New Enterprise Portal. The same setting enables the GitHub App workflow for content repositories. Use this workflow to create, authorize, and link repos.
 

--- a/docs/vendor/enterprise-portal-v2-connect-repo.mdx
+++ b/docs/vendor/enterprise-portal-v2-connect-repo.mdx
@@ -6,6 +6,10 @@ Features described on this page are in alpha and subject to change. Some capabil
 
 Enterprise Portal content is driven by a GitHub repo you control. Connecting a repo is a prerequisite to offer versioned docs, advanced theming, and Terraform module delivery.
 
+:::note
+Enterprise Portal requires a GitHub organization. The content repo integration uses the Replicated GitHub App for syncing and webhooks. GitLab, Bitbucket, and other git providers are not currently supported.
+:::
+
 The Content tab appears when your team has the New Enterprise Portal. The same setting enables the GitHub App workflow for content repositories. Use this workflow to create, authorize, and link repos.
 
 The Vendor Portal walks you through setup in three steps:
@@ -59,3 +63,25 @@ replicated api post /v3/app/<APP_ID>/enterprise-portal/content-repos/<REPO_ID>/s
 :::important
 Content branches must be named with semver versions (e.g., 1.0.0) that match your release version_label values. The main branch is synced but never shown to customers directly. See [Naming Your Branches](/vendor/enterprise-portal-v2-versioned-docs#naming-your-branches) for details.
 :::
+
+## Adopting template updates
+
+Your content repo is created from the [replicatedhq/enterprise-portal-content](https://github.com/replicatedhq/enterprise-portal-content) template. Because the repo is cloned rather than forked, it diverges from the template as soon as you start customizing content, branding, and navigation.
+
+When Replicated publishes improvements to the template (new MDX components, updated default pages, navigation changes), the Vendor Portal notifies you on the **Content** tab with a banner showing how many updates are available since your last review.
+
+### Reviewing updates
+
+Click **Review** on the Content tab banner to open the template updates modal. Each update includes:
+
+- **Title and date**: What changed and when
+- **Impact level**: `required`, `recommended`, or `optional`, indicating how important the update is for your portal
+- **Summary**: A brief description of the change and its effect on your customers' portal experience
+- **Affected areas**: Tags showing which parts of the template are affected (for example, installation instructions, navigation, troubleshooting content)
+- **Guide link**: Opens the full adoption guide on GitHub with step-by-step instructions for applying the change to your repo
+
+### Applying an update
+
+Template updates are not applied automatically. Each update's guide describes what files to copy or modify and what to verify after making the change. Because your repo has diverged from the template, updates are designed as targeted adoption steps rather than wholesale merges.
+
+After reviewing the available updates, click **Mark reviewed** to acknowledge them. The banner clears until the next template update is published. Marking updates as reviewed is per-user, so other team members continue to see the banner until they review it themselves.


### PR DESCRIPTION
Preview links
* https://deploy-preview-4216--replicated-docs.netlify.app/vendor/enterprise-portal-v2-about#requirements
* https://deploy-preview-4216--replicated-docs.netlify.app/vendor/enterprise-portal-v2-connect-repo

## Summary
- Adds explicit GitHub organization requirement to the EP v2 About page (Requirements section) and Connect a Git Repo page (note callout), clarifying that GitLab/Bitbucket are not supported
- Documents the template update notification and review flow (Content tab banner, Review modal, impact levels, Guide link, Mark reviewed) on the Connect a Git Repo page

## Context
- GitHub requirement was implied throughout EP v2 docs but never stated explicitly, causing confusion for prospects on other git providers
- Template update adoption feature (sc-137981) shipped but was not documented anywhere

## Test plan
- [ ] Verify About page Requirements section renders correctly with the new GitHub bullet
- [ ] Verify Connect a Git Repo page note callout renders correctly
- [ ] Verify new "Adopting template updates" section renders with correct heading hierarchy
- [ ] Confirm no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)