### PR TITLE
Clarify Login as customer is a full customer-admin session

### DIFF
--- a/docs/vendor/enterprise-portal-v2-access.mdx
+++ b/docs/vendor/enterprise-portal-v2-access.mdx
@@ -60,3 +60,13 @@ To view the production Enterprise Portal as a specific customer, use the **Login
 This is useful for verifying that a customer sees the correct content, entitlements, and branding without creating a permanent user account in their portal team. The system creates a temporary system user scoped to that customer and generates a magic link nonce that expires after 10 minutes.
 
 The login routes to the correct portal version automatically. If the customer is on the new Enterprise Portal, the link opens `{appSlug}.enterpriseportal.app` (or your custom domain). If the customer is on Classic, the link opens `get.replicated.com`.
+
+:::note
+**Login as customer** opens a full customer-admin session, not a read-only or preview view. Any action you take runs as the customer and is visible to them, including starting install flows and creating or revoking service accounts. Use it to view and assist, not to make changes on the customer's behalf.
+:::
+
+### Undoing changes made while logged in as a customer
+
+Records created during a **Login as customer** session are read-only in the Vendor Portal. To revoke a service account, log in as the customer again, open the team settings **Service accounts** tab in the Enterprise Portal, and revoke the account. Revoking is a soft action: the account is marked revoked and its token is cleared, and the record is retained.
+
+{/* TODO: document removing a pending install attempt once the discard control is restored in the Enterprise Portal UI. */}

--- a/docs/vendor/enterprise-portal-v2-access.mdx
+++ b/docs/vendor/enterprise-portal-v2-access.mdx
@@ -69,4 +69,4 @@ The login routes to the correct portal version automatically. If the customer is
 
 Records created during a **Login as customer** session are read-only in the Vendor Portal. To revoke a service account, log in as the customer again, open the team settings **Service accounts** tab in the Enterprise Portal, and revoke the account. Revoking is a soft action: the account is marked revoked and its token is cleared, and the record is retained.
 
-{/* TODO: document removing a pending install attempt once the discard control is restored in the Enterprise Portal UI. */}
+To discard a pending installation, log in as the customer again and open the installation flow. In the list of pending installations, select the discard icon (the trash icon) for the installation you want to remove, then confirm in the **Discard install and service account token** dialog. Discarding permanently deletes the service account that was created for that installation, so when a service account was created only by starting an installation, discarding the installation removes both at once.


### PR DESCRIPTION
Preview link - https://deploy-preview-4289--replicated-docs.netlify.app/vendor/enterprise-portal-v2-access#login-as-customer

## What

The Enterprise Portal "Login as customer" docs framed the feature as a benign "view as a customer" preview. It didn't convey that the button opens a **full customer-admin session** where any action is real and visible to the customer, and it didn't explain how to undo changes made in that session.

This adds to the **Login as customer** section of `enterprise-portal-v2-access.mdx`:

- A `:::note` warning that the session is full customer-admin, not read-only/preview, and that starting installs or creating/revoking service accounts affects the customer directly.
- A new **Undoing changes made while logged in as a customer** subsection, explaining how to undo the two artifacts a session can create:
  - Discard a pending installation from the installations list (the discard control was restored in Enterprise Portal v2 by vandoor #10256). Discarding also permanently deletes the service account created for that installation, so both are removed in one step.
  - Revoke a standalone service account from the team settings **Service accounts** tab.

## Why

A vendor started an install flow and created a service account while logged in as a customer, then couldn't find a way to remove them (the Vendor Portal sections are read-only). The failure mode was confusion about the privilege level and where to undo, not a permissions bug. A companion Vendor Portal UI change (info-icon tooltip near the button) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)