### PR TITLE
Clarify GitHub App read-only access in EP v2 docs

### DIFF
--- a/docs/vendor/enterprise-portal-v2-about.mdx
+++ b/docs/vendor/enterprise-portal-v2-about.mdx
@@ -41,7 +41,7 @@ The new Enterprise Portal is a complete rebuild of the customer portal experienc
 
 ## Requirements
 
-Enterprise Portal uses a GitHub App integration to sync content from your repo. You must have a GitHub organization. GitLab, Bitbucket, and other git providers are not supported.
+Enterprise Portal uses a GitHub App integration to sync content from your repo. The App has read-only access and never writes to or modifies your repositories. You must have a GitHub organization. GitLab, Bitbucket, and other git providers are not supported.
 
 Replicated enables the New Enterprise Portal by default for new teams. If your existing team uses the Classic Enterprise Portal, check the Vendor Portal for New Enterprise Portal pages. Contact your Replicated account representative if you do not see them.
 

--- a/docs/vendor/enterprise-portal-v2-connect-repo.mdx
+++ b/docs/vendor/enterprise-portal-v2-connect-repo.mdx
@@ -24,7 +24,7 @@ If you already have a content repository (or prefer to create one from scratch),
 
 ## Step 2: Connect GitHub
 
-Click **Connect GitHub** and authorize the Replicated GitHub App on your GitHub organization. Creating the repo first (Step 1) ensures it's available to grant access to during this step.
+Click **Connect GitHub** and authorize the Replicated GitHub App on your GitHub organization. The App requests read-only access to sync content from your repo into Replicated. It does not write to or modify your repositories. Creating the repo first (Step 1) ensures it's available to grant access to during this step.
 
 To change the linked GitHub account later (for example, if you move your content repo to a different organization), go to **[Team > GitHub Integration](https://vendor.replicated.com/team/github-integration)** and connect the new account.
 


### PR DESCRIPTION
## Summary

- Adds explicit read-only language to the **About** page Requirements section and the **Connect a Git Repo** Step 2 description
- Prompted by a customer asking what information gets pushed to their GitHub when connecting the App. The answer: nothing. The App only reads content (markdown, YAML config, Terraform files) and never writes to or modifies vendor repositories.

Companion product story for in-app copy: https://app.shortcut.com/replicated/story/138651

## Test plan

- [ ] Verify the about page Requirements section reads clearly with the new sentence
- [ ] Verify the connect-repo Step 2 paragraph flows naturally with the added context

🤖 Generated with [Claude Code](https://claude.com/claude-code)