### PR TITLE
Add customer automation examples to SA enablement page

### DIFF
--- a/docs/vendor/enterprise-portal-v2-service-account-automation.mdx
+++ b/docs/vendor/enterprise-portal-v2-service-account-automation.mdx
@@ -26,6 +26,26 @@ With these docs in the portal, customers can:
 
 These docs are customer-facing. They describe the Enterprise Portal API that runs from the customer's portal domain. They do not replace the Replicated Vendor API.
 
+## Customer automation examples
+
+The Workflow Guide component covers the initial install flow. The following examples show additional automation patterns your customers can build with the service account API.
+
+### Automated upgrade pipeline
+
+A customer's CI/CD system polls for new releases and applies upgrades automatically, without checking the portal manually or waiting for email notifications.
+
+A scheduled job calls the latest release endpoint and compares the returned version against the currently deployed version. When a new version is available, the job updates the customer's existing install options record to target the new version, fetches the generated update instructions, and executes the returned commands to apply the upgrade.
+
+This pattern lets customers keep installations current without adopting an in-cluster agent or operator. The polling interval and upgrade approval logic are controlled entirely by the customer's own automation. A polling interval between 15 minutes and 1 hour is reasonable for most release cadences.
+
+### Pre-stage airgap artifacts
+
+A customer in an air-gapped environment downloads new release artifacts and stages them in an internal repository before a maintenance window, so the upgrade itself only needs to apply pre-staged assets.
+
+A scheduled job polls for the latest available release and compares the returned version against the last staged version. When a new version is available, the job updates the customer's existing install options record, fetches update instructions, downloads each artifact referenced in the instruction steps, and pushes them to an internal artifact store. The operations team is notified that the new version is staged and ready.
+
+This pattern separates artifact retrieval from the upgrade itself, which is useful when the air-gapped network has a narrow transfer window or when artifacts need security scanning before deployment.
+
 ## Add the default pages
 
 The default Enterprise Portal content template includes an **Automation** section.


### PR DESCRIPTION
## Summary
- Adds a "Customer automation examples" section under "Why add automation docs" on the Enable Customer Automation page
- Two examples: automated upgrade pipeline (polling for new releases) and pre-staging airgap artifacts
- Helps vendors understand why to enable the service account API for their customers

Relates to sc-138835

## Test plan
- [ ] Verify page renders correctly in Docusaurus
- [ ] Confirm examples section reads well positioned between "Why add automation docs" and "Add the default pages"

🤖 Generated with [Claude Code](https://claude.com/claude-code)