### PR TITLE
Document the CVE details severity filter (Security Center)

### DIFF
--- a/docs/vendor/security-center-view-vendor-portal.mdx
+++ b/docs/vendor/security-center-view-vendor-portal.mdx
@@ -43,14 +43,14 @@ You can also select **Show only vulnerable images** to limit the list to images 
 
 ### Filter CVEs by severity
 
-On the **CVE details** tab, you can filter the list of CVEs by severity. Select any combination of severities to narrow the list:
+On the **CVE details** tab, you can filter the list of CVEs by severity level. Select any combination of the following to narrow the list:
 
-* **All**: All CVEs in the release. This is the default and is cleared when you select one or more individual severities.
-* **Critical**, **High**, **Medium**, **Low**: Show only CVEs of the selected severities. Each option displays the number of CVEs at that severity in the release.
+* **All**: All CVEs in the release. This is the default. Selecting one or more individual severity levels clears it.
+* **Critical**, **High**, **Medium**, and **Low**: Show only CVEs with the selected severity levels. Each option displays the number of CVEs at that level in the release.
 
 The **Showing X of Y CVEs** label reflects how many CVEs match the current filter.
 
-A CVE is grouped under its highest severity across all affected images. For example, a CVE that is rated Critical in one image and Low in another appears under **Critical**, so that a CVE is always represented by its most severe rating.
+Security Center groups each CVE by its highest severity level across all affected images. For example, a CVE with a Critical rating in one image and a Low rating in another appears in the **Critical** group. This ensures that each CVE reflects its most severe rating.
 
 ## Release-specific CVE information
 

--- a/docs/vendor/security-center-view-vendor-portal.mdx
+++ b/docs/vendor/security-center-view-vendor-portal.mdx
@@ -41,6 +41,17 @@ On the **Container images** tab, you can filter the list of scanned images by so
 
 You can also select **Show only vulnerable images** to limit the list to images that have known vulnerabilities.
 
+### Filter CVEs by severity
+
+On the **CVE details** tab, you can filter the list of CVEs by severity. Select any combination of severities to narrow the list:
+
+* **All**: All CVEs in the release. This is the default and is cleared when you select one or more individual severities.
+* **Critical**, **High**, **Medium**, **Low**: Show only CVEs of the selected severities. Each option displays the number of CVEs at that severity in the release.
+
+The **Showing X of Y CVEs** label reflects how many CVEs match the current filter.
+
+A CVE is grouped under its highest severity across all affected images. For example, a CVE that is rated Critical in one image and Low in another appears under **Critical**, so that a CVE is always represented by its most severe rating.
+
 ## Release-specific CVE information
 
 CVE details are available for all current and previously promoted application release versions. To view CVE information for a specific release, go to **Releases > [Release Version] > Security**. This page shows the same container image list and source filter as the [Security Center dashboard](#security-center-dashboard).


### PR DESCRIPTION
Adds a **Filter CVEs by severity** section to _View Security Information in Vendor Portal_, covering:

- The **All + Critical / High / Medium / Low** multi-select chips, each with a per-severity count.
- The **"Showing X of Y CVEs"** label.
- That a CVE is grouped under its highest severity across all affected images.