### PR TITLE
Soften Security Center "continuous" scanning language

### DIFF
--- a/docs/vendor/security-center-about.mdx
+++ b/docs/vendor/security-center-about.mdx
@@ -47,7 +47,7 @@ You can explicitly include or exclude images from being scanned by the Security 
 
 ### How cve scanning works
 
-The Security Center is powered by Replicated's [SecureBuild](https://securebuild.com/) technology. With SecureBuild, every image is scanned continuously (not just at release time) using the open source vulnerability scanner [Grype](https://github.com/anchore/grype). This means that, as new CVEs are disclosed, they automatically appear in your Security Center without requiring a new release.
+The Security Center is powered by Replicated's [SecureBuild](https://securebuild.com/) technology. With SecureBuild, images are scanned on a recurring schedule using the open source vulnerability scanner [Grype](https://github.com/anchore/grype), not only at release time. Newly promoted images are scanned as soon as they are identified, and previously scanned images are rescanned periodically, with more recently promoted images scanned more frequently than older ones. This means that, as new CVEs are disclosed, they surface in your Security Center over time without requiring a new release.
 
 The following describes the Security Center CVE scanning process:
 


### PR DESCRIPTION
## What

Reword the "How CVE scanning works" section of the Security Center (Alpha) docs so it no longer claims every image is scanned **continuously**.

## Why

"Continuously" reads as real-time and overstates what the system does. Scanning actually runs on a recurring schedule with variable frequency:

- Newly promoted images that have never been scanned are prioritized and scanned right away.
- Previously scanned images are rescanned periodically, more often for recently promoted images than for older ones.

The new wording describes a recurring schedule without committing to the exact cadence (which may change), while keeping the honest and valuable point that newly disclosed CVEs surface after release without requiring a new release.

## Change

Before:
> With SecureBuild, every image is scanned continuously (not just at release time) using the open source vulnerability scanner Grype. This means that, as new CVEs are disclosed, they automatically appear in your Security Center without requiring a new release.

After:
> With SecureBuild, images are scanned on a recurring schedule using the open source vulnerability scanner Grype, not only at release time. Newly promoted images are scanned as soon as they are identified, and previously scanned images are rescanned periodically, with more recently promoted images scanned more frequently than older ones. This means that, as new CVEs are disclosed, they surface in your Security Center over time without requiring a new release.

Scope is intentionally limited to the continuous-scanning language. The SecureBuild references are left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)