### PR TITLE
Document EP v2 service account token rotation and revoke impact

### DIFF
--- a/docs/vendor/enterprise-portal-v2-invite.mdx
+++ b/docs/vendor/enterprise-portal-v2-invite.mdx
@@ -78,11 +78,7 @@ Service accounts provide programmatic access to the Enterprise Portal (e.g., for
 - View and manage service accounts on the customer's **Enterprise Portal access** tab under **Customer Service Accounts**
 - Service accounts are created by customer team admins from **Team Settings > Service Accounts** in the Enterprise Portal, automatically when a customer starts a new installation from the portal, and when you create install options through the Vendor API
 - Vendors can revoke service accounts from the Vendor Portal
-
-{/* HOLD (sc-139006). Do not publish until the token rotation fix ships. Rotation currently fails in production and silently invalidates the token. https://app.shortcut.com/replicated/story/139006
-
 - Customer team admins can rotate a service account token in place from the Enterprise Portal, which issues a new token and keeps the same account. Use rotation instead of revoking when a token should be replaced but the account should keep working. See [Rotate or revoke a service account token](/vendor/enterprise-portal-v2-use#rotate-or-revoke-a-service-account-token).
-*/}
 
 ## Emails
 

--- a/docs/vendor/enterprise-portal-v2-invite.mdx
+++ b/docs/vendor/enterprise-portal-v2-invite.mdx
@@ -76,8 +76,13 @@ SAML supports just-in-time user provisioning. When a user logs in via SAML for t
 Service accounts provide programmatic access to the Enterprise Portal (e.g., for CI/CD pipelines pulling install commands or registry credentials).
 
 - View and manage service accounts on the customer's **Enterprise Portal access** tab under **Customer Service Accounts**
-- Service accounts are created automatically when a customer starts a new installation from the portal
+- Service accounts are created by customer team admins from **Team Settings > Service Accounts** in the Enterprise Portal, automatically when a customer starts a new installation from the portal, and when you create install options through the Vendor API
 - Vendors can revoke service accounts from the Vendor Portal
+
+{/* HOLD (sc-139006). Do not publish until the token rotation fix ships. Rotation currently fails in production and silently invalidates the token. https://app.shortcut.com/replicated/story/139006
+
+- Customer team admins can rotate a service account token in place from the Enterprise Portal, which issues a new token and keeps the same account. Use rotation instead of revoking when a token should be replaced but the account should keep working. See [Rotate or revoke a service account token](/vendor/enterprise-portal-v2-use#rotate-or-revoke-a-service-account-token).
+*/}
 
 ## Emails
 

--- a/docs/vendor/enterprise-portal-v2-service-account-automation.mdx
+++ b/docs/vendor/enterprise-portal-v2-service-account-automation.mdx
@@ -145,3 +145,8 @@ Authorization: Bearer <service-account-token>
 ```
 
 Browser portal sessions and service account tokens are separate authentication methods. Customers should store service account tokens securely and rotate them when needed.
+
+{/* HOLD (sc-139006). Do not publish until the token rotation fix ships. https://app.shortcut.com/replicated/story/139006
+
+Team admins rotate or revoke tokens from **Team Settings > Service Accounts** in the Enterprise Portal. Rotating a token issues a new one and invalidates the old one, so any automation that authenticates with the token must be updated with the new value. For more information, see [Rotate or revoke a service account token](/vendor/enterprise-portal-v2-use#rotate-or-revoke-a-service-account-token).
+*/}

--- a/docs/vendor/enterprise-portal-v2-service-account-automation.mdx
+++ b/docs/vendor/enterprise-portal-v2-service-account-automation.mdx
@@ -146,7 +146,4 @@ Authorization: Bearer <service-account-token>
 
 Browser portal sessions and service account tokens are separate authentication methods. Customers should store service account tokens securely and rotate them when needed.
 
-{/* HOLD (sc-139006). Do not publish until the token rotation fix ships. https://app.shortcut.com/replicated/story/139006
-
 Team admins rotate or revoke tokens from **Team Settings > Service Accounts** in the Enterprise Portal. Rotating a token issues a new one and invalidates the old one, so any automation that authenticates with the token must be updated with the new value. For more information, see [Rotate or revoke a service account token](/vendor/enterprise-portal-v2-use#rotate-or-revoke-a-service-account-token).
-*/}

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -95,8 +95,6 @@ The default Enterprise Portal content template includes an API reference and wor
 
 For more information, see [Service account automation](/vendor/enterprise-portal-v2-service-account-automation).
 
-{/* HOLD (sc-139006). Do not publish the section below until the token rotation fix ships. Rotation currently fails in production and silently invalidates the token. https://app.shortcut.com/replicated/story/139006
-
 ## Rotate or revoke a service account token
 
 Customer team admins manage a token's lifecycle from **Team Settings > Service Accounts** in the Enterprise Portal. Each service account has a row menu with two actions.
@@ -114,7 +112,6 @@ Read-only automation is not exempt. If you use the token headlessly to call Ente
 :::note
 Revoking or rotating a token affects every system that authenticates with it. When a service account token is the identity credential for a running installation, this includes update checks, license sync, and registry pulls. Plan the change so that each installation can be updated with the new token.
 :::
-*/}
 
 ## Support bundles
 

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -102,7 +102,7 @@ Customer team admins manage a token's lifecycle from **Team Settings > Service A
 **Rotate token** issues a new token and immediately invalidates the current one, while keeping the same service account and its identity. Any system still using the old token loses access until it is updated with the new token:
 
 - For Helm installs, run `helm registry login` again with the new token and then redeploy with `helm upgrade`. The portal displays the exact commands after rotation.
-- For Embedded Cluster 2.7.4 and later, the running cluster picks up the new token on its next license sync, so no manual step is needed.
+- For Embedded Cluster 2.7.4 and later, upload the new token from the **License** page in the cluster's admin console. The cluster then adopts the rotated token without reinstalling. Automatic license sync does not pick up a rotated token on its own, because the running cluster authenticates with the old token, which rotation has already invalidated.
 - For Embedded Cluster versions earlier than 2.7.4, the cluster cannot adopt a rotated token and can no longer be updated. The portal asks the admin to confirm this before rotating.
 
 Read-only automation is not exempt. If you use the token headlessly to call Enterprise Portal API endpoints, for example to list available releases or check for new versions, those calls also stop working with the old token after rotation. Update the token everywhere it is stored, not only on the installation.

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -102,8 +102,8 @@ Customer team admins manage a token's lifecycle from **Team Settings > Service A
 **Rotate token** issues a new token and immediately invalidates the current one, while keeping the same service account and its identity. Any system still using the old token loses access until it is updated with the new token:
 
 - For Helm installs, run `helm registry login` again with the new token and then redeploy with `helm upgrade`. The portal displays the exact commands after rotation.
-- For Embedded Cluster 2.7.4 and later, upload the new token from the **License** page in the cluster's admin console. The cluster then adopts the rotated token without reinstalling. Automatic license sync does not pick up a rotated token on its own, because the running cluster authenticates with the old token, which rotation has already invalidated.
-- For Embedded Cluster versions earlier than 2.7.4, the cluster cannot adopt a rotated token and can no longer be updated. The portal asks the admin to confirm this before rotating.
+- For Embedded Cluster installs that include the admin console, version 2.7.4 and later, upload the new token from the **License** page in the admin console. The cluster then adopts the rotated token without reinstalling. Automatic license sync does not pick up a rotated token on its own, because the running cluster authenticates with the old token, which rotation has already invalidated.
+- For Embedded Cluster versions earlier than 2.7.4, and for Embedded Cluster installs that do not include the admin console, a running cluster cannot adopt a rotated token. Reinstalling with the new token is required. Confirm the installed versions before rotating a token that Embedded Cluster instances depend on.
 
 Read-only automation is not exempt. If you use the token headlessly to call Enterprise Portal API endpoints, for example to list available releases or check for new versions, those calls also stop working with the old token after rotation. Update the token everywhere it is stored, not only on the installation.
 

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -95,6 +95,27 @@ The default Enterprise Portal content template includes an API reference and wor
 
 For more information, see [Service account automation](/vendor/enterprise-portal-v2-service-account-automation).
 
+{/* HOLD (sc-139006). Do not publish the section below until the token rotation fix ships. Rotation currently fails in production and silently invalidates the token. https://app.shortcut.com/replicated/story/139006
+
+## Rotate or revoke a service account token
+
+Customer team admins manage a token's lifecycle from **Team Settings > Service Accounts** in the Enterprise Portal. Each service account has a row menu with two actions.
+
+**Rotate token** issues a new token and immediately invalidates the current one, while keeping the same service account and its identity. Any system still using the old token loses access until it is updated with the new token:
+
+- For Helm installs, run `helm registry login` again with the new token and then redeploy with `helm upgrade`. The portal displays the exact commands after rotation.
+- For Embedded Cluster 2.7.4 and later, the running cluster picks up the new token on its next license sync, so no manual step is needed.
+- For Embedded Cluster versions earlier than 2.7.4, the cluster cannot adopt a rotated token and can no longer be updated. The portal asks the admin to confirm this before rotating.
+
+Read-only automation is not exempt. If you use the token headlessly to call Enterprise Portal API endpoints, for example to list available releases or check for new versions, those calls also stop working with the old token after rotation. Update the token everywhere it is stored, not only on the installation.
+
+**Revoke** permanently disables the service account. Its token is cleared and cannot be recovered, so revoking is the right choice only when a token should stop working entirely. To replace a token while keeping the account and its installations working, use **Rotate token** instead.
+
+:::note
+Revoking or rotating a token affects every system that authenticates with it. When a service account token is the identity credential for a running installation, this includes update checks, license sync, and registry pulls. Plan the change so that each installation can be updated with the new token.
+:::
+*/}
+
 ## Support bundles
 
 Customers can generate and upload support bundles from the portal:

--- a/docs/vendor/enterprise-portal-v2-vendor-api-automation.mdx
+++ b/docs/vendor/enterprise-portal-v2-vendor-api-automation.mdx
@@ -231,10 +231,7 @@ Revoking is immediate and permanent. The token stops working right away, its sec
 There is no per-token expiry setting in the API. Do not script scheduled revocation as a substitute for token expiry. Revoking issues no new token, so every downstream installation must be updated with a working token out of band, and the required steps differ by installer. For example, Helm installs need a new `helm registry login` and a redeploy, while Embedded Cluster installs re-sync on newer versions but not on older ones. Scheduled revocation without a re-sync plan will take those installations offline.
 :::
 
-{/* HOLD (sc-139006). Do not publish until the token rotation fix ships. https://app.shortcut.com/replicated/story/139006
-
 The Vendor API can list and revoke service accounts, but it cannot rotate a token. Rotation is a customer team admin action performed from **Team Settings > Service Accounts** in the Enterprise Portal. For more information, see [Rotate or revoke a service account token](/vendor/enterprise-portal-v2-use#rotate-or-revoke-a-service-account-token).
-*/}
 
 ## Related API reference
 

--- a/docs/vendor/enterprise-portal-v2-vendor-api-automation.mdx
+++ b/docs/vendor/enterprise-portal-v2-vendor-api-automation.mdx
@@ -225,6 +225,17 @@ curl --request DELETE \
 
 Revoking a service account clears sensitive token data and makes the service account name reusable.
 
+:::note
+Revoking is immediate and permanent. The token stops working right away, its secret is cleared, and no replacement token is issued. Any running installation or headless automation that authenticates with the token loses access, including update checks and registry pulls, with no automatic re-sync.
+
+There is no per-token expiry setting in the API. Do not script scheduled revocation as a substitute for token expiry. Revoking issues no new token, so every downstream installation must be updated with a working token out of band, and the required steps differ by installer. For example, Helm installs need a new `helm registry login` and a redeploy, while Embedded Cluster installs re-sync on newer versions but not on older ones. Scheduled revocation without a re-sync plan will take those installations offline.
+:::
+
+{/* HOLD (sc-139006). Do not publish until the token rotation fix ships. https://app.shortcut.com/replicated/story/139006
+
+The Vendor API can list and revoke service accounts, but it cannot rotate a token. Rotation is a customer team admin action performed from **Team Settings > Service Accounts** in the Enterprise Portal. For more information, see [Rotate or revoke a service account token](/vendor/enterprise-portal-v2-use#rotate-or-revoke-a-service-account-token).
+*/}
+
 ## Related API reference
 
 The examples on this page require customer, channel, and channel release identifiers.


### PR DESCRIPTION
Preview links
* https://deploy-preview-4290--replicated-docs.netlify.app/vendor/enterprise-portal-v2-use#rotate-or-revoke-a-service-account-token
* https://deploy-preview-4290--replicated-docs.netlify.app/vendor/enterprise-portal-v2-vendor-api-automation#manage-service-accounts
* https://deploy-preview-4290--replicated-docs.netlify.app/vendor/enterprise-portal-v2-invite#service-accounts
* https://deploy-preview-4290--replicated-docs.netlify.app/vendor/enterprise-portal-v2-service-account-automation#customer-authentication

## What

Documents Enterprise Portal service account **token rotation**, which was previously undocumented (mentioned once, in passing) while **revoke** appeared in five places. Also corrects a statement about how service accounts are created, and warns vendors about the downstream impact of revoking a customer's token.

## Changes

- **enterprise-portal-v2-use.mdx** — new "Rotate or revoke a service account token" section. Covers where the actions live, rotate vs revoke semantics, the per-installer steps to adopt a rotated token (Helm re-login and redeploy; Embedded Cluster 2.7.4+ upload the new token on the admin console License page; older Embedded Cluster cannot adopt it), a caveat that read-only headless API calls also stop working with the old token, and a note on the full blast radius.
- **enterprise-portal-v2-invite.mdx** — fixes the "created automatically when a customer starts a new installation" bullet, which implied that was the only path. Service accounts are also created by team admins in Team Settings and via the Vendor API create-install-options call. Adds a bullet pointing to rotation.
- **enterprise-portal-v2-vendor-api-automation.mdx** — adds a note that revoking is immediate and permanent, issues no replacement token, and silently breaks downstream installs. Tells vendors not to script scheduled revocation as a substitute for token expiry (which does not exist in the API), and clarifies the Vendor API cannot rotate a token.
- **enterprise-portal-v2-service-account-automation.mdx** — cross-reference into the new rotation section.

## Reviewer note

**Do not merge until the rotation fix is in production.** Rotation currently fails and silently invalidates the token (sc-139006). This PR describes the intended, fixed behavior. This docs PR will not be merged until that fix is live. 

## Related
- sc-139006 — rotation returns 500 / silently invalidates token (merge blocker)
- sc-139009 — feature request: bounded-lifetime (expiring) tokens with downstream re-sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)