### PR TITLE
Clarify EC v3 BYO registry behavior vs. proxyRegistryDomain

### DIFF
--- a/embedded-cluster/embedded-config.mdx
+++ b/embedded-cluster/embedded-config.mdx
@@ -167,6 +167,10 @@ You must add the custom domains that you specify in the `domains.proxyRegistryDo
 
 If `domains.proxyRegistryDomain` and `domains.replicatedAppDomain` are not set, Embedded Cluster uses the default Replicated domains. For more information about aliasing Replicated endpoints with custom domains, see [About Custom Domains](/vendor/custom-domains).
 
+:::note
+Setting `domains.proxyRegistryDomain` is not the same as using a customer-managed (BYO) registry. A custom domain still fronts the Replicated proxy registry, so images continue to originate from Replicated. To pull all images from a registry that the customer controls instead, use a BYO registry. See [Install with a customer-managed registry](installing-embedded-byo-registry).
+:::
+
 #### Example
 
 ```yaml

--- a/embedded-cluster/installing-embedded-byo-registry.mdx
+++ b/embedded-cluster/installing-embedded-byo-registry.mdx
@@ -13,6 +13,12 @@ When BYO registry is enabled, Embedded Cluster pulls _all_ images from a single 
 
 BYO registry is supported for both online and air gap installations. In air gap installations with BYO registry, Embedded Cluster does not deploy its internal image registry to the cluster, because all images are served from the customer's registry.
 
+:::note
+A BYO registry is not the same as a [custom domain for the Replicated proxy registry](embedded-config#domains). The `domains.proxyRegistryDomain` field in the Embedded Cluster Config sets a custom (vanity) domain that still fronts the Replicated proxy registry, so images continue to originate from Replicated. The `--registry` flag instead replaces the proxy registry entirely with a registry that the customer controls.
+
+The two are independent. When you install or upgrade with `--registry`, Embedded Cluster pulls all images from the BYO registry regardless of whether `domains.proxyRegistryDomain` is set, and you do not need to set `domains.proxyRegistryDomain` to use a BYO registry.
+:::
+
 ### When to use a customer-managed registry
 
 A customer-managed registry is useful for customers with strict network or compliance policies that require all container images to come from a registry they control. Use cases include:
@@ -20,6 +26,7 @@ A customer-managed registry is useful for customers with strict network or compl
 * Customers that block outbound traffic to `proxy.replicated.com` and cannot run the internal air gap registry that Embedded Cluster deploys.
 * Customers that scan and sign images in their own registry before they reach the cluster.
 * Customers that already mirror third-party images to a central registry and want application images to follow the same path.
+* Customers that want to install now and mirror later: bring the cluster up against the default registry to unblock environmental testing, then switch to the BYO registry once their image review and mirroring are complete. See [Enable BYO registry on an existing cluster](#upgrade-byo).
 
 ### Limitations
 
@@ -30,7 +37,7 @@ A customer-managed registry is useful for customers with strict network or compl
 
 Before a customer can install with BYO registry, the following must be in place:
 
-* An OCI-compliant registry that is reachable from every Embedded Cluster host. Authentication can be anonymous, username and password, or mTLS (`--registry-tls-cert` and `--registry-tls-key`). If the registry's TLS certificate is signed by a private CA, pass it with `--registry-ca-cert`; otherwise the host's system root CAs are used.
+* An OCI-compliant registry that is reachable from every Embedded Cluster host. These three authentication mechanisms are supported, and are the only mechanisms supported: anonymous (public) access, username and password, and mTLS (`--registry-tls-cert` and `--registry-tls-key`). Cloud provider IAM or keyless authentication (for example, Amazon ECR or Google Artifact Registry credential helpers) is not supported; use a username and password or mTLS instead. If the registry's TLS certificate is signed by a private CA, pass it with `--registry-ca-cert`; otherwise the host's system root CAs are used.
 
 * All images required for the release are pushed to the registry using the layout described in [Registry layout requirements](#registry-layout) below.
 
@@ -217,6 +224,8 @@ sudo ./APP_SLUG upgrade \
 ## Author charts for a BYO registry {#chart-authoring}
 
 To work with BYO registry, application Helm charts must produce image references through Replicated template functions rather than hardcoding registry hosts. Embedded Cluster rewrites the output of these functions at install time based on the install mode (`proxy`, `airgap`, or `byo`).
+
+The `ReplicatedImageName` and `ReplicatedImageRegistry` behavior described here is the current Embedded Cluster 3.x (v3) contract.
 
 ### `ReplicatedImageName`
 


### PR DESCRIPTION
Preview links
* https://deploy-preview-4233--replicated-docs.netlify.app/embedded-cluster/v3/embedded-config#domains
* https://deploy-preview-4233--replicated-docs.netlify.app/embedded-cluster/v3/installing-embedded-byo-registry#overview

## What

Clarifies Embedded Cluster v3 customer-managed (BYO) registry docs based on customer questions in the field. The confusion centered on how the `--registry` BYO flag relates to the `domains.proxyRegistryDomain` config field, plus a few narrower gaps.

## Changes

- **BYO vs. `proxyRegistryDomain`** — A customer pasted an EC Config with `domains.proxyRegistryDomain` and asked whether `--registry` overrides it. These are different mechanisms: `proxyRegistryDomain` is a custom/vanity domain that *still fronts the Replicated proxy registry*, while `--registry` replaces the proxy registry with a customer-controlled one. Added a `:::note` in the BYO topic Overview and a reciprocal note in the `domains` section of `embedded-config`.
- **"Install now, mirror later" use case** — The customer wanted to install against the default registry to unblock environmental testing, then switch to the BYO registry once image review/mirroring completes. This is already supported via `upgrade`, but wasn't discoverable. Added it to the "When to use" list with a link to the existing enable-on-upgrade section.
- **Auth mechanisms as a closed set** — States that anonymous, username/password, and mTLS are the *only* supported mechanisms, and that cloud IAM / keyless auth (ECR, GAR credential helpers) is not supported.
- **v3 template-function reassurance** — Confirms the `ReplicatedImageName` / `ReplicatedImageRegistry` behavior described is the current v3 contract.
