### PR TITLE
Document in-cluster v1beta3 preflight collectors for Embedded Cluster v3

### DIFF
--- a/embedded-cluster/embedded-using.mdx
+++ b/embedded-cluster/embedded-using.mdx
@@ -176,6 +176,63 @@ spec:
 
 If the chart's `values.yaml` has `gpu.enabled: false` and the customer has not overridden it, the GPU node check is excluded from the rendered spec.
 
+### Run connectivity checks inside the cluster {#in-cluster-collectors}
+
+The `http`, `postgres`, `mysql`, `mssql`, `redis`, and `clickhouse` collectors run wherever the preflight process runs. In Embedded Cluster v3, that is the host, not inside the cluster. As a result, a check such as "is the application's database reachable" tests connectivity from the host rather than from within the cluster, which can produce misleading results.
+
+To run one of these checks from inside the cluster, wrap it in a [`runPod`](https://troubleshoot.sh/docs/collect/run-pod) collector that uses the Troubleshoot image and the matching `collect` subcommand. The Pod runs the collector from within the cluster and prints its result, which you evaluate with a [`textAnalyze`](https://troubleshoot.sh/docs/analyze/regex) analyzer. The following example checks that a PostgreSQL database is reachable from inside the cluster:
+
+```yaml
+apiVersion: troubleshoot.sh/v1beta3
+kind: Preflight
+metadata:
+  name: my-app-preflights
+spec:
+  collectors:
+    - runPod:
+        name: postgres-check
+        namespace: '{{ .Release.Namespace }}'
+        podSpec:
+          restartPolicy: Never
+          containers:
+            - name: check
+              image: proxy.replicated.com/library/troubleshoot:v0.131.0
+              command: ["collect", "postgres", "--uri", "postgres://{{ .Values.db.user }}:{{ .Values.db.password }}@{{ .Values.db.host }}:5432/{{ .Values.db.name }}"]
+  analyzers:
+    - textAnalyze:
+        checkName: PostgreSQL reachable
+        collectorName: postgres-check
+        fileName: "*.log"
+        regex: '"isConnected": *true'
+        outcomes:
+          - pass:
+              when: "true"
+              message: "Connected to PostgreSQL from inside the cluster."
+          - fail:
+              when: "false"
+              message: "Could not connect to PostgreSQL from inside the cluster."
+```
+
+Each collector documents its `collect` subcommand and flags on its own page in the Troubleshoot documentation: [http](https://troubleshoot.sh/docs/collect/http), [postgres](https://troubleshoot.sh/docs/collect/postgresql), [mysql](https://troubleshoot.sh/docs/collect/mysql), [mssql](https://troubleshoot.sh/docs/collect/mssql), [redis](https://troubleshoot.sh/docs/collect/redis), and [clickhouse](https://troubleshoot.sh/docs/collect/clickhouse).
+
+### Include preflight images in air gap bundles {#preflight-air-gap-images}
+
+In air gap installations, images referenced by a v1beta3 preflight spec are **not** automatically included in the air gap bundle. This includes the Troubleshoot image used to run checks inside the cluster (see [Run connectivity checks inside the cluster](#in-cluster-collectors)) and any other images your collectors reference, such as a `runPod` container image. Unlike application workload images, which are detected from your Helm charts, preflight images must be declared explicitly.
+
+Add each image to the `additionalImages` field of the [Application custom resource](/reference/custom-resource-application) so that it is included in the air gap bundle:
+
+```yaml
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  additionalImages:
+    - proxy.replicated.com/library/troubleshoot:v0.131.0
+```
+
+For more information, see [Define Additional Images](/vendor/operator-defining-additional-images).
+
 ### Limitations
 
 - A release may contain at most one external preflight spec.

--- a/embedded-cluster/embedded-v3-migrate.mdx
+++ b/embedded-cluster/embedded-v3-migrate.mdx
@@ -44,6 +44,8 @@ v1beta3 supports this model because it treats the spec as Helm template YAML rat
 - The spec uses Helm template syntax (`{{ .Values.something }}`, `{{ include "helper" . }}`) instead of `repl{{ }}` Replicated template syntax.
 - The spec is not valid YAML before rendering. Standard YAML linters will not work on it directly.
 - For releases with multiple Helm charts, you can use `{{ if eq .Chart.Name "my-chart" }}` conditionals to gate specific collectors or analyzers to the chart they belong to. Embedded Cluster renders the spec one time per chart in the release, each time in that chart's context.
+- The connectivity collectors (`http`, `postgres`, `mysql`, `mssql`, `redis`, and `clickhouse`) run wherever the preflight process runs, which is the host in Embedded Cluster v3, rather than inside the cluster as they did under KOTS. To run these checks from within the cluster, wrap them in a `runPod` collector. See [Run connectivity checks inside the cluster](embedded-using#in-cluster-collectors).
+- For air gap installations, images referenced by the preflight spec (such as the Troubleshoot image used to run checks inside the cluster) are not automatically included in the air gap bundle and must be added to the Application `additionalImages` field. See [Include preflight images in air gap bundles](embedded-using#preflight-air-gap-images).
 
 For details about the rendering pipeline and multi-chart examples, see [Add preflight checks](embedded-using#preflights). For more information about the v1beta3 spec format, see [v1beta3 overview](https://troubleshoot.sh/docs/preflight/v1beta3-overview) in the Troubleshoot documentation.
 


### PR DESCRIPTION
## What
Expands the Embedded Cluster v3 **Add preflight checks** section (`embedded-using.mdx`) with two subsections:

- **Run connectivity checks inside the cluster** — explains that the `http`, `postgres`, `mysql`, `mssql`, `redis`, and `clickhouse` collectors run where the preflight process runs (the host in v3), and shows how to run them from inside the cluster with a `runPod` collector using the Troubleshoot image and the `collect <name>` subcommand, analyzed with `textAnalyze`. Includes a postgres example and links to each collector's page in the Troubleshoot docs for its flags.
- **Include preflight images in air gap bundles** — documents that images referenced by a v1beta3 preflight (the Troubleshoot image and any `runPod` image) are not auto-detected and must be listed in the Application `additionalImages`.

## Why
In v3, these collectors run on the host rather than in-cluster (as they did under KOTS), so connectivity checks can be misleading unless run in a pod. And unlike workload images detected from Helm charts, preflight images must be declared for air gap.

## Notes
- Scoped to the EC v3 page; the v1beta2 vendor preflight docs are unchanged.
- `registryImages` is intentionally excluded (no `collect` subcommand yet).
- Collector reference and flag details live in the Troubleshoot docs (linked), not duplicated here.
