### PR TITLE
Document KOTS/kURL adoption for the new Enterprise Portal

### DIFF
--- a/docs/vendor/enterprise-portal-v2-about.mdx
+++ b/docs/vendor/enterprise-portal-v2-about.mdx
@@ -36,9 +36,9 @@ The new Enterprise Portal is a complete rebuild of the customer portal experienc
 
 ## Current limitations {#current-limitations}
 
-- Step-by-step, in-console install and upgrade instructions, and structured install-step customization, are available only for Embedded Cluster and Helm CLI installations. The Enterprise Portal does not provide install or upgrade commands for KOTS or kURL. For more information, see [KOTS and kURL customers](#kots-and-kurl-customers).
+- Installation and upgrade instructions are available only for Embedded Cluster and Helm CLI installations. The Enterprise Portal does not provide instructions for KOTS or kURL. For more information, see [KOTS and kURL customers](#kots-and-kurl-customers).
 - Air gap instance records do not appear until the customer creates one from the Instances & Updates page, either by manually entering instance information or by extracting details from an uploaded support bundle. Availability depends on the customer's license having the corresponding install type and air gap option enabled.
-- Security Center data (CVE reports and SBOMs) is available for Helm and Embedded Cluster installations only. Customers whose only instances are KOTS or kURL do not see Security Center at all. Customers with a mix of instance types see Security Center data for their Helm and Embedded Cluster instances.
+- Security Center data (CVE reports and SBOMs) is available for Helm and Embedded Cluster installations only. Customers whose only instances are KOTS or kURL see an explanatory message instead of security data. Customers with a mix of instance types see Security Center data for their Helm and Embedded Cluster instances.
 - If you have many version branches and need to make a change across all versions, you must update each branch individually.
 
 ## Requirements
@@ -55,46 +55,39 @@ Some Enterprise Portal capabilities require additional access:
 
 ## For vendors already using the Classic Enterprise Portal
 
-If your team already uses the Classic Enterprise Portal, you can adopt the New Enterprise Portal incrementally. To avoid disrupting existing customers, run both portal versions in mixed mode.
+If your team already uses the Classic Enterprise Portal, you can adopt the new Enterprise Portal incrementally. Run both portals side by side, then move customers over individually or all at once.
 
 The new Enterprise Portal runs at a different domain (`{appSlug}.enterpriseportal.app`) than Classic (`get.replicated.com/{appSlug}/...`). Both portals share the same backend, so customer data, licenses, and instance information are consistent across both.
 
-### How to get started
+### How to get started {#how-to-get-started}
 
-1. **Enable mixed mode.** Contact Replicated to run the New Enterprise Portal alongside the Classic Enterprise Portal. Customers continue using their current portal until you move them to the new version.
+1. **Run both portals side by side.** Contact Replicated to enable the new Enterprise Portal for your team alongside the Classic Enterprise Portal. Customers continue using their current portal until you move them.
 1. **Connect a content repo.** Follow the setup steps in [Connect a Git Repo](/vendor/enterprise-portal-v2-connect-repo). Connecting a repo has zero effect on any customer's portal version. No customer sees the new portal until you explicitly switch them.
-1. **Test it yourself.** Use the local CLI preview (`replicated enterprise-portal preview`) or open the new portal URL directly to see how your content renders. The Vendor Portal also has a "Login as customer" button on each customer's EP access tab.
-1. **Move individual customers.** On the customer's **Enterprise Portal access** tab in Vendor Portal, set the **Portal Version** toggle to use the new Enterprise Portal. Only that customer is affected.
-1. **Move customers back if needed.** Set the Portal Version toggle back to Classic at any time. The customer immediately returns to the Classic experience.
+1. **Test it yourself.** Use the local CLI preview (`replicated enterprise-portal preview`) or open the new portal URL directly to see how your content renders. The Vendor Portal also has a "Login as customer" button on each customer's Enterprise Portal access tab.
+1. **Move individual customers.** On the customer's **Enterprise Portal access** tab, set **Portal Version** to **Use new Enterprise Portal for this customer**. This affects only that customer. If the customer doesn't have Enterprise Portal access yet, turn on **Enable Enterprise Portal for this customer** first — the Portal Version control only appears after access is on.
+1. **Move customers back if needed.** Set Portal Version back to Classic at any time. The customer immediately returns to the Classic experience.
+1. **Move everyone at the same time, if you don't need a gradual rollout.** On **Enterprise Portal > Customer Access**, turn on **Enable Enterprise Portal for all customers** to move every customer, including those on KOTS or kURL, off the Download Portal immediately. This doesn't change any customer's individual access or Portal Version setting — it overrides the result while it's on, and turning it back off returns each customer to their individual setting.
 
 ### Vendor Portal view vs. customer portal version
 
-The **New Portal** / **Classic Portal** toggle appears only in mixed mode. It controls the Vendor Portal view that you see. It does not change which portal your customers see. Use the Portal Version toggle on each customer's EP access tab to change their portal.
-
-## KOTS and kURL customers {#kots-and-kurl-customers}
-
-The Classic Enterprise Portal never supported KOTS or kURL installations. Customers using these install types have historically used the [Download Portal](/vendor/releases-share-download-portal) instead. The new Enterprise Portal supports KOTS and kURL customers as well, with some differences from Helm and Embedded Cluster customers. For details on what your KOTS and kURL customers see, including current limitations, see [KOTS and kURL instances](/vendor/enterprise-portal-v2-use#kots-and-kurl-instances) in _Log in to and Use the Enterprise Portal_.
-
-### Move a KOTS or kURL customer to the new Enterprise Portal
-
-On the customer's **Enterprise Portal access** tab, switch **Portal Version** to the new Enterprise Portal. This is the same toggle used for Helm and Embedded Cluster customers. There is no separate setting based on install type.
-
-Changing a customer's Portal Version immediately invalidates their active Enterprise Portal sessions. The next time the customer logs in, they land on the portal version you selected.
-
-To automate this instead of using the Vendor Portal UI, use [Update Enterprise Portal settings](https://replicated-vendor-api.readme.io/reference/updateenterpriseportalsettings) in the Vendor API v3 with `portalVersion: "v2"`. For more information, see [Customer access](/vendor/enterprise-portal-v2-vendor-api-automation#customer-access) in _Enterprise Portal Headless Automation_.
-
-If you also want this customer to see Security Center, enable it on the same **Enterprise Portal access** tab. This is a separate toggle from Portal Version. For a KOTS or kURL customer, Security Center only shows data after the customer also has a Helm or Embedded Cluster instance. See [Security](/vendor/enterprise-portal-v2-use#security). For more information about the Security Center toggle, see [Enable Customer Access to Security Information](/vendor/security-center-enable-customer-access).
-
-### Enable the new Enterprise Portal for all customers
-
-There is no single switch that moves your entire existing customer base to the new Enterprise Portal at once. The Portal Version setting is per customer, and any customer without an explicit setting stays on their current portal (Classic Enterprise Portal or Download Portal). Enabling mixed mode for your app does not move any existing customers, including those on KOTS or kURL. After you move them, KOTS and kURL customers land on a portal that supports their install type, including instance visibility and license information. See [KOTS and kURL instances](/vendor/enterprise-portal-v2-use#kots-and-kurl-instances) for what's supported today.
-
-To move many customers at once, call [Update Enterprise Portal settings](https://replicated-vendor-api.readme.io/reference/updateenterpriseportalsettings) for each customer instead of switching them individually in Vendor Portal.
-
-New customers that you create after you enable mixed mode default to the new Enterprise Portal, regardless of install type.
+The **New Portal** / **Classic Portal** toggle appears only when both portals are running for your team. It controls the Vendor Portal view that you see. It does not change which portal your customers see. Use each customer's **Portal Version** setting to change their portal.
 
 ### Portal coexistence
 
-You can run the Download Portal, the Classic Enterprise Portal, and the new Enterprise Portal at the same time, with different customers on each. This is an intended, ongoing state, not only a step along the way to a full migration. Each customer's Portal Version is independent, so you can move customers over gradually and leave others on their current portal indefinitely.
+You can run the Download Portal and the new Enterprise Portal side by side, with different customers on each, indefinitely. This is intended and ongoing, not only a step toward a full migration.
 
-Moving a customer's Portal Version to the new Enterprise Portal does not disable their Download Portal access. The two are independent. If a KOTS or kURL customer relies on the Download Portal today, you can keep sharing that link. This works even after you move them to the new Enterprise Portal.
+For a single customer, though, these are alternatives, not concurrent options. Turning on Enterprise Portal access for a customer moves that customer off the Download Portal onto whichever portal version their Portal Version setting selects.
+
+## KOTS and kURL customers {#kots-and-kurl-customers}
+
+The Classic Enterprise Portal does not support KOTS or kURL installations. Customers using these install types use the [Download Portal](/vendor/releases-share-download-portal) instead. The new Enterprise Portal supports KOTS and kURL customers as well, with some differences from Helm and Embedded Cluster customers. For details on what your KOTS and kURL customers see, including current limitations, see [KOTS and kURL instances](/vendor/enterprise-portal-v2-use#kots-and-kurl-instances) in _Log in to and Use the Enterprise Portal_.
+
+### Move a KOTS or kURL customer to the new Enterprise Portal
+
+Follow the steps in [How to get started](#how-to-get-started) to run the new Enterprise Portal for your team. This works the same way for KOTS and kURL customers as it does for Helm and Embedded Cluster customers. The app-level **Enable Enterprise Portal for all customers** option applies to KOTS and kURL customers too.
+
+One thing to plan for: most KOTS and kURL customers don't have Enterprise Portal access enabled yet, since they've been using the Download Portal. You need to turn on **Enable Enterprise Portal for this customer** before the **Portal Version** control appears. Classic Enterprise Portal does not support KOTS or kURL. Leaving Portal Version at its default after enabling access does not give the customer a working portal. Set it to **Use new Enterprise Portal for this customer** explicitly.
+
+To automate this instead of using the Vendor Portal UI: use [Patch a customer](https://replicated-vendor-api.readme.io/reference/patchcustomer) with `is_enterprise_portal_enabled: true` to grant access, then [Update Enterprise Portal settings](https://replicated-vendor-api.readme.io/reference/updateenterpriseportalsettings) with `portalVersion: "v2"` to select the new Enterprise Portal. For more information, see [Customer access](/vendor/enterprise-portal-v2-vendor-api-automation#customer-access) in _Enterprise Portal Headless Automation_.
+
+If you also want this customer to see Security Center, enable it on the same **Enterprise Portal access** tab. This is a separate toggle from Portal Version. For a KOTS or kURL customer, Security Center shows an explanatory message instead of security data until they also have a Helm or Embedded Cluster instance. See [Security](/vendor/enterprise-portal-v2-use#security). For more information about the Security Center toggle, see [Enable Customer Access to Security Information](/vendor/security-center-enable-customer-access).

--- a/docs/vendor/enterprise-portal-v2-about.mdx
+++ b/docs/vendor/enterprise-portal-v2-about.mdx
@@ -55,7 +55,7 @@ Some Enterprise Portal capabilities require additional access:
 
 ## For vendors already using the Classic Enterprise Portal
 
-If your team already uses the Classic Enterprise Portal, you can adopt the new Enterprise Portal incrementally. Run both portals side by side, then move customers over individually or all at once.
+If your team already uses the Classic Enterprise Portal, you can adopt the new Enterprise Portal incrementally. Run both portals side by side, then move customers over individually or all together.
 
 The new Enterprise Portal runs at a different domain (`{appSlug}.enterpriseportal.app`) than Classic (`get.replicated.com/{appSlug}/...`). Both portals share the same backend, so customer data, licenses, and instance information are consistent across both.
 
@@ -74,7 +74,7 @@ The **New Portal** / **Classic Portal** toggle appears only when both portals ar
 
 ### Portal coexistence
 
-You can run the Download Portal and the new Enterprise Portal side by side, with different customers on each, indefinitely. This is intended and ongoing, not only a step toward a full migration.
+You can run the Download Portal and the new Enterprise Portal side by side, with different customers on each, indefinitely. Treat this as an ongoing state, not only a step toward a full migration.
 
 For a single customer, though, these are alternatives, not concurrent options. Turning on Enterprise Portal access for a customer moves that customer off the Download Portal onto whichever portal version their Portal Version setting selects.
 

--- a/docs/vendor/enterprise-portal-v2-about.mdx
+++ b/docs/vendor/enterprise-portal-v2-about.mdx
@@ -37,7 +37,7 @@ The new Enterprise Portal is a complete rebuild of the customer portal experienc
 ## Current limitations {#current-limitations}
 
 - Step-by-step, in-console install and upgrade instructions, and structured install-step customization, are available only for Embedded Cluster and Helm CLI installations. The Enterprise Portal does not provide install or upgrade commands for KOTS or kURL. For more information, see [KOTS and kURL customers](#kots-and-kurl-customers).
-- Air gap instance records do not appear until the customer creates one from the Instances & Updates page, either by manually entering instance information or by extracting details from an uploaded support bundle. This is available for Embedded Cluster and Helm air gap installations. It is not yet available for KOTS or kURL, so only KOTS and kURL instances that have already checked in appear in the portal.
+- Air gap instance records do not appear until the customer creates one from the Instances & Updates page, either by manually entering instance information or by extracting details from an uploaded support bundle. Availability depends on the customer's license having the corresponding install type and air gap option enabled.
 - Security Center data (CVE reports and SBOMs) is available for Helm and Embedded Cluster installations only. Customers whose only instances are KOTS or kURL do not see Security Center at all. Customers with a mix of instance types see Security Center data for their Helm and Embedded Cluster instances.
 - If you have many version branches and need to make a change across all versions, you must update each branch individually.
 

--- a/docs/vendor/enterprise-portal-v2-about.mdx
+++ b/docs/vendor/enterprise-portal-v2-about.mdx
@@ -36,9 +36,9 @@ The new Enterprise Portal is a complete rebuild of the customer portal experienc
 
 ## Current limitations {#current-limitations}
 
-- Installation and upgrade instructions are available only for Embedded Cluster and Helm CLI installations. The Enterprise Portal does not provide instructions for KOTS or kURL.
-- Air gap instance records do not appear until the customer creates one from the Instances & Updates page, either by manually entering instance information or by extracting details from an uploaded support bundle.
-- Security Center data (CVE reports and SBOMs) is available for Helm and Embedded Cluster installations only. Security data is not displayed for KOTS or kURL installations.
+- Step-by-step, in-console install and upgrade instructions, and structured install-step customization, are available only for Embedded Cluster and Helm CLI installations. The Enterprise Portal does not provide install or upgrade commands for KOTS or kURL. For more information, see [KOTS and kURL customers](#kots-and-kurl-customers).
+- Air gap instance records do not appear until the customer creates one from the Instances & Updates page, either by manually entering instance information or by extracting details from an uploaded support bundle. This is available for Embedded Cluster and Helm air gap installations. It is not yet available for KOTS or kURL, so only KOTS and kURL instances that have already checked in appear in the portal.
+- Security Center data (CVE reports and SBOMs) is available for Helm and Embedded Cluster installations only. Customers whose only instances are KOTS or kURL do not see Security Center at all. Customers with a mix of instance types see Security Center data for their Helm and Embedded Cluster instances.
 - If you have many version branches and need to make a change across all versions, you must update each branch individually.
 
 ## Requirements
@@ -70,3 +70,31 @@ The new Enterprise Portal runs at a different domain (`{appSlug}.enterpriseporta
 ### Vendor Portal view vs. customer portal version
 
 The **New Portal** / **Classic Portal** toggle appears only in mixed mode. It controls the Vendor Portal view that you see. It does not change which portal your customers see. Use the Portal Version toggle on each customer's EP access tab to change their portal.
+
+## KOTS and kURL customers {#kots-and-kurl-customers}
+
+The Classic Enterprise Portal never supported KOTS or kURL installations. Customers using these install types have historically used the [Download Portal](/vendor/releases-share-download-portal) instead. The new Enterprise Portal supports KOTS and kURL customers as well, with some differences from Helm and Embedded Cluster customers. For details on what your KOTS and kURL customers see, including current limitations, see [KOTS and kURL instances](/vendor/enterprise-portal-v2-use#kots-and-kurl-instances) in _Log in to and Use the Enterprise Portal_.
+
+### Move a KOTS or kURL customer to the new Enterprise Portal
+
+On the customer's **Enterprise Portal access** tab, switch **Portal Version** to the new Enterprise Portal. This is the same toggle used for Helm and Embedded Cluster customers. There is no separate setting based on install type.
+
+Changing a customer's Portal Version immediately invalidates their active Enterprise Portal sessions. The next time the customer logs in, they land on the portal version you selected.
+
+To automate this instead of using the Vendor Portal UI, use [Update Enterprise Portal settings](https://replicated-vendor-api.readme.io/reference/updateenterpriseportalsettings) in the Vendor API v3 with `portalVersion: "v2"`. For more information, see [Customer access](/vendor/enterprise-portal-v2-vendor-api-automation#customer-access) in _Enterprise Portal Headless Automation_.
+
+If you also want this customer to see Security Center, enable it on the same **Enterprise Portal access** tab. This is a separate toggle from Portal Version. For a KOTS or kURL customer, Security Center only shows data after the customer also has a Helm or Embedded Cluster instance. See [Security](/vendor/enterprise-portal-v2-use#security). For more information about the Security Center toggle, see [Enable Customer Access to Security Information](/vendor/security-center-enable-customer-access).
+
+### Enable the new Enterprise Portal for all customers
+
+There is no single switch that moves your entire existing customer base to the new Enterprise Portal at once. The Portal Version setting is per customer, and any customer without an explicit setting stays on their current portal (Classic Enterprise Portal or Download Portal). Enabling mixed mode for your app does not move any existing customers, including those on KOTS or kURL. After you move them, KOTS and kURL customers land on a portal that supports their install type, including instance visibility and license information. See [KOTS and kURL instances](/vendor/enterprise-portal-v2-use#kots-and-kurl-instances) for what's supported today.
+
+To move many customers at once, call [Update Enterprise Portal settings](https://replicated-vendor-api.readme.io/reference/updateenterpriseportalsettings) for each customer instead of switching them individually in Vendor Portal.
+
+New customers that you create after you enable mixed mode default to the new Enterprise Portal, regardless of install type.
+
+### Portal coexistence
+
+You can run the Download Portal, the Classic Enterprise Portal, and the new Enterprise Portal at the same time, with different customers on each. This is an intended, ongoing state, not only a step along the way to a full migration. Each customer's Portal Version is independent, so you can move customers over gradually and leave others on their current portal indefinitely.
+
+Moving a customer's Portal Version to the new Enterprise Portal does not disable their Download Portal access. The two are independent. If a KOTS or kURL customer relies on the Download Portal today, you can keep sharing that link. This works even after you move them to the new Enterprise Portal.

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -32,7 +32,7 @@ All users invited to the same customer team share access to the same pull tokens
 
 Once logged in, customers see a sidebar with the navigation defined by the vendor's `toc.yaml`. The default template organizes content into:
 
-- **Installation**: Requirements, release history, and step-by-step install instructions for Linux and Helm
+- **Installation**: Requirements, release history, and step-by-step install instructions for Linux (Embedded Cluster) and Helm
 - **Operations**: Security reports and support bundle management
 - **Updates**: Check for updates and follow upgrade instructions
 - **Support**: FAQ and contact support information
@@ -76,6 +76,14 @@ Depending on the install method and license entitlements, customers can download
 
 For Embedded Cluster air gap installations, customers using a private registry can enter their registry hostname directly in the install flow. The instructions update to include image pull, tag, and push commands targeting that registry, along with the appropriate `--registry` flags on the install command. This is also available during Embedded Cluster upgrades when the instance was originally installed with a private registry.
 
+### KOTS and kURL instances {#kots-and-kurl-instances}
+
+KOTS and kURL instances appear on the **Instances & Updates** page alongside Helm and Embedded Cluster instances, labeled **KOTS** or **kURL**. Each instance shows its current version and status.
+
+The Enterprise Portal does not provide step-by-step, in-console install or upgrade instructions for KOTS or kURL. These instance cards don't expand into inline upgrade steps the way Helm and Embedded Cluster cards do.
+
+Air gap instance records for KOTS and kURL are not yet available. Only KOTS and kURL instances that have already checked in appear in the portal. Customers can't manually add a record or extract one from a support bundle for these install types yet.
+
 ## Team management
 
 Customer team admins can manage their portal team from the Team Settings page:
@@ -112,9 +120,9 @@ When Security Center is enabled by the vendor, customers with Helm or Embedded C
 - **SBOMs**: Download the Software Bill of Materials for any release version. SBOMs are accessible to all portal team members regardless of role.
 
 :::note
-Security Center data is available for Helm and Embedded Cluster installations only. Security data is not displayed for KOTS or kURL installations.
+Security Center data is available for Helm and Embedded Cluster installations only. KOTS and kURL instances don't contribute CVE data or upgrade recommendations, and they aren't counted toward instance totals in Security Center. Customers whose only instances are KOTS or kURL don't see Security Center at all. Customers with a mix of instance types still see Security Center for their Helm and Embedded Cluster instances.
 :::
 
 ## License information
 
-Customers can view their license details including expiration date, license type, assigned channel, and any custom license fields configured by the vendor. This information is accessible from the portal but is read-only for customers.
+Customers can view their license details including expiration date, license type, assigned channel, and any custom license fields configured by the vendor. This information is accessible from the portal but is read-only for customers. License details, including the install type label (Helm, Linux (Embedded Cluster), KOTS, or kURL), display correctly regardless of which install types the customer uses.

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -82,7 +82,7 @@ KOTS and kURL instances appear on the **Instances & Updates** page alongside Hel
 
 The Enterprise Portal does not provide step-by-step, in-console install or upgrade instructions for KOTS or kURL. These instance cards don't expand into inline upgrade steps the way Helm and Embedded Cluster cards do.
 
-Air gap instance records for KOTS and kURL are not yet available. Only KOTS and kURL instances that have already checked in appear in the portal. Customers can't manually add a record or extract one from a support bundle for these install types yet.
+Customers can create air gap instance records for KOTS and kURL the same way as for Helm and Embedded Cluster. They can enter instance information manually from the Instances & Updates page, or extract details from an uploaded support bundle. Availability depends on the customer's license having the corresponding install type and air gap option enabled.
 
 ## Team management
 

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -125,4 +125,4 @@ Security Center data is available for Helm and Embedded Cluster installations on
 
 ## License information
 
-Customers can view their license details including expiration date, license type, assigned channel, and any custom license fields configured by the vendor. This information is accessible from the portal but is read-only for customers. License details display correctly regardless of which install types the customer uses.
+Customers can view their license details including expiration date, license type, assigned channel, and any custom license fields configured by the vendor. Customers can access this information from the portal but cannot edit it. License details display correctly regardless of which install types the customer uses.

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -125,4 +125,4 @@ Security Center data is available for Helm and Embedded Cluster installations on
 
 ## License information
 
-Customers can view their license details including expiration date, license type, assigned channel, and any custom license fields configured by the vendor. Customers can access this information from the portal but cannot edit it. License details display correctly regardless of which install types the customer uses.
+Customers can view their license details including expiration date, license type, assigned channel, and any custom license fields configured by the vendor. This information is accessible from the portal but is read-only for customers.

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -120,9 +120,9 @@ When Security Center is enabled by the vendor, customers with Helm or Embedded C
 - **SBOMs**: Download the Software Bill of Materials for any release version. SBOMs are accessible to all portal team members regardless of role.
 
 :::note
-Security Center data is available for Helm and Embedded Cluster installations only. KOTS and kURL instances don't contribute CVE data or upgrade recommendations, and they aren't counted toward instance totals in Security Center. Customers whose only instances are KOTS or kURL don't see Security Center at all. Customers with a mix of instance types still see Security Center for their Helm and Embedded Cluster instances.
+Security Center data is available for Helm and Embedded Cluster installations only. KOTS and kURL instances don't contribute CVE data or upgrade recommendations, and they aren't counted toward instance totals in Security Center. Customers whose only instances are KOTS or kURL see an explanatory message instead of security data. Customers with a mix of instance types still see Security Center for their Helm and Embedded Cluster instances.
 :::
 
 ## License information
 
-Customers can view their license details including expiration date, license type, assigned channel, and any custom license fields configured by the vendor. This information is accessible from the portal but is read-only for customers. License details, including the install type label (Helm, Linux (Embedded Cluster), KOTS, or kURL), display correctly regardless of which install types the customer uses.
+Customers can view their license details including expiration date, license type, assigned channel, and any custom license fields configured by the vendor. This information is accessible from the portal but is read-only for customers. License details display correctly regardless of which install types the customer uses.


### PR DESCRIPTION
## Summary

Documents how vendors can move KOTS/kURL customers onto the new Enterprise Portal (EP v2), scoped to what's currently merged rather than the full planned feature set.

- How to enable EP v2 for a single KOTS/kURL customer (per-customer **Portal Version** toggle, plus its Vendor API equivalent for scripting many at once)
- Why there's no single app-level switch that moves an existing customer base at once, and what happens to KOTS/kURL customers when they are moved
- Pairing the Portal Version toggle with the separate Security Center toggle for a customer
- How Download Portal, Classic Enterprise Portal, and the new Enterprise Portal coexist (intentional, ongoing, not just a migration step)
- What KOTS/kURL customers see today: instance visibility/labels, no in-console install/upgrade instructions, Security Center gating (hidden if a customer's only instances are KOTS/kURL), correct license labeling, and manual/support-bundle air gap instance record creation

## Scope vs. Shortcut tracking

Content is scoped to match story status as of this PR:

| Story | Status | Reflected in docs |
|---|---|---|
| sc-135427 — Backend asset URL resolution | Completed | Yes |
| sc-135421 — MDX download components | Completed | Yes |
| sc-138598 — Instance visibility | Completed | Yes |
| sc-138600 — Air gap instance creation | Completed | Yes |
| sc-138487 — Default KOTS/kURL template pages | In Development | **Not yet** — intentionally left out until merged |
| sc-138833 — Version-filtered release browsing + downloads | In Development (no code yet) | **Not yet** — intentionally left out until built |

This is the docs deliverable for sc-138819. It links out to a spot the sc-138820 (VP portal access messaging) update can point to once that ships.

## Test plan

- [x] Vale style pass clean on all new/changed lines
- [ ] Docs review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

###Images to help give confidence:
### Portal Type Toggle:
<img width="800" height="245" alt="newportaltoggle" src="https://github.com/user-attachments/assets/15a223ef-bc49-4e18-a44d-52a0945558ae" />
### Enterprise Portal Per Customer:
<img width="1843" height="406" alt="PerCustomerEPSettings" src="https://github.com/user-attachments/assets/c2e6a537-ff68-45e0-9be6-db772684a7d2" />
### Enterprise Portal for all customers:
<img width="1838" height="390" alt="EPForAll" src="https://github.com/user-attachments/assets/4e807ae7-0d02-41c2-843e-980102ac0463" />
### EP With Change All Customers Toggled<img width="1836" height="379" alt="Screenshot 2026-07-23 at 2 41 51 PM" src="https://github.com/user-attachments/assets/2166b586-1a06-4966-985b-b21b2b9b747c" />
### Kots And Kurl Create Airgap Instance:
<img width="639" height="428" alt="KotsKurlCreateAirGapInstance" src="https://github.com/user-attachments/assets/f573791c-d40f-4319-96d9-092e0823efb5" />
### Kots And Kurl Instances Shown without Drop Down:
<img width="836" height="280" alt="KotsKurlInstanceShownNoDropdown" src="https://github.com/user-attachments/assets/1be85720-dfea-4853-9459-5161b12e21f9" />
### Security Center without helm or EC entitlments:
<img width="989" height="695" alt="scWithNoHelmOrEC" src="https://github.com/user-attachments/assets/a5700c91-3536-4c06-91ae-b4208b540141" />
### Security Center Tab:
<img width="1035" height="856" alt="securitycenter" src="https://github.com/user-attachments/assets/55f40be2-dcb8-4fe7-bc40-c9b7c370ab55" />
###  Security Center Tab, SBOM portion:
<img width="1042" height="892" alt="sbom" src="https://github.com/user-attachments/assets/89dd134e-19c9-421f-a9b3-09dec6fb0c38" />

Image