### PR TITLE
Document builder key for EC extension charts and airgap bundle structure

### DIFF
--- a/docs/partials/embedded-cluster/v3/_support-air-gap-releases.mdx
+++ b/docs/partials/embedded-cluster/v3/_support-air-gap-releases.mdx
@@ -93,7 +93,7 @@ To support air gap installations with Embedded Cluster v3:
 
 1. If you added any Helm chart `extensions` in the Embedded Cluster Config, configure them for air gap:
 
-    **a. Configure the `builder` key** if the extension chart has optional images that only appear with specific values. The `builder` key tells the Vendor Portal which values to use when running `helm template` to discover images for the air gap bundle. If the chart's default `values.yaml` already exposes all images, you can skip this step. See [`builder`](embedded-config#extensions) in _Embedded Cluster Config_.
+    **a. Configure the `builder` key** if the extension chart has optional images that only appear with specific values. The `builder` key tells the Vendor Portal which values to use when running `helm template` to discover images for the air gap bundle. If the chart's default `values.yaml` already exposes all images, you can skip this step. The `builder` key does not support Replicated template functions. See [`builder`](embedded-config#extensions) in _Embedded Cluster Config_.
 
     <details>
     <summary>Example (Extension with conditional images)</summary>
@@ -113,13 +113,9 @@ To support air gap installations with Embedded Cluster v3:
             builder:
               defaultBackend:
                 enabled: true
-            values: |
-              defaultBackend:
-                enabled: true
-              controller:
-                image:
-                  registry: 'repl{{ ReplicatedImageRegistry "registry.k8s.io" }}'
     ```
+
+    Use `builder` for static values that affect image discovery. Use `values` (step 4b below) for template functions like `ReplicatedImageRegistry` that rewrite image references at install time.
     </details>
 
     **b. Rewrite image references** in each extension using either the [ReplicatedImageName](/embedded-cluster/v3/template-functions#replicatedimagename) template function (if the chart uses a single field for the full image reference) or the [ReplicatedImageRegistry](/embedded-cluster/v3/template-functions#replicatedimageregistry) template function (if the chart uses separate fields for registry and repository).

--- a/docs/partials/embedded-cluster/v3/_support-air-gap-releases.mdx
+++ b/docs/partials/embedded-cluster/v3/_support-air-gap-releases.mdx
@@ -91,7 +91,38 @@ To support air gap installations with Embedded Cluster v3:
             registry: '{{repl ReplicatedImageRegistry (HelmValue ".replicated.image.registry") }}'
     ```
 
