### PR TITLE
Document how Security Center classifies images

### DIFF
--- a/docs/vendor/security-center-about.mdx
+++ b/docs/vendor/security-center-about.mdx
@@ -24,6 +24,19 @@ The following describes the types of images that Replicated identifies for each 
 - **Additional images**: Any images listed in the Replicated Application custom resource [`additionalImages`](/reference/custom-resource-application#additionalimages) field. For example, applications packaged as Kubernetes Operators might need to include additional images that are not referenced until runtime. 
 - **Embedded Cluster images**: Any infrastructure images used by Replicated Embedded Cluster installations, if relevant.
 
+### How images are classified
+
+Security Center classifies each scanned image as an application image or a Replicated Platform image:
+
+* **Application image**: An image that belongs to your application. This includes images referenced in your Helm charts or Kubernetes manifests, and images listed in the Application custom resource [`additionalImages`](/reference/custom-resource-application#additionalimages) field.
+* **Replicated Platform image**: An image that Replicated owns and maintains, rather than an image from your application. This includes the Replicated SDK and, for Embedded Cluster installations, infrastructure that Replicated installs, such as the Admin Console and the Embedded Cluster operator.
+
+The Replicated SDK is classified as a Replicated Platform image even when it is bundled as a subchart of your application's chart.
+
+If Security Center cannot determine that an image is Replicated-owned, it classifies the image as an application image.
+
+In the Vendor Portal, you can filter the container image list by this classification. For more information, see [Filter container images by source](/vendor/security-center-view-vendor-portal#filter-container-images-by-source) in _View Security Information in Vendor Portal_.
+
 ### Include and exclude images from Security Center scans
 
 You can explicitly include or exclude images from being scanned by the Security Center:

--- a/docs/vendor/security-center-about.mdx
+++ b/docs/vendor/security-center-about.mdx
@@ -24,16 +24,16 @@ The following describes the types of images that Replicated identifies for each 
 - **Additional images**: Any images listed in the Replicated Application custom resource [`additionalImages`](/reference/custom-resource-application#additionalimages) field. For example, applications packaged as Kubernetes Operators might need to include additional images that are not referenced until runtime. 
 - **Embedded Cluster images**: Any infrastructure images used by Replicated Embedded Cluster installations, if relevant.
 
-### How images are classified
+### How image classification works
 
 Security Center classifies each scanned image as an application image or a Replicated Platform image:
 
 * **Application image**: An image that belongs to your application. This includes images referenced in your Helm charts or Kubernetes manifests, and images listed in the Application custom resource [`additionalImages`](/reference/custom-resource-application#additionalimages) field.
 * **Replicated Platform image**: An image that Replicated owns and maintains, rather than an image from your application. This includes the Replicated SDK and, for Embedded Cluster installations, infrastructure that Replicated installs, such as the Admin Console and the Embedded Cluster operator.
 
-The Replicated SDK is classified as a Replicated Platform image even when it is bundled as a subchart of your application's chart.
+Security Center classifies the Replicated SDK as a Replicated Platform image even when you bundle it as a subchart of your application's chart.
 
-If Security Center cannot determine that an image is Replicated-owned, it classifies the image as an application image.
+If Security Center cannot determine that Replicated owns an image, it classifies the image as an application image.
 
 In the Vendor Portal, you can filter the container image list by this classification. For more information, see [Filter container images by source](/vendor/security-center-view-vendor-portal#filter-container-images-by-source) in _View Security Information in Vendor Portal_.
 


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/replicated/story/138773

Adds a "How images are classified" concept section to the About the Security Center page, explaining how each scanned image is classified as an application image or a Replicated Platform image (the Replicated SDK and Embedded Cluster / KOTS infrastructure).