### PR TITLE
docs: note OCI Referrers API passthrough on proxy registry

### DIFF
--- a/docs/vendor/private-images-about.md
+++ b/docs/vendor/private-images-about.md
@@ -26,6 +26,15 @@ After connecting your registry, the steps to enable the proxy registry vary depe
 
 * **Embedded Cluster v3 installations**: The Embedded Cluster daemon handles registry authentication using an enterprise portal service account token instead of a license ID.
 
+## About OCI Referrers API support
+
+The proxy registry passes OCI Referrers API requests (`GET /v2/<name>/referrers/<digest>`) through to your upstream registry. Whether these requests return referrers depends on your upstream registry:
+
+* If your upstream registry serves the OCI Referrers API, referrers requests through the proxy return the upstream response. Response headers, including `OCI-Filters-Applied` when the `artifactType` filter is applied, are passed through unmodified.
+* If your upstream registry does not serve the OCI Referrers API, the proxy returns a spec-compliant `404` on the endpoint. This signals clients to fall back to the `sha256-<digest>` referrers tag schema.
+
+The Replicated-hosted registry (`registry.replicated.com`) does not serve the OCI Referrers API.
+
 ## About allowing pull-through access of public images
 
 Using the Replicated proxy registry to grant pull-through access to public images can simplify network access requirements for your customers, as they only need to whitelist a single domain (either `proxy.replicated.com` or your custom domain) instead of multiple registry domains.

--- a/docs/vendor/private-images-about.md
+++ b/docs/vendor/private-images-about.md
@@ -28,10 +28,10 @@ After connecting your registry, the steps to enable the proxy registry vary depe
 
 ## About OCI Referrers API support
 
-The proxy registry passes OCI Referrers API requests (`GET /v2/<name>/referrers/<digest>`) through to your upstream registry. Whether these requests return referrers depends on your upstream registry:
+The proxy registry passes all Open Container Initiative (OCI) Referrers API requests (`GET /v2/<name>/referrers/<digest>`) through to your upstream registry. Whether these requests return referrers depends on your upstream registry:
 
-* If your upstream registry serves the OCI Referrers API, referrers requests through the proxy return the upstream response. Response headers, including `OCI-Filters-Applied` when the `artifactType` filter is applied, are passed through unmodified.
-* If your upstream registry does not serve the OCI Referrers API, the proxy returns a spec-compliant `404` on the endpoint. This signals clients to fall back to the `sha256-<digest>` referrers tag schema.
+* If your upstream registry serves the OCI Referrers API, the proxy passes the upstream response back unchanged, including response headers such as `OCI-Filters-Applied` when the upstream applies the `artifactType` filter.
+* If your upstream registry does not serve the OCI Referrers API, it returns a `404` on the endpoint and the proxy passes that response through. The spec-compliant `404` signals clients to fall back to the `sha256-<digest>` referrers tag schema.
 
 The Replicated-hosted registry (`registry.replicated.com`) does not serve the OCI Referrers API.
 


### PR DESCRIPTION
Preview link https://deploy-preview-4287--replicated-docs.netlify.app/vendor/private-images-about#about-oci-referrers-api-support

## What

Adds a short, factual section to the proxy registry overview page ([About the Replicated proxy registry](docs/vendor/private-images-about.md)) noting that the proxy now passes native OCI Referrers API requests (`GET /v2/<name>/referrers/<digest>`) through to the upstream registry.

## Why

The passthrough shipped in the proxy registry (replicatedhq/vandoor#10183) but was undocumented. The section states the endpoint behavior and, importantly, the dependency on the upstream registry supporting the Referrers API (and that `registry.replicated.com` does not). It also notes the spec-compliant 404 fallback to the tag schema.

Deliberately scoped to the endpoint behavior only. No how-to or recommended distribution pattern, since that ties into broader supply-chain strategy still being worked on enablement-wise.

