### PR TITLE
docs(ec): recommend required release when bumping K8s minor version

### DIFF
--- a/embedded-cluster/embedded-config.mdx
+++ b/embedded-cluster/embedded-config.mdx
@@ -86,9 +86,9 @@ Replicated recommends that you update the version frequently to ensure that you 
 
 ### Increase the Kubernetes minor version {#increment-k8s}
 
-Kubernetes supports upgrading only one minor version at a time, and Embedded Cluster blocks any upgrade that would skip a Kubernetes minor version. When you promote a release that increases the Kubernetes minor version, Replicated recommends that you mark the release as required. This guides customers through each Kubernetes minor version in sequence, so that their upgrades stay on a supported path.
+Kubernetes supports upgrading only one minor version at a time, and Embedded Cluster blocks any upgrade that would skip a Kubernetes minor version. When you promote a release that increases the Kubernetes minor version, Replicated recommends that you mark the release as required.
 
-If these releases are not marked as required, a customer can attempt to upgrade directly from an older version to your latest release, skipping the intermediate versions. Because this would skip one or more Kubernetes minor versions, Embedded Cluster blocks the upgrade, and the customer must instead upgrade to the intermediate releases one at a time.
+Marking these releases as required leads customers through the Kubernetes minor versions in order. Customers can then upgrade to your latest release without having to plan the upgrade path themselves or run into a blocked upgrade.
 
 For more information about required releases, see [Required releases](/vendor/releases-about#required-releases).
 

--- a/embedded-cluster/embedded-config.mdx
+++ b/embedded-cluster/embedded-config.mdx
@@ -86,9 +86,9 @@ Replicated recommends that you update the version frequently to ensure that you 
 
 ### Increase the Kubernetes minor version {#increment-k8s}
 
-Kubernetes supports upgrading only one minor version at a time. Because of this, when you promote a release that increases the Kubernetes minor version, Replicated recommends that you mark the release as required. Marking the release as required prevents customers from skipping it during an upgrade, so that each upgrade advances Kubernetes by at most one minor version.
+Kubernetes supports upgrading only one minor version at a time, and Embedded Cluster blocks any upgrade that would skip a Kubernetes minor version. When you promote a release that increases the Kubernetes minor version, Replicated recommends that you mark the release as required. This guides customers through each Kubernetes minor version in sequence, so that their upgrades stay on a supported path.
 
-If these releases are not marked as required, a customer can attempt to upgrade directly from an older version to your latest release in a single step. When that upgrade would advance Kubernetes by more than one minor version, it fails. The customer must instead upgrade to the intermediate releases one at a time.
+If these releases are not marked as required, a customer can attempt to upgrade directly from an older version to your latest release, skipping the intermediate versions. Because this would skip one or more Kubernetes minor versions, Embedded Cluster blocks the upgrade, and the customer must instead upgrade to the intermediate releases one at a time.
 
 For more information about required releases, see [Required releases](/vendor/releases-about#required-releases).
 

--- a/embedded-cluster/embedded-config.mdx
+++ b/embedded-cluster/embedded-config.mdx
@@ -84,6 +84,14 @@ Replicated recommends that you update the version frequently to ensure that you 
 
 <DoNotDowngrade/>
 
+### Increase the Kubernetes minor version {#increment-k8s}
+
+Kubernetes supports upgrading only one minor version at a time. Because of this, when you promote a release that increases the Kubernetes minor version, Replicated recommends that you mark the release as required. Marking the release as required prevents customers from skipping it during an upgrade, so that each upgrade advances Kubernetes by at most one minor version.
+
+If these releases are not marked as required, a customer can attempt to upgrade directly from an older version to your latest release in a single step. When that upgrade would advance Kubernetes by more than one minor version, it fails. The customer must instead upgrade to the intermediate releases one at a time.
+
+For more information about required releases, see [Required releases](/vendor/releases-about#required-releases).
+
 ## roles (Beta) {#roles}
 
 You can customize node roles in the Embedded Cluster Config using the `roles` key.

--- a/embedded-cluster/embedded-v3-migrate.mdx
+++ b/embedded-cluster/embedded-v3-migrate.mdx
@@ -208,6 +208,12 @@ The Embedded Cluster v3 installer wizard includes a **Set Up** page where end cu
 
 Embedded Cluster supports upgrading existing installations from v2 to v3 without having to reinstall the application. The migration uses the same `upgrade` command as any v3-to-v3 upgrade. The v3 binary automatically detects the v2 installation and handles the migration, prompting the user to confirm. Running `install` on a node with an existing v2 installation is blocked — use `upgrade` instead.
 
+:::important
+If your v3 release uses a newer Kubernetes minor version than the customer's v2 installation, the migration also upgrades Kubernetes. Because Kubernetes supports upgrading only one minor version at a time, the migration fails if the customer's Kubernetes version is more than one minor version behind the version in your v3 release.
+
+To avoid this, ensure that customers step through the intermediate Kubernetes minor versions before they migrate to v3. Replicated recommends that you mark each release that increases the Kubernetes minor version as required so that customers cannot skip it. For more information, see [Increase the Kubernetes minor version](embedded-config#increment-k8s).
+:::
+
 :::note
 Releases that use Embedded Cluster v3 will not appear as available updates in the Embedded Cluster v2 KOTS Admin Console. This is by design to prevent accidental migrations. Your customers will need to get the v3 release from the [Enterprise Portal](/vendor/enterprise-portal-about) or by downloading the binary directly. Plan to communicate this to your customer base when you promote a v3-enabled release.
 :::

--- a/embedded-cluster/embedded-v3-migrate.mdx
+++ b/embedded-cluster/embedded-v3-migrate.mdx
@@ -209,7 +209,7 @@ The Embedded Cluster v3 installer wizard includes a **Set Up** page where end cu
 Embedded Cluster supports upgrading existing installations from v2 to v3 without having to reinstall the application. The migration uses the same `upgrade` command as any v3-to-v3 upgrade. The v3 binary automatically detects the v2 installation and handles the migration, prompting the user to confirm. Running `install` on a node with an existing v2 installation is blocked — use `upgrade` instead.
 
 :::important
-If your v3 release uses a newer Kubernetes minor version than the customer's v2 installation, the migration also upgrades Kubernetes. Because Kubernetes supports upgrading only one minor version at a time, the migration fails if the customer's Kubernetes version is more than one minor version behind the version in your v3 release.
+If your v3 release uses a newer Kubernetes minor version than the customer's v2 installation, the migration also upgrades Kubernetes. Kubernetes supports upgrading only one minor version at a time, so Embedded Cluster blocks the migration if the customer's Kubernetes version is more than one minor version behind the version in your v3 release.
 
 To avoid this, ensure that customers step through the intermediate Kubernetes minor versions before they migrate to v3. Replicated recommends that you mark each release that increases the Kubernetes minor version as required so that customers cannot skip it. For more information, see [Increase the Kubernetes minor version](embedded-config#increment-k8s).
 :::


### PR DESCRIPTION
## What

Documents that vendors should mark a release as **required** when it increases the Kubernetes minor version.

Kubernetes supports upgrading only one minor version at a time. Marking these releases as required prevents customers from attempting an upgrade that would advance Kubernetes by more than one minor version in a single step, which fails.

## Where

Guidance is added in two locations:

- **`embedded-cluster/embedded-config.mdx`** — a new `Increase the Kubernetes minor version` subsection in the Config `version` section (the general reference, anchored at `#increment-k8s`).
- **`embedded-cluster/embedded-v3-migrate.mdx`** — a migration-specific note. The v2-to-v3 migration also upgrades Kubernetes *only if* the v3 release uses a newer Kubernetes minor version than the customer's v2 installation, and it fails when the installed version is more than one minor version behind. Cross-references the config topic.

## Context

Addresses vendor confusion when a v2-to-v3 migration is blocked because the K8s version skip exceeds one minor version (for example, v2 on K8s 1.32 migrating to a v3 release on K8s 1.36). This is a docs-only change recommending the required-release workflow as the prevention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)