### PR TITLE
EP v2 docs: reduce content-repo onboarding confusion

### DIFF
--- a/docs/vendor/enterprise-portal-v2-access.mdx
+++ b/docs/vendor/enterprise-portal-v2-access.mdx
@@ -18,13 +18,15 @@ From anywhere on your machine, run the command below, replacing both placeholder
 - `<your-app-slug>` — your application's slug.
 
 ```shell
-replicated enterprise-portal preview /path/to/your-content-repo --app <your-app-slug>
+replicated enterprise-portal preview /path/to/your-content-repo \
+  --app <your-app-slug>
 ```
 
 For example, if you cloned your repo to `~/repos/acme-enterprise-portal-content` and your app slug is `acme`:
 
 ```shell
-replicated enterprise-portal preview ~/repos/acme-enterprise-portal-content --app acme
+replicated enterprise-portal preview ~/repos/acme-enterprise-portal-content \
+  --app acme
 ```
 
 The CLI pulls a preview container (first run only), starts a local server, and opens the full Enterprise Portal experience at `http://localhost:3000` (auto-increments if the port is busy).

--- a/docs/vendor/enterprise-portal-v2-access.mdx
+++ b/docs/vendor/enterprise-portal-v2-access.mdx
@@ -12,13 +12,26 @@ Run the Enterprise Portal locally using the Replicated CLI. This is the fastest 
 
 **Prerequisites:** Docker running, the `replicated` CLI installed, and your content repo checked out locally.
 
-From anywhere on your machine:
+From anywhere on your machine, run the command below, replacing both placeholders:
+
+- `/path/to/your-content-repo` — the absolute path to the local directory where you cloned your content repo. This is a path on disk, not a Git URL, and not the literal placeholder text.
+- `<your-app-slug>` — your application's slug.
 
 ```shell
 replicated enterprise-portal preview /path/to/your-content-repo --app <your-app-slug>
 ```
 
+For example, if you cloned your repo to `~/repos/acme-enterprise-portal-content` and your app slug is `acme`:
+
+```shell
+replicated enterprise-portal preview ~/repos/acme-enterprise-portal-content --app acme
+```
+
 The CLI pulls a preview container (first run only), starts a local server, and opens the full Enterprise Portal experience at `http://localhost:3000` (auto-increments if the port is busy).
+
+:::note
+If you see `content path does not exist: /path/to/repo`, the example path was run literally. Replace it with the absolute path to your locally cloned content repo.
+:::
 
 If you are authenticated with the CLI (`replicated login`, `REPLICATED_API_TOKEN`, or `--token`), a customer switcher dropdown appears in the preview toolbar. Switching customers re-renders the page with that customer's entitlements, channel, and license data applied. Without a token, the preview runs with mock customer data.
 

--- a/docs/vendor/enterprise-portal-v2-connect-repo.mdx
+++ b/docs/vendor/enterprise-portal-v2-connect-repo.mdx
@@ -82,6 +82,28 @@ Click **Review** on the Content tab banner to open the template updates modal. E
 
 ### Applying an update
 
-Template updates do not apply automatically. Each update's guide describes what files to copy or modify and what to verify after making the change. Because your repo has diverged from the template, each guide provides targeted adoption steps rather than a wholesale merge.
+Template updates do not apply automatically, and Replicated does not modify your repo. The banner is an informational feed of changes published since your last review, not a comparison against your repo or a list of changes you are missing. Each update's guide describes what files to copy or modify and what to verify.
 
