### PR TITLE
docs: clarify auto-join and Google auth are independent

### DIFF
--- a/docs/vendor/team-management-google-auth.md
+++ b/docs/vendor/team-management-google-auth.md
@@ -20,7 +20,11 @@ To manage Google authentication settings:
     |-----------------------|------------------------|
     | Allow Google authentication for team members | Enables team members to log in using a Google account. |
     | Restrict login to only allow to Google authentication | Requires new users to accept an invitation and sign up with a Google account that exactly matches the email address used in the invitation. The email address can be a gmail.com address or user from another domain, but it must match the email address from the invitation exactly. Disabling this setting requires users to accept the invitation by creating a username and password (or use the SAML workflow). |
-  
+
+:::note
+Google authentication and the auto-join feature are independent. Auto-join limits who can join your team _without an invitation_ to users whose email domain matches your team's domain. It does not limit who you can invite manually. An administrator can invite a user from any domain, even when auto-join is enabled, as long as that user signs in with a Google account whose email exactly matches the invitation. For more information about auto-join, see [Enable users to auto-join your team](team-management#enable-users-to-auto-join-your-team).
+:::
+
 
 ## Migrating existing accounts
 Existing end users can sign in to an account that matches their Google Workspace (formerly GSuite) email address. This applies to all teams except those that restrict end users to SAML or require two-factor authentication (2FA). However, Google authentication only matches existing user accounts. For users with task-based email addresses (such as name+news@domain.com), you can sign in with email/password or invite your regular email address to join the team. You can also contact support to change your email address. For more information about task-based email addresses, see [Create task-specific email addresses](https://support.google.com/a/users/answer/9308648?hl=en) in the Google Support site.

--- a/docs/vendor/team-management-google-auth.md
+++ b/docs/vendor/team-management-google-auth.md
@@ -22,7 +22,7 @@ To manage Google authentication settings:
     | Restrict login to only allow to Google authentication | Requires new users to accept an invitation and sign up with a Google account that exactly matches the email address used in the invitation. The email address can be a gmail.com address or user from another domain, but it must match the email address from the invitation exactly. Disabling this setting requires users to accept the invitation by creating a username and password (or use the SAML workflow). |
 
 :::note
-Google authentication and the auto-join feature are independent. Auto-join limits who can join your team _without an invitation_ to users whose email domain matches your team's domain. It does not limit who you can invite manually. An administrator can invite a user from any domain, even when auto-join is enabled, as long as that user signs in with a Google account whose email exactly matches the invitation. For more information about auto-join, see [Enable users to auto-join your team](team-management#enable-users-to-auto-join-your-team).
+Google authentication and the auto-join feature are independent. Auto-join limits who can join your team _without an invitation_ to users whose email domain matches your team's domain. It does not limit who you can invite manually. Even when you enable auto-join, an administrator can invite a user from any domain. That user then signs in with a Google account whose email exactly matches the invitation. For more information about auto-join, see [Enable users to auto-join your team](team-management#enable-users-to-auto-join-your-team).
 :::
 
 

--- a/docs/vendor/team-management.md
+++ b/docs/vendor/team-management.md
@@ -78,6 +78,10 @@ To edit policy permissions for individual team members:
 ## Enable users to auto-join your team
 By default, users must receive an invitation to join your team. Team administrators can use the auto-join feature to allow users from the same email domain to join their team automatically. This applies to users registering with an email, or with Google authentication if the team enables it. The auto-join feature does not apply to SAML authentication because SAML users log in through their SAML provider's portal.
 
+:::note
+Auto-join only affects who can join _without an invitation_. It does not restrict who you can invite manually. An administrator can always invite a user from a domain other than the auto-join domain. For more information, see [Manage google authentication](team-management-google-auth).
+:::
+
 To add, edit, or delete custom RBAC policies, see [Configure RBAC Policies](team-management-rbac-configuring).
 
 To enable users to auto-join your team:


### PR DESCRIPTION
## What

Adds reciprocal `:::note` callouts to the Google authentication doc and the auto-join section clarifying that the two features are independent:

- **Auto-join** only governs who can join *without an invitation* (limited to the team's email domain).
- **Manual invitations** are not constrained by the auto-join domain. An admin can invite a user from any domain, and with Google auth restriction enabled that user just needs a Google account whose email exactly matches the invitation.

## Why

A support thread surfaced the assumption that enabling Google authentication limits *all* accounts to the auto-join domain. Notably, an internal team member initially answered this incorrectly before re-deriving the right answer from the docs. When the docs don't prevent an expert from getting it wrong, the mental model isn't clear enough.

The root cause is two separate "domain" concepts sitting in adjacent settings with no cross-reference. The Google auth doc already hints at it ("can be a gmail.com address or user from another domain") but never states the payoff explicitly. These notes close that gap and link the two topics together.

## Files

- `docs/vendor/team-management-google-auth.md`
- `docs/vendor/team-management.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)