### PR TITLE
Add node reboot guidance to EC manage nodes page

### DIFF
--- a/embedded-cluster/embedded-manage-nodes.mdx
+++ b/embedded-cluster/embedded-manage-nodes.mdx
@@ -136,6 +136,22 @@ To enable HA for an existing Embedded Cluster installation with three or more co
 
    Where `APP_SLUG` is the unique slug for the application.
 
+## Reboot nodes
+
+Embedded Cluster runs Kubernetes (k0s) as a systemd service, so a node automatically rejoins the cluster after a reboot. No special preparation is required — you do not need to cordon or drain the node before rebooting.
+
+**Single-node clusters:** The application is unavailable while the node is rebooting. Schedule reboots during a maintenance window, and expect a short outage (typically a few minutes) while the node restarts and pods are rescheduled.
+
+**Multi-node clusters:** Reboot one node at a time. Wait for the rebooted node to fully rejoin the cluster and report `Ready` before rebooting the next node. Do not reboot two or more controller nodes at the same time — losing multiple controllers simultaneously can break etcd quorum and take the entire cluster offline.
+
+To check whether a node has rejoined after a reboot, run the following command from a controller node:
+
+```bash
+sudo ./APP_SLUG shell kubectl get nodes
+```
+
+Where `APP_SLUG` is the unique slug for the application. All nodes should show `Ready` status before proceeding with the next reboot.
+
 ## Reset nodes and remove clusters
 
 This section describes how to reset individual nodes and how to delete an entire multi-node cluster using the Embedded Cluster [reset](embedded-cluster-reset) command.

--- a/embedded-cluster/embedded-manage-nodes.mdx
+++ b/embedded-cluster/embedded-manage-nodes.mdx
@@ -147,7 +147,7 @@ Embedded Cluster runs Kubernetes (k0s) as a systemd service, so a node automatic
 To check whether a node has rejoined after a reboot, run the following command from a controller node:
 
 ```bash
-sudo ./APP_SLUG shell kubectl get nodes
+sudo ./APP_SLUG shell -c "kubectl get nodes"
 ```
 
 Where `APP_SLUG` is the unique slug for the application. All nodes should show `Ready` status before proceeding with the next reboot.

--- a/embedded-cluster_versioned_docs/version-2.0.0/embedded-manage-nodes.mdx
+++ b/embedded-cluster_versioned_docs/version-2.0.0/embedded-manage-nodes.mdx
@@ -178,7 +178,7 @@ Embedded Cluster runs Kubernetes (k0s) as a systemd service, so a node automatic
 To check whether a node has rejoined after a reboot, run the following command from a controller node:
 
 ```bash
-sudo ./APP_SLUG shell kubectl get nodes
+sudo ./APP_SLUG shell -c "kubectl get nodes"
 ```
 
 Where `APP_SLUG` is the unique slug for the application. All nodes should show `Ready` status before proceeding with the next reboot.

--- a/embedded-cluster_versioned_docs/version-2.0.0/embedded-manage-nodes.mdx
+++ b/embedded-cluster_versioned_docs/version-2.0.0/embedded-manage-nodes.mdx
@@ -167,6 +167,22 @@ sudo ./APP_SLUG enable-ha
 
 Where `APP_SLUG` is the unique slug for the application.
 
+## Reboot nodes
+
+Embedded Cluster runs Kubernetes (k0s) as a systemd service, so a node automatically rejoins the cluster after a reboot. No special preparation is required — you do not need to cordon or drain the node before rebooting.
+
+**Single-node clusters:** The application is unavailable while the node is rebooting. Schedule reboots during a maintenance window, and expect a short outage (typically a few minutes) while the node restarts and pods are rescheduled.
+
+**Multi-node clusters:** Reboot one node at a time. Wait for the rebooted node to fully rejoin the cluster and report `Ready` before rebooting the next node. Do not reboot two or more controller nodes at the same time — losing multiple controllers simultaneously can break etcd quorum and take the entire cluster offline.
+
+To check whether a node has rejoined after a reboot, run the following command from a controller node:
+
+```bash
+sudo ./APP_SLUG shell kubectl get nodes
+```
+
+Where `APP_SLUG` is the unique slug for the application. All nodes should show `Ready` status before proceeding with the next reboot.
+
 ## Reset nodes and remove clusters
 
 This section describes how to reset individual nodes and how to delete an entire multi-node cluster using the Embedded Cluster [reset](embedded-cluster-reset) command.


### PR DESCRIPTION
Preview link 
* v3 https://deploy-preview-4261--replicated-docs.netlify.app/embedded-cluster/v3/embedded-manage-nodes#reboot-nodes
* v2 https://deploy-preview-4261--replicated-docs.netlify.app/embedded-cluster/v2/embedded-manage-nodes#reboot-nodes

## Summary

- Adds a "Reboot nodes" section to the "Access and manage embedded clusters" page, between the HA section and the "Reset nodes and remove clusters" section
- Covers single-node maintenance windows, rolling reboots for multi-node HA clusters, and etcd quorum safety for controller nodes
- Documents that no cordon/drain is needed for reboots (k0s auto-restarts via systemd)
- Includes a `kubectl get nodes` check for verifying a node has rejoined after reboot

Prompted by a vendor question in Slack about best practices for restarting nodes. This guidance applies to both EC v2 and v3 since both use k0s as the underlying Kubernetes distribution.

## Test plan

- [ ] Verify the new section renders correctly on the docs site
- [ ] Confirm the `shell kubectl get nodes` command example is accurate for the current EC CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)