### PR TITLE
docs(ep-v2): document multi-channel access via multiple customers

### DIFF
--- a/docs/vendor/enterprise-portal-v2-invite.mdx
+++ b/docs/vendor/enterprise-portal-v2-invite.mdx
@@ -31,6 +31,18 @@ For teams using only the New Enterprise Portal, go to **Enterprise Portal > Cust
 
 For vendors in mixed mode (both Classic and New enabled), the customer creation screen includes a **Use new Enterprise Portal for this customer** checkbox. When checked, the customer is enrolled in the New portal and any auto-invite email points them to the New portal URL instead of Classic. This checkbox is only visible to team admins. When unchecked or not visible, new customers default to Classic.
 
+## Access to multiple channels
+
+A license is assigned to a single channel. To give one end user access to releases from more than one channel (for example, a stable channel for production and an alpha channel for a test environment), create a separate customer for each channel, each with a license on the intended channel.
+
+To present these as a single login, invite the **same email address** to each customer. The user logs in once and switches between the customers using the team switcher in the portal. For the customer-side experience, see [Access with multiple teams](/vendor/enterprise-portal-v2-use#access-with-multiple-teams).
+
+Because each customer appears to the end user as a separate team, name your customers descriptively (for example, `Customer A - Stable` and `Customer A - Alpha`) so users can tell their environments apart.
+
+:::note
+Inviting different email addresses to each customer creates separate logins with no team switcher. Use the same email address for each customer to give one person a unified experience.
+:::
+
 ## Removing users
 
 To remove a user from a customer's portal team:


### PR DESCRIPTION
## What

Adds an **Access to multiple channels** section to the EP v2 "Manage Customer Access" page (`enterprise-portal-v2-invite.mdx`).

## Why

When a vendor wants to give one customer access to releases from more than one channel (e.g. stable for prod, alpha for a test env), the setup is: create a separate customer per channel and invite the **same email** to each, which gives that person a single login with the team switcher. This pattern lives in the code (`enterprise_portal_customer_user` is a many-to-many join on `(customer_id, email_address)`) and the customer-side experience is already documented under "Access with multiple teams" on the usage page, but the vendor-side setup was undocumented. It kept having to be researched each time it came up in support threads.

## What's in the section

- A license maps to one channel, so multi-channel access means one customer per channel.
- Invite the same email to each customer to get one login + team switcher (cross-links to the customer-side usage page).
- Name customers descriptively, since each surfaces as a "team" to the end user.
- `:::note` warning that different emails produce separate logins with no switcher.

## Notes

- Behavior is identical in Classic and New portals; scoped this to EP v2 docs per the ask. Can add Classic parity if wanted.
- Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)