### PR TITLE
Fix EC v3 extension helmCharts values: YAML map, not multi-line string

### DIFF
--- a/embedded-cluster/embedded-config.mdx
+++ b/embedded-cluster/embedded-config.mdx
@@ -204,8 +204,6 @@ Each extension chart is installed with `helm upgrade --install --wait --wait-for
 
 * You must provide `chart.chartVersion`. Omitting it can cause upgrade issues.
 
-* The `values` field must be nested YAML, not a multi-line string (`values: |`). Vendor Portal does not reject releases where `values` is a string, and air gap bundles still build, but installation fails when Embedded Cluster parses the extension.
-
 * For air gap bundles, images used by Helm extensions must not refer to a multi-architecture image by digest. Air gap bundles include only x64 images, and the digest for the x64 image will be different from the digest for the multi-architecture image, preventing Kubernetes from locating the image in the bundle. For an example of how to set digests to empty strings and pull by tag only, see the `ingress-nginx` [Example](embedded-config#extension-example).
 
 #### Example {#extension-example}

--- a/embedded-cluster/embedded-config.mdx
+++ b/embedded-cluster/embedded-config.mdx
@@ -42,7 +42,7 @@ spec:
           chartVersion: "4.11.3"
         releaseName: ingress-nginx
         namespace: ingress-nginx
-        values: |
+        values:
           controller:
             service:
               type: NodePort
@@ -66,7 +66,7 @@ spec:
         releaseName: goldpinger
         namespace: goldpinger
         weight: 11
-        values: |
+        values:
           image:
             repository: 'repl{{ ReplicatedImageName "docker.io/bloomberg/goldpinger" }}'
 ```
@@ -196,13 +196,15 @@ Each object in `helmCharts` can include the following fields:
 * `releaseName`: (Required) Helm release name.
 * `namespace`: (Required) Namespace for the release.
 * `weight`: Controls installation order relative to other Helm chart extensions. Lower weights install before higher weights. When weights are equal, charts install in alphabetical order by namespace and release name. The default weight is `0`. Negative weights are supported.
-* `values`: Multi-line string of Helm values. This field supports [Replicated template functions](/reference/template-functions-about). Embedded Cluster updates Helm extensions when users deploy new versions of your application. For example, you can change `values` from one release to another, and those changes apply when the user deploys the new version.
+* `values`: Helm values for the chart, provided as nested YAML (a map, not a multi-line string). This field supports [Replicated template functions](/reference/template-functions-about). Embedded Cluster updates Helm extensions when users deploy new versions of your application. For example, you can change `values` from one release to another, and those changes apply when the user deploys the new version.
 
 Each extension chart is installed with `helm upgrade --install --wait --wait-for-jobs`, so Helm hooks (such as `pre-install` and `pre-upgrade` Jobs) run and must succeed before the next chart begins.
 
 #### Requirements
 
 * You must provide `chart.chartVersion`. Omitting it can cause upgrade issues.
