### PR TITLE
Document multi-node upgrade flow for EC v3

### DIFF
--- a/embedded-cluster/embedded-cluster-create-upgrade-bundle.mdx
+++ b/embedded-cluster/embedded-cluster-create-upgrade-bundle.mdx
@@ -2,7 +2,7 @@
 
 This topic describes the options available with the Embedded Cluster `create-upgrade-bundle` command. Use this command to produce a bundle used for offline or constrained-path upgrades.
 
-In most clusters, you do not need this command. When you run `upgrade` on the primary controller, the daemon automatically streams the upgrade to each remote node. See [Multi-node clusters](updating-embedded#multi-node-clusters).
+In most clusters, you do not need this command. When you run `upgrade` on the primary controller, the daemon automatically streams the upgrade bundle to each remote node. See [Multi-node clusters](updating-embedded#multi-node-clusters).
 
 Use `create-upgrade-bundle` when you need to upgrade nodes manually, for example when a node is running an Embedded Cluster version earlier than 3.2 and cannot receive streamed upgrades. Copy the output bundle to the target node and run [node upgrade](embedded-cluster-node-upgrade).
 

--- a/embedded-cluster/embedded-cluster-create-upgrade-bundle.mdx
+++ b/embedded-cluster/embedded-cluster-create-upgrade-bundle.mdx
@@ -2,6 +2,10 @@
 
 This topic describes the options available with the Embedded Cluster `create-upgrade-bundle` command. Use this command to produce a bundle used for offline or constrained-path upgrades.
 
+In most clusters, you do not need this command. When you run `upgrade` on the primary controller, the daemon automatically streams the upgrade to each remote node. See [Multi-node clusters](updating-embedded#multi-node-clusters).
+
+Use `create-upgrade-bundle` when you need to upgrade nodes manually, for example when a node is running an Embedded Cluster version earlier than 3.2 and cannot receive streamed upgrades. Copy the output bundle to the target node and run [node upgrade](embedded-cluster-node-upgrade).
+
 ## Usage
 
 ```bash

--- a/embedded-cluster/embedded-cluster-node-upgrade.mdx
+++ b/embedded-cluster/embedded-cluster-node-upgrade.mdx
@@ -2,6 +2,10 @@
 
 This topic describes the options available with the Embedded Cluster `node upgrade` command.
 
+In most clusters, you do not need to run this command directly. When you run `upgrade` on the primary controller, the daemon automatically streams the upgrade bundle to each remote node. See [Multi-node clusters](updating-embedded#multi-node-clusters).
+
+Use `node upgrade` when you need to upgrade a node manually, for example when a node is running an Embedded Cluster version earlier than 3.2 and cannot receive streamed upgrades. To produce the bundle for manual upgrades, run `create-upgrade-bundle` on the primary controller and copy the output to the target node.
+
 ## Usage
 
 ```bash

--- a/embedded-cluster/updating-embedded.mdx
+++ b/embedded-cluster/updating-embedded.mdx
@@ -8,6 +8,21 @@ Each Embedded Cluster binary that you download targets a particular application 
 
 You can upgrade interactively in the browser or headlessly from the command line. To change configuration or redeploy without moving to a newer application version, run `upgrade` using the binary for the version that is already installed.
 
+## Multi-node clusters
+
+In multi-node clusters, run the `upgrade` command on the primary controller (the first controller installed). The upgrade proceeds in two stages:
+
+1. The primary controller upgrades its own binaries, Kubernetes version, and Embedded Cluster components.
+2. The primary controller's daemon streams the upgrade bundle to each remaining node over HTTPS. Controllers upgrade first (one at a time, to preserve etcd quorum), then workers (one at a time).
+
+The operator does not need to copy files to remote nodes or run commands on them. The daemon on each remote node receives the bundle, extracts it, and performs the local upgrade automatically. Progress is visible in the installer UI or persistent admin console during interactive upgrades, and in the CLI output during headless upgrades.
+
+If a node cannot be reached during the upgrade, the orchestrator reports the failure and stops. Resolve the connectivity issue and re-run the upgrade to retry.
+
+:::note
+If your cluster contains nodes running Embedded Cluster versions earlier than 3.2, the orchestrator cannot stream bundles to those nodes. Instead, use `create-upgrade-bundle` on the primary controller to produce a bundle, copy it to each older node, and run `node upgrade` on that node. See [create-upgrade-bundle](embedded-cluster-create-upgrade-bundle) and [node upgrade](embedded-cluster-node-upgrade).
+:::
+
 ## Upgrade using the Embedded Cluster UI
 
 ### Use the Enterprise Portal for a guided upgrade

--- a/embedded-cluster/updating-embedded.mdx
+++ b/embedded-cluster/updating-embedded.mdx
@@ -15,12 +15,12 @@ In multi-node clusters, run the `upgrade` command on the primary controller (the
 1. The primary controller upgrades its own binaries, Kubernetes version, and Embedded Cluster components.
 2. The primary controller's daemon streams the upgrade bundle to each remaining node over HTTPS. Controllers upgrade first (one at a time, to preserve etcd quorum), then workers (one at a time).
 
-The operator does not need to copy files to remote nodes or run commands on them. The daemon on each remote node receives the bundle, extracts it, and performs the local upgrade automatically. Progress is visible in the installer UI or persistent admin console during interactive upgrades, and in the CLI output during headless upgrades.
+The end user does not need to copy files to remote nodes or run commands on them. The daemon on each remote node receives the bundle, extracts it, and performs the local upgrade automatically. Progress is visible in the installer UI or persistent admin console during interactive upgrades, and in the CLI output during headless upgrades.
 
 If a node cannot be reached during the upgrade, the orchestrator reports the failure and stops. Resolve the connectivity issue and re-run the upgrade to retry.
 
 :::note
-If your cluster contains nodes running Embedded Cluster versions earlier than 3.2, the orchestrator cannot stream bundles to those nodes. Instead, use `create-upgrade-bundle` on the primary controller to produce a bundle, copy it to each older node, and run `node upgrade` on that node. See [create-upgrade-bundle](embedded-cluster-create-upgrade-bundle) and [node upgrade](embedded-cluster-node-upgrade).
+If your cluster contains nodes running Embedded Cluster versions earlier than 3.2, the orchestrator cannot stream bundles to those nodes. The installer UI automatically detects this and displays manual instructions for upgrading those nodes. You can also use `create-upgrade-bundle` on the primary controller to produce a bundle, copy it to each older node, and run `node upgrade` on that node. See [create-upgrade-bundle](embedded-cluster-create-upgrade-bundle) and [node upgrade](embedded-cluster-node-upgrade).
 :::
 
 ## Upgrade using the Embedded Cluster UI


### PR DESCRIPTION
Preview links
* https://deploy-preview-4222--replicated-docs.netlify.app/embedded-cluster/v3/updating-embedded#multi-node-clusters
* https://deploy-preview-4222--replicated-docs.netlify.app/embedded-cluster/v3/embedded-cluster-create-upgrade-bundle
* https://deploy-preview-4222--replicated-docs.netlify.app/embedded-cluster/v3/embedded-cluster-node-upgrade

## Summary

- Add a "Multi-node clusters" section to the EC v3 upgrade procedural page explaining how upgrades propagate from the primary controller to remote nodes (orchestrated streaming over HTTPS, controllers first then workers, serially)
- Add context to the `node upgrade` and `create-upgrade-bundle` command references explaining when each is needed (manual fallback for pre-3.2 nodes) vs the default orchestrated path
- These pages previously had no explanation of multi-node upgrade behavior, leaving readers to guess what happens after running `upgrade` on one controller

## Test plan

- [ ] Verify links between the three updated pages resolve correctly
- [ ] Confirm the `#multi-node-clusters` anchor works from the command reference pages
- [ ] EC team review for technical accuracy of the orchestrated flow description

🤖 Generated with [Claude Code](https://claude.com/claude-code)