### PR TITLE
Document registry egress summary on the Image Registries page

### DIFF
--- a/docs/vendor/packaging-private-images.md
+++ b/docs/vendor/packaging-private-images.md
@@ -306,9 +306,7 @@ To duplicate an existing external registry:
 
 ## View pull activity
 
-You can view image pull activity for each of your external registries that are connected to the Replicated proxy registry. This includes a summary of recent pull activity as well as the full history of image pulls.
-
-The **Image Registries** page also shows total registry egress for the current calendar month. You can use this value with the **Egress Threshold Reached** notification event to get alerted when monthly registry egress reaches a configured threshold. For more information, see [Event types and filters](/reference/notifications-events-filters#egress-threshold-reached).
+You can view image pull activity for each of your external registries that are connected to the Replicated proxy registry. This includes a summary of recent pull activity as well as the full history of image pulls. For aggregate download volume across all your registries, see [View registry egress](#view-registry-egress) below.
 
 You can also use the Replicated Vendor API `/v3/external_registry/logs` endpoint to get image pull activity. For more information, see [Get the logs for a specific external registry either by endpoint or slug, or both](https://replicated-vendor-api.readme.io/reference/externalregistrylogs) in the Vendor API documentation.
 
@@ -366,3 +364,36 @@ You can also use the Replicated Vendor API `/v3/external_registry/logs` endpoint
       <td>If the registry operation was successful</td>
     </tr>
   </table>
+
+## View registry egress
+
+The **Image Registries** page displays a **Registry egress this month** summary at the top, showing the total volume of image data downloaded through Replicated during the current calendar month (in UTC). This is the outbound data transfer generated when your customers, or your own systems, pull images through the Replicated proxy registry or the Replicated registry.
+
+The summary breaks the total down as follows:
+
+<table>
+  <tr>
+    <th>Field</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>Team total</td>
+    <td>The combined egress for all applications in your team for the current month.</td>
+  </tr>
+  <tr>
+    <td>Proxy registry</td>
+    <td>Egress from images pulled through the Replicated proxy registry, which delivers images from your external private registries.</td>
+  </tr>
+  <tr>
+    <td>Replicated registry</td>
+    <td>Egress from images pulled from the Replicated registry.</td>
+  </tr>
+  <tr>
+    <td>This app</td>
+    <td>The portion of the team total attributable to the application you are currently viewing.</td>
+  </tr>
+</table>
+
+:::note
+To get alerted when your monthly registry egress reaches a configured volume, use the **Egress Threshold Reached** notification event. For more information, see [Event types and filters](/reference/notifications-events-filters#egress-threshold-reached).
+:::


### PR DESCRIPTION
## What

Adds a dedicated **View registry egress** section to the [packaging-private-images](https://docs.replicated.com/vendor/packaging-private-images) page and cross-links it with pull activity and the related alerting event.

## Why

The registry egress summary card (shipped in vandoor #10046, made unconditional in #10118) was documented as a single sentence buried inside the **View pull activity** section, with no heading of its own. That left it invisible in the page's right-hand table of contents, so vendors landing on the page had no easy way to discover it. Even someone familiar with the page missed it.

## Changes

- New `## View registry egress` H2 (its own TOC entry + stable `#view-registry-egress` anchor) describing the **Registry egress this month** summary and its Team total / Proxy registry / Replicated registry / This app breakdown.
- Removed the buried egress sentence from **View pull activity** and replaced it with an inline pointer to the new section, keeping that section focused on per-registry pull logs.
- Cross-links are now bidirectional: pull activity → egress, and egress → the **Egress Threshold Reached** notification event (via a `:::note`).
- Qualified the reporting window as "current calendar month (in UTC)" to match the API's UTC month period.

## Follow-up

No screenshot exists for the egress summary card yet. I intentionally did not insert a broken image link; a `proxy-registry-registry-egress-summary.png` can be added in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)