### PR TITLE
Rename EP vendor API page to Headless Automation

### DIFF
--- a/docs/vendor/enterprise-portal-v2-vendor-api-automation.mdx
+++ b/docs/vendor/enterprise-portal-v2-vendor-api-automation.mdx
@@ -1,15 +1,17 @@
-# Automate Enterprise Portal with the Vendor API
+---
+sidebar_label: Enterprise Portal Headless Automation
+---
+
+# Enterprise Portal Headless Automation
 
 :::important Alpha Feature
 Features described on this page are in alpha and subject to change. Some capabilities might require additional access.
 :::
 
-This topic describes how to use the Vendor API to manage Enterprise Portal setup for your customers.
-Use these APIs when your own systems create customers, invite customer users, prepare install profiles, or revoke Enterprise Portal service accounts.
+The Enterprise Portal can be operated headlessly through the Vendor API v3. This lets you integrate Enterprise Portal functionality into your existing distribution portal, support portal, or internal tooling rather than directing customers to the Enterprise Portal UI. Common use cases include automating customer onboarding, embedding portal access into your own product, and programmatically managing install profiles and instructions.
 
-Vendor API automation is different from customer service account automation.
 Vendor API requests use a vendor API token and run against `https://api.replicated.com/vendor/v3`.
-Customer service account requests use a customer service account token and run against your Enterprise Portal domain.
+This is different from customer service account automation, where customer service account requests use a customer service account token and run against your Enterprise Portal domain.
 
 ## When to use the Vendor API
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -221,10 +221,10 @@ const sidebars = {
         "vendor/enterprise-portal-v2-terraform",
         "vendor/enterprise-portal-v2-access",
         "vendor/enterprise-portal-v2-invite",
-        "vendor/enterprise-portal-v2-vendor-api-automation",
         "vendor/enterprise-portal-v2-self-serve-signup",
         "vendor/enterprise-portal-v2-use",
         "vendor/enterprise-portal-v2-troubleshooting",
+        "vendor/enterprise-portal-v2-vendor-api-automation",
       ],
     },
     {


### PR DESCRIPTION
## Summary
- Renames the page title and sidebar label from "Automate Enterprise Portal with the Vendor API" to "Enterprise Portal Headless Automation"
- Updates the intro to explicitly frame the headless use case: integrating EP functionality into existing vendor distribution or support portals
- Moves the nav entry to the last position in the EP v2 sidebar section

## Test plan
- [ ] Verify sidebar renders "Enterprise Portal Headless Automation" as the last item in the EP v2 section
- [ ] Verify the page intro reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)