### PR TITLE
Remove RBAC for legacy notifications API

### DIFF
--- a/docs/vendor/team-management-rbac-resource-names.md
+++ b/docs/vendor/team-management-rbac-resource-names.md
@@ -150,14 +150,6 @@ Grants the holder permission to delete the customer specified by ID for the spec
 
 Grants the holder permission to unarchive (restore) the customer specified by ID for the specified applications.
 
-### KOTS/app/[:appid]/license/[:customerid]/slack-notifications/read
-
-Grants the holder permission to view the team's Slack notification subscriptions for instances associated with the specified license.
-
-### KOTS/app/[:appid]/license/[:customerid]/slack-notifications/update
-
-Grants the holder permission to edit the team's Slack notification subscriptions for instances associated with the specified license.
-
 ### KOTS/app/[:appid]/builtin-licensefields/update
 
 Grants the holder permission to edit the builtin license field override values for the specified applications.


### PR DESCRIPTION
This API is no longer enabled.