-1. If you added any Helm chart `extensions` in the Embedded Cluster Config, rewrite image references in each extension using either the [ReplicatedImageName](/embedded-cluster/v3/template-functions#replicatedimagename) template function (if the chart uses a single field for the full image reference) or the [ReplicatedImageRegistry](/embedded-cluster/v3/template-functions#replicatedimageregistry) template function (if the chart uses separate fields for registry and repository).
+1. If you added any Helm chart `extensions` in the Embedded Cluster Config, configure them for air gap:
+
+    **a. Configure the `builder` key** if the extension chart has optional images that only appear with specific values. The `builder` key tells the Vendor Portal which values to use when running `helm template` to discover images for the air gap bundle. If the chart's default `values.yaml` already exposes all images, you can skip this step. See [`builder`](embedded-config#extensions) in _Embedded Cluster Config_.
+
+    <details>
+    <summary>Example (Extension with conditional images)</summary>
+
+    ```yaml
+    # Embedded Cluster Config
+    apiVersion: embeddedcluster.replicated.com/v1beta1
+    kind: Config
+    spec:
+      extensions:
+        helmCharts:
+          - chart:
+              name: ingress-nginx
+              chartVersion: "4.11.3"
+            releaseName: ingress-nginx
+            namespace: ingress-nginx
+            builder:
+              defaultBackend:
+                enabled: true
+            values: |
+              defaultBackend:
+                enabled: true
+              controller:
+                image:
+                  registry: 'repl{{ ReplicatedImageRegistry "registry.k8s.io" }}'
+    ```
+    </details>
+
+    **b. Rewrite image references** in each extension using either the [ReplicatedImageName](/embedded-cluster/v3/template-functions#replicatedimagename) template function (if the chart uses a single field for the full image reference) or the [ReplicatedImageRegistry](/embedded-cluster/v3/template-functions#replicatedimageregistry) template function (if the chart uses separate fields for registry and repository).
 
     <details>
     <summary>Example (Extension for a Helm chart that you own)</summary>

--- a/embedded-cluster/embedded-config.mdx
+++ b/embedded-cluster/embedded-config.mdx
@@ -197,6 +197,7 @@ Each object in `helmCharts` can include the following fields:
 * `namespace`: (Required) Namespace for the release.
 * `weight`: Controls installation order relative to other Helm chart extensions. Lower weights install before higher weights. When weights are equal, charts install in alphabetical order by namespace and release name. The default weight is `0`. Negative weights are supported.
 * `values`: Helm values for the chart, provided as nested YAML. This field supports [Replicated template functions](/reference/template-functions-about). Embedded Cluster updates Helm extensions when users deploy new versions of your application. For example, you can change `values` from one release to another, and those changes apply when the user deploys the new version.
+* `builder`: Helm values used only during air gap bundle building. When the Vendor Portal builds an air gap bundle, it runs `helm template` on the chart with these values to discover which container images to include. Use `builder` when the chart has optional images that only appear with specific values (for example, `metrics.enabled: true`). If the chart's default `values.yaml` already exposes all images, you do not need to configure `builder`. This field works the same way as [`builder`](/reference/custom-resource-helmchart-v2#builder) on the HelmChart v2 custom resource.
 
 Each extension chart is installed with `helm upgrade --install --wait --wait-for-jobs`, so Helm hooks (such as `pre-install` and `pre-upgrade` Jobs) run and must succeed before the next chart begins.
 

--- a/embedded-cluster/installing-embedded-air-gap.mdx
+++ b/embedded-cluster/installing-embedded-air-gap.mdx
@@ -16,7 +16,7 @@ The Embedded Cluster air gap bundle is a `.tgz` archive that contains:
 * `assets/APP_SLUG.airgap` containing application images and Helm extension images in a Docker registry format
 * `assets/ec-VERSION.airgap` containing Embedded Cluster infrastructure images (k0s, Calico, CoreDNS, OpenEBS, and other built-in components)
 
-Application images and Helm extension images are stored in separate registries within the bundle. Application images are in the `images/` directory of the app `.airgap` file. Extension images are in the `embedded-cluster/` directory. At install time, application images are loaded into a Docker registry deployed to the cluster, while infrastructure and extension images are preloaded directly into containerd on each node.
+Application images and Helm extension images are stored in separate locations within the bundle. Application images are in the `images/` directory of the app `.airgap` file. Extension images are in the `embedded-cluster/` directory. At install time, application images and extension images are loaded into a Docker registry deployed to the cluster. Infrastructure images (k0s, Calico, and other built-in components) are preloaded directly into containerd on each node.
 
 ## Prerequisites
 

--- a/embedded-cluster/installing-embedded-air-gap.mdx
+++ b/embedded-cluster/installing-embedded-air-gap.mdx
@@ -8,9 +8,15 @@ This topic describes how to install an application with Replicated Embedded Clus
 
 Building an air gap bundle for a release with an Embedded Cluster Config produces an Embedded Cluster air gap bundle that contains everything needed to install in an air-gapped environment.
 
-The Embedded Cluster air gap bundle contains the assets normally found in an application air gap bundle (`airgap.yaml`, `app.tar.gz`, and an images directory). It also includes an `embedded-cluster` directory with the assets needed to install the infrastructure (Embedded Cluster/k0s and [extensions](embedded-config#extensions)).
+The Embedded Cluster air gap bundle is a `.tgz` archive that contains:
 
-During installation with Embedded Cluster in air gap environments, Embedded Cluster deploys a Docker registry to the cluster to store application images. The installer preloads infrastructure images (for Embedded Cluster and Helm extensions) and the Helm charts on each node at installation time.
+* The Embedded Cluster CLI binary and supporting binaries
+* `license.yaml` with the customer license
+* `assets/release.tgz` with the application release (Helm charts, custom resources, and manifests)
+* `assets/APP_SLUG.airgap` containing application images and Helm extension images in a Docker registry format
+* `assets/ec-VERSION.airgap` containing Embedded Cluster infrastructure images (k0s, Calico, CoreDNS, OpenEBS, and other built-in components)
+
+Application images and Helm extension images are stored in separate registries within the bundle. Application images are in the `images/` directory of the app `.airgap` file. Extension images are in the `embedded-cluster/` directory. At install time, application images are loaded into a Docker registry deployed to the cluster, while infrastructure and extension images are preloaded directly into containerd on each node.
 
 ## Prerequisites
 


### PR DESCRIPTION
Preview links
* https://deploy-preview-4283--replicated-docs.netlify.app/embedded-cluster/v3/installing-embedded-air-gap#overview
* (Step 4) https://deploy-preview-4283--replicated-docs.netlify.app/embedded-cluster/v3/embedded-using#configure-the-release
* https://deploy-preview-4283--replicated-docs.netlify.app/embedded-cluster/v3/embedded-config#helmcharts

## Summary

- Add the `builder` field to the EC Config `extensions.helmCharts` reference so vendors know they can use it for airgap image discovery on extension charts
- Update the airgap install overview to describe the bundle's internal structure (which files contain app images vs extension images vs EC infra images)
- Add `builder` key guidance and example to the air gap support steps for extensions

## Context

Came out of a conversation with Salah and Evans about extension chart images in airgap bundles. The `builder` key works for extensions (same `ChartSpec` struct in the airgap builder), but was not documented anywhere. The bundle structure documentation was also a single sentence that didn't explain where extension images vs app images live, which caused confusion when inspecting bundle contents.

## Test plan

- [ ] Verify the `builder` field description in embedded-config.mdx renders correctly
- [ ] Verify the new bundle structure list in installing-embedded-air-gap.mdx renders correctly
- [ ] Verify the updated step 4 in the air gap support partial renders with the builder sub-step and example
