### PR TITLE
Document application links on EC v3 Finish page

### DIFF
--- a/embedded-cluster/embedded-using.mdx
+++ b/embedded-cluster/embedded-using.mdx
@@ -272,6 +272,24 @@ For air gap installations, use a Base64 encoded image for the `icon` field becau
 
 For more information about the Application custom resource fields, see [Application custom resource](/reference/custom-resource-application).
 
+## Add application links to the Finish page
+
+To display access links on the Installation Complete page, include a SIG Application custom resource (`app.k8s.io/v1beta1`) in your release with `spec.descriptor.links`:
+
+```yaml
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  descriptor:
+    links:
+      - description: Open My App
+        url: "http://my-app-url"
+```
+
+Links defined here appear on the Finish page after a successful install.
+
 ## Add support for air gap installations {#local-image-registry}
 
 This section describes how to support air gap installations with Embedded Cluster v3. It includes information about how to configure your release and lists the limitations and known issues of air gap installations with Embedded Cluster v3.

--- a/embedded-cluster/embedded-using.mdx
+++ b/embedded-cluster/embedded-using.mdx
@@ -288,7 +288,7 @@ spec:
         url: "http://my-app-url"
 ```
 
-Links defined here appear on the Finish page after a successful install and on the dashboard in the persistent console.
+Links defined here appear on the Finish page after a successful install and on the dashboard in the [persistent console](/embedded-cluster/embedded-persistent-console).
 
 ## Add support for air gap installations {#local-image-registry}
 

--- a/embedded-cluster/embedded-using.mdx
+++ b/embedded-cluster/embedded-using.mdx
@@ -288,7 +288,7 @@ spec:
         url: "http://my-app-url"
 ```
 
-Links defined here appear on the Finish page after a successful install.
+Links defined here appear on the Finish page after a successful install and on the dashboard in the persistent console.
 
 ## Add support for air gap installations {#local-image-registry}
 

--- a/embedded-cluster/embedded-using.mdx
+++ b/embedded-cluster/embedded-using.mdx
@@ -288,7 +288,7 @@ spec:
         url: "http://my-app-url"
 ```
 
-Links defined here appear on the Finish page after a successful install and on the dashboard in the [persistent console](/embedded-cluster/embedded-persistent-console).
+Links defined here appear on the Finish page after a successful install and on the dashboard in the [persistent console](/embedded-cluster/v3/embedded-persistent-console).
 
 ## Add support for air gap installations {#local-image-registry}
 


### PR DESCRIPTION
Preview link https://deploy-preview-4245--replicated-docs-upgrade.netlify.app/embedded-cluster/v3/embedded-using#add-application-links-to-the-finish-page

## Summary
- Add a new section to the EC v3 setup docs (`embedded-using.mdx`) that explains how to display application links on the Installation Complete page using a SIG Application custom resource (`app.k8s.io/v1beta1`) with `spec.descriptor.links`
- Placed after the "Customize the wizard branding" section, grouping it with other wizard UI customization content

Ref: sc-137016

## Test plan
- [ ] Verify the new section renders correctly in the docs site
- [ ] Confirm the YAML example is valid and correctly formatted
- [ ] Check that the section placement flows logically within the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)