-After reviewing the available updates, click **Mark reviewed** to acknowledge them. The banner clears until Replicated publishes the next template update. Marking updates as reviewed is per-user, so other team members continue to see the banner until they review it themselves.
+Because you cloned the template rather than forked it, your repo shares no Git history with it, so you cannot bring in updates with a plain `git pull` or `git merge`. Instead, add the template as a remote once, then pull in the specific files each guide lists:
+
+```shell
+# One-time setup: add the template as a remote
+git remote add upstream https://github.com/replicatedhq/enterprise-portal-content.git
+git fetch upstream
+
+# See what changed in the template compared to your content
+git diff HEAD upstream/main -- pages toc.yaml theme.yaml updates
+
+# Bring in the files a specific update's guide lists, then review and commit
+git checkout upstream/main -- pages/example.md toc.yaml
+git add -A && git commit -m "Adopt template update"
+git push
+```
+
+Verify the result with a [local preview](/vendor/enterprise-portal-v2-access#local-preview) before pushing to a branch that customers see.
+
+:::note
+Adopting an update on one branch does not propagate it to your other branches. If you maintain version branches, apply the update to each branch where you want it.
+:::
+
+After reviewing the available updates, click **Mark reviewed** to acknowledge them. This only clears the banner for you and does not change your repo. Marking updates as reviewed is per-user, so other team members continue to see the banner until they review it themselves.

--- a/docs/vendor/enterprise-portal-v2-troubleshooting.mdx
+++ b/docs/vendor/enterprise-portal-v2-troubleshooting.mdx
@@ -23,6 +23,15 @@ API manual sync (see [Connect a Git Repo](/vendor/enterprise-portal-v2-connect-r
 replicated api post /v3/app/<APP_ID>/enterprise-portal/content-repos/<REPO_ID>/sync
 ```
 
+## Updated `main` but customers still see old content
+
+The `main` branch is only the last-resort fallback. When a customer views a release, Enterprise Portal serves the highest version branch whose name is at or below that release version (nearest lower semver), and falls back to `main` only when no such branch exists. A stray version branch (for example, `v0.0.1`) sorts at or below almost every release, so it captures those releases and serves its own content, even after you update `main`.
+
+- On the Content tab, check which branches are synced. If you are not maintaining version-specific docs, keep only `main` and delete stray version branches so every release falls back to `main`.
+- If you are using versioned docs, update the version branch that actually serves the release, not just `main`.
+
+See [Manage Content Versions](/vendor/enterprise-portal-v2-versioned-docs) for how version resolution works.
+
 ## Pages not showing in navigation
 
 - Check `toc.yaml` includes the page
@@ -36,6 +45,10 @@ replicated api post /v3/app/<APP_ID>/enterprise-portal/content-repos/<REPO_ID>/s
 - Branch names with `/` (like `feature/foo` or `austin/initial-customization`) are treated as nested URL path segments in the preview. Use flat branch names (like `feature-foo`) to avoid this.
 - The `main` branch is hidden from the version list when other branches exist. If you only have `main`, it shows as the sole version. If you have other branches, navigating to a URL with `/main/` in the path returns a 404.
 - Uncommitted changes only appear on your currently checked-out branch. Other branches serve their last committed state.
+
+## Local preview: "content path does not exist"
+
+The preview command's example path is a placeholder. If you see `content path does not exist: /path/to/repo`, you ran the example literally. Replace `/path/to/repo` with the absolute path to your locally cloned content repo, for example `~/repos/acme-enterprise-portal-content`. See [Local preview](/vendor/enterprise-portal-v2-access#local-preview).
 
 ## Version branch not working
 

--- a/docs/vendor/enterprise-portal-v2-versioned-docs.mdx
+++ b/docs/vendor/enterprise-portal-v2-versioned-docs.mdx
@@ -6,6 +6,10 @@ Features described on this page are in alpha and subject to change. For access, 
 
 Use versioned docs if you need to maintain different documentation for different versions of your software, for example, distinct install steps or caveats for specific releases.
 
+:::note
+If your documentation does not change between releases, you do not need version branches. Keep only `main` and let every release fall back to it. Add a version branch only when a specific release needs different content. Avoid leaving stray version branches (for example, `v0.0.1`): through the nearest-lower-semver rule below, such a branch captures releases and serves its content instead of `main`.
+:::
+
 Each Git branch in your content repo (other than `main`) becomes a selectable version in the customer-facing portal. Each version has its own table of contents, markdown pages, and theme/branding overrides.
 
 ## Process

--- a/docs/vendor/enterprise-portal-v2-versioned-docs.mdx
+++ b/docs/vendor/enterprise-portal-v2-versioned-docs.mdx
@@ -6,10 +6,6 @@ Features described on this page are in alpha and subject to change. For access, 
 
 Use versioned docs if you need to maintain different documentation for different versions of your software, for example, distinct install steps or caveats for specific releases.
 
-:::note
-If your documentation does not change between releases, you do not need version branches. Keep only `main` and let every release fall back to it. Add a version branch only when a specific release needs different content. Avoid leaving stray version branches (for example, `v0.0.1`): through the nearest-lower-semver rule below, such a branch captures releases and serves its content instead of `main`.
-:::
-
 Each Git branch in your content repo (other than `main`) becomes a selectable version in the customer-facing portal. Each version has its own table of contents, markdown pages, and theme/branding overrides.
 
 ## Process


### PR DESCRIPTION
Preview links
* https://deploy-preview-4282--replicated-docs.netlify.app/vendor/enterprise-portal-v2-access#local-preview
* https://deploy-preview-4282--replicated-docs.netlify.app/vendor/enterprise-portal-v2-connect-repo#applying-an-update
* https://deploy-preview-4282--replicated-docs.netlify.app/vendor/enterprise-portal-v2-troubleshooting#updated-main-but-customers-still-see-old-content
* https://deploy-preview-4282--replicated-docs.netlify.app/vendor/enterprise-portal-v2-troubleshooting#local-preview-content-path-does-not-exist

## What

Documentation improvements targeting recurring points of confusion for vendors setting up an Enterprise Portal v2 content repo.

- **Access / Local preview**: spell out the `/path/to/repo` and `<app-slug>` placeholders, add a filled-in example, and document the `content path does not exist` error (vendors run the example command verbatim).
- **Troubleshooting**: add *"Updated main but customers still see old content"* (nearest-lower-semver + stray version branch) and *"Local preview: content path does not exist"*.
- **Connect a Git Repo / Applying an update**: add the actual git workflow for adopting template updates (cloned repos share no history, so `git pull`/`merge` don't work — add `upstream` remote, `git checkout upstream/main -- <files>`); clarify the banner is an informational feed and *Mark reviewed* only clears it.


## Why

Based on real onboarding friction: placeholder commands run literally, `main` synced but a stray version branch still serving old content, and the template-update flow assuming knowledge of how to bring changes into a diverged repo.

There are a few small UI improvements stories created as well, but this handles the docs side
