### PR TITLE
fix(ci): auto-label workflow fails on every Dependabot PR

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,19 +1,25 @@
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 name: Auto-label new PRs
 
+permissions:
+  pull-requests: write
+
 jobs:
   label:
+    # Dependabot PRs are already labeled via .github/dependabot.yml
+    # (dependencies / type::security), and pull_request_target runs
+    # them with a read-only token from a separate secret store.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.DOCS_GH_PAT }}
           script: |
             const labels = ['type::feature', 'type::docs']
-            github.rest.issues.addLabels({
+            await github.rest.issues.addLabels({
               ...context.repo,
               issue_number: context.issue.number,
               labels


### PR DESCRIPTION
## Problem

The `Auto-label new PRs` workflow ([auto-label.yml](https://github.com/replicatedhq/replicated-docs/blob/main/.github/workflows/auto-label.yml)) fails on **every Dependabot PR** with:

```
Error: Input required and not supplied: github-token
```

### Root cause

The step reads `github-token: ${{ secrets.DOCS_GH_PAT }}`. That secret lives in the **Actions** secret store, but Dependabot-triggered workflow runs only receive secrets from the separate **Dependabot** secret store (which is empty here). So on Dependabot PRs the token resolves to empty and the step errors. Human-authored PRs get the Actions secret, which is why only Dependabot PRs went red.

## Fix

- Switch the trigger to `pull_request_target` and use the built-in `GITHUB_TOKEN` with an explicit `permissions: pull-requests: write`, removing the external-PAT dependency entirely. This workflow only adds static labels (never checks out or executes PR code), so `pull_request_target` is safe here.
- Skip Dependabot PRs (`if: github.actor != 'dependabot[bot]'`). They are already labeled by `dependabot.yml` (`dependencies` / `type::security`), and the old workflow was additionally mislabeling them as `type::feature`/`type::docs`.

## Result

No more red X on Dependabot PRs, no more mislabeling, and no dependency on a PAT that has to be duplicated across two secret stores.