### PR TITLE
docs(ec): cover repo/OCI-sourced Helm extension charts in v2→v3 migration

### DIFF
--- a/embedded-cluster/embedded-config.mdx
+++ b/embedded-cluster/embedded-config.mdx
@@ -202,6 +202,8 @@ Each extension chart is installed with `helm upgrade --install --wait --wait-for
 
 #### Requirements
 
+* Each chart referenced in `helmCharts` must be packaged as a `.tgz` chart archive and included in the release. Embedded Cluster resolves extension charts from bundled archives by `chart.name` and `chart.chartVersion`; it does not pull them from an HTTP Helm repository or an OCI registry at install time. See [Add Helm chart extensions](embedded-using#add-extensions).
+
 * You must provide `chart.chartVersion`. Omitting it can cause upgrade issues.
 
 * For air gap bundles, images used by Helm extensions must not refer to a multi-architecture image by digest. Air gap bundles include only x64 images, and the digest for the x64 image will be different from the digest for the multi-architecture image, preventing Kubernetes from locating the image in the bundle. For an example of how to set digests to empty strings and pull by tag only, see the `ingress-nginx` [Example](embedded-config#extension-example).

--- a/embedded-cluster/embedded-config.mdx
+++ b/embedded-cluster/embedded-config.mdx
@@ -204,6 +204,8 @@ Each extension chart is installed with `helm upgrade --install --wait --wait-for
 
 * Each chart referenced in `helmCharts` must be packaged as a `.tgz` chart archive and included in the release. Embedded Cluster resolves extension charts from bundled archives by `chart.name` and `chart.chartVersion`; it does not pull them from an HTTP Helm repository or an OCI registry at install time. See [Add Helm chart extensions](embedded-using#add-extensions).
 
+* Extension charts do not need a separate HelmChart v2 custom resource. The `extensions.helmCharts` entry in the Embedded Cluster Config serves the same purpose.
+
 * You must provide `chart.chartVersion`. Omitting it can cause upgrade issues.
 
 * For air gap bundles, images used by Helm extensions must not refer to a multi-architecture image by digest. Air gap bundles include only x64 images, and the digest for the x64 image will be different from the digest for the multi-architecture image, preventing Kubernetes from locating the image in the bundle. For an example of how to set digests to empty strings and pull by tag only, see the `ingress-nginx` [Example](embedded-config#extension-example).

--- a/embedded-cluster/embedded-using.mdx
+++ b/embedded-cluster/embedded-using.mdx
@@ -371,9 +371,23 @@ Embedded Cluster installations in air gap environments have the following limita
 
 If your application requires certain components deployed before the application and as part of the cluster itself, add them as [extensions](embedded-config#extensions) in the Embedded Cluster Config. For example, you can add a Helm extension to deploy an ingress controller. You can add extensions for Helm charts that you own or for third-party charts.
 
+Embedded Cluster v3 resolves each extension chart from a `.tgz` chart archive that is bundled in the release, matching by chart name and version. It does not pull extension charts at install time from an HTTP Helm repository or an OCI registry. For this reason, adding an extension for a chart hosted in a repository or registry requires you to first package the chart as a `.tgz` archive and include it in your release, the same way you do for your application charts.
+
 To add Helm extensions:
 
-1. In the Embedded Cluster Config, add the Helm chart to the [`extensions`](embedded-config#extensions) key.
+1. Package the chart as a `.tgz` archive at the version you want to install, and add the archive to your release. For a chart hosted in an HTTP Helm repository or an OCI registry, pull it first with `helm pull`. For example:
+
+   ```bash
+   # HTTP Helm repository
+   helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+   helm repo update
+   helm pull ingress-nginx/ingress-nginx --version 4.11.3
+
+   # OCI registry
+   helm pull oci://quay.io/jetstack/charts/cert-manager --version 1.19.2
+   ```
+
+1. Reference the chart in the Embedded Cluster Config under [`extensions.helmCharts`](embedded-config#extensions), using a `chart.name` and `chart.chartVersion` that match the packaged archive's `Chart.yaml`.
 
 1. If you support air gap installations, configure each of your `extensions` so that they resolve correctly for both online and air gap installations. See [Add support for air gap installations](#local-image-registry) on this page.
 

--- a/embedded-cluster/embedded-v3-migrate.mdx
+++ b/embedded-cluster/embedded-v3-migrate.mdx
@@ -55,7 +55,7 @@ To use Embedded Cluster v3, package your application as one or more Helm charts.
 
 ### HelmChart v2 required
 
-Embedded Cluster v3 supports installing Helm charts with a corresponding HelmChart v2 custom resource (API version `v1beta2`). It does not support HelmChart v1.
+Embedded Cluster v3 supports installing Helm charts with a corresponding HelmChart v2 custom resource (API version `v1beta2`). It does not support HelmChart v1. Extension charts defined in the Embedded Cluster Config do not need a separate HelmChart CR — the extension schema in the Config serves the same purpose.
 
 ### Helm extension charts must be bundled in the release {#extension-charts}
 
@@ -137,7 +137,7 @@ To update a release from Embedded Cluster v2 to v3:
 
    For more information about the v1beta3 migration, see [Migrate from v1beta2 to v1beta3](https://troubleshoot.sh/docs/preflight/v1beta3-migration) in the Troubleshoot documentation.
 
-1. Ensure that your release has a corresponding HelmChart v2 custom resource for each of your Helm charts. See [HelmChart v2](/reference/custom-resource-helmchart-v2).
+1. Ensure that your release has a corresponding HelmChart v2 custom resource for each of your application Helm charts. Extension charts defined in the Embedded Cluster Config do not need a separate HelmChart CR. See [HelmChart v2](/reference/custom-resource-helmchart-v2).
 
 1. In your Embedded Cluster Config, update `version` to the latest version of Embedded Cluster v3. You can also optionally increment the Kubernetes version by one minor version.
 

--- a/embedded-cluster/embedded-v3-migrate.mdx
+++ b/embedded-cluster/embedded-v3-migrate.mdx
@@ -57,6 +57,14 @@ To use Embedded Cluster v3, package your application as one or more Helm charts.
 
 Embedded Cluster v3 supports installing Helm charts with a corresponding HelmChart v2 custom resource (API version `v1beta2`). It does not support HelmChart v1.
 
+### Helm extension charts must be bundled in the release {#extension-charts}
+
+In Embedded Cluster v2, Helm extensions defined under `extensions.helm.charts` were pulled at install time from an HTTP Helm repository or an OCI registry, based on the `chartname` and `version` fields (and any repositories listed under `extensions.helm.repositories`).
+
+Embedded Cluster v3 does not pull extension charts at install time from any source, whether an HTTP Helm repository or an OCI registry. Instead, it resolves each extension chart from a `.tgz` chart archive that is bundled in the release, matching by chart name and version. The v3 `extensions.helmCharts` schema has no repository or registry field.
+
+As a result, migrating a repo-sourced or OCI-sourced v2 extension is not only a change to the Config YAML shape. You must also package the chart as a `.tgz` archive and include it in the release. For the steps, see [Update your release to Embedded Cluster v3](#update-your-release-to-embedded-cluster-v3) below.
+
 ### Config value defaults are persisted at install time
 
 In Embedded Cluster v2 (KOTS), only config values explicitly set by the end customer were persisted. Default values from the Config spec were re-evaluated on each release, so changing a `default` field in a new release would take effect for any field the customer hadn't explicitly set.
@@ -137,9 +145,31 @@ To update a release from Embedded Cluster v2 to v3:
 
     <EcConfig/>    
 
-1. Update any existing Helm extensions to use the `extensions.helmChart` format. See [`extensions`](embedded-config#extensions).
+1. Update any existing Helm extensions to the v3 `extensions.helmCharts` format. See [`extensions`](embedded-config#extensions).
 
-   **Example:**
+   Because Embedded Cluster v3 resolves extension charts from bundled `.tgz` archives rather than pulling them from a repository or registry (see [Helm extension charts must be bundled in the release](#extension-charts)), updating the Config YAML is not sufficient on its own. For each Helm extension you defined in v2:
+
+   1. Pull the chart to a local `.tgz` archive at the version you want to install.
+
+      For a chart hosted in an HTTP Helm repository (for example, a v2 `chartname` such as `ingress-nginx/ingress-nginx`):
+
+      ```bash
+      helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+      helm repo update
+      helm pull ingress-nginx/ingress-nginx --version 4.11.3
+      ```
+
+      For a chart hosted in an OCI registry (for example, a v2 `chartname` such as `oci://quay.io/jetstack/charts/cert-manager`):
+
+      ```bash
+      helm pull oci://quay.io/jetstack/charts/cert-manager --version 1.19.2
+      ```
+
+   1. Add the resulting `.tgz` archive to your release.
+
+   1. Reference the chart in the Embedded Cluster Config under `extensions.helmCharts`, using a `chart.name` and `chart.chartVersion` that match the packaged archive's `Chart.yaml`.
+
+   **Example Config:**
 
    ```yaml
    apiVersion: embeddedcluster.replicated.com/v1beta1


### PR DESCRIPTION
Fixes [SC-138905](https://app.shortcut.com/replicated/story/138905)

## Problem

Embedded Cluster v3 resolves Helm extension charts from `.tgz` archives **bundled in the release**. It does not pull extension charts at install time from an HTTP Helm repository or an OCI registry — the v3 `extensions.helmCharts` schema has no repository/registry field.

A vendor migrating a v2 extension whose chart was sourced from a repo or registry (e.g. `chartname: ingress-nginx/ingress-nginx` or `chartname: oci://quay.io/jetstack/charts/cert-manager`) hits a wall: the v2→v3 migration docs only showed the Config YAML shape change and never explained where the `.tgz` comes from. In one case a v2-shaped extensions config was promoted under a v3 apiVersion, the extension's images never made it into the air gap bundle, and the install failed.

## What this changes

Docs-only. Closes the migration-path gap by documenting the fetch-and-bundle procedure.

- **`embedded-v3-migrate.mdx`** — new comparison subsection *"Helm extension charts must be bundled in the release"* explaining the v2 (repo/OCI pull) → v3 (bundled `.tgz`) model; and expands the extensions migration step from a pure YAML swap into: `helm pull` (HTTP repo **and** OCI examples) → add the `.tgz` to the release → reference it in `extensions.helmCharts`.
- **`embedded-using.mdx`** (`#add-extensions`) — states the bundled-`.tgz` requirement and expands the steps to package/pull and reference the chart.
- **`embedded-config.mdx`** — adds a requirements bullet to the `extensions.helmCharts` reference.

Example chart sources were verified against upstream: `https://kubernetes.github.io/ingress-nginx` (valid repo, versions have no `v` prefix) and `oci://quay.io/jetstack/charts/cert-manager` (canonical OCI location; the `1.19.2` tag exists on quay.io).

## Out of scope

The related asks to add a **promote-time lint for a missing chart archive / HelmChart CR** and to **fetch-and-bundle at the platform level during promote** are code/product changes in other repos, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)