+
+* The `values` field must be nested YAML, not a multi-line string (`values: |`). Vendor Portal does not reject releases where `values` is a string, and air gap bundles still build, but installation fails when Embedded Cluster parses the extension.
 
 * For air gap bundles, images used by Helm extensions must not refer to a multi-architecture image by digest. Air gap bundles include only x64 images, and the digest for the x64 image will be different from the digest for the multi-architecture image, preventing Kubernetes from locating the image in the bundle. For an example of how to set digests to empty strings and pull by tag only, see the `ingress-nginx` [Example](embedded-config#extension-example).
 
@@ -219,7 +221,7 @@ spec:
           chartVersion: "4.11.3"
         releaseName: ingress-nginx
         namespace: ingress-nginx
-        values: |
+        values:
           controller:
             service:
               type: NodePort

--- a/embedded-cluster/embedded-config.mdx
+++ b/embedded-cluster/embedded-config.mdx
@@ -196,7 +196,7 @@ Each object in `helmCharts` can include the following fields:
 * `releaseName`: (Required) Helm release name.
 * `namespace`: (Required) Namespace for the release.
 * `weight`: Controls installation order relative to other Helm chart extensions. Lower weights install before higher weights. When weights are equal, charts install in alphabetical order by namespace and release name. The default weight is `0`. Negative weights are supported.
-* `values`: Helm values for the chart, provided as nested YAML (a map, not a multi-line string). This field supports [Replicated template functions](/reference/template-functions-about). Embedded Cluster updates Helm extensions when users deploy new versions of your application. For example, you can change `values` from one release to another, and those changes apply when the user deploys the new version.
+* `values`: Helm values for the chart, provided as nested YAML. This field supports [Replicated template functions](/reference/template-functions-about). Embedded Cluster updates Helm extensions when users deploy new versions of your application. For example, you can change `values` from one release to another, and those changes apply when the user deploys the new version.
 
 Each extension chart is installed with `helm upgrade --install --wait --wait-for-jobs`, so Helm hooks (such as `pre-install` and `pre-upgrade` Jobs) run and must succeed before the next chart begins.
 

--- a/embedded-cluster/embedded-using.mdx
+++ b/embedded-cluster/embedded-using.mdx
@@ -425,7 +425,7 @@ spec:
           chartVersion: "v24.9.1"
         releaseName: gpu-operator
         namespace: gpu-operator
-        values: |
+        values:
           # configure the containerd options
           toolkit:
             env:

--- a/embedded-cluster/embedded-v3-migrate.mdx
+++ b/embedded-cluster/embedded-v3-migrate.mdx
@@ -152,7 +152,7 @@ To update a release from Embedded Cluster v2 to v3:
              chartVersion: "4.11.3"
            releaseName: ingress-nginx
            namespace: ingress-nginx
-           values: |
+           values:
              controller:
                service:
                  type: NodePort

--- a/embedded-cluster/template-functions.mdx
+++ b/embedded-cluster/template-functions.mdx
@@ -203,7 +203,7 @@ extensions:
         chartVersion: "4.11.3"
       releaseName: ingress-nginx
       namespace: ingress-nginx
-      values: |
+      values:
         controller:
           image:
             registry: 'repl{{ ReplicatedImageRegistry "registry.k8s.io" }}'


### PR DESCRIPTION
## What

In Embedded Cluster v3, `extensions.helmCharts[].values` must be nested YAML (it is unmarshaled into `map[string]any` — see [`pkg/appcharts/appcharts.go`](https://github.com/replicatedhq/ec/blob/main/pkg/appcharts/appcharts.go) `HelmChartSpec.Values`), unlike EC v2 where it was a multi-line string. The v3 docs carried the v2 convention forward:

- The `values` field description on [/embedded-cluster/v3/embedded-config#helmcharts](https://docs.replicated.com/embedded-cluster/v3/embedded-config#helmcharts) said "Multi-line string of Helm values"
- Every v3 extension example used a block scalar (`values: |`)

## Why it matters

A release authored per the current docs passes Vendor Portal lint and airgap builds, but installation fails with `cannot unmarshal !!str into map[string]interface {}` when Embedded Cluster parses the extension (reproduced end-to-end on a test app).

## Changes

- Correct the `values` field description in `embedded-config.mdx`
- Change `values: |` to `values:` in all v3 extension examples: `embedded-config.mdx` (3 examples), `embedded-using.mdx` (GPU operator), `embedded-v3-migrate.mdx`, `template-functions.mdx`

Deliberately unchanged, verified against the EC v3 source:

- `unsupportedOverrides.builtInExtensions[].values` — genuinely a multi-line string in v3 (`pkg/addons/config.go` asserts `.(string)`)
- `unsupportedOverrides.k0s` — also a string
- v2 versioned docs (`embedded-cluster_versioned_docs/version-2.0.0/`) — v2's k0s-based schema really does use string values

All edited YAML examples were validated to parse with `values` as a map, and the dryrun extension tests confirm template functions render correctly in map-form values.