### PR TITLE
docs: fix GitHub token regeneration attribution in Terraform proxy flow

### DIFF
--- a/docs/vendor/enterprise-portal-v2-terraform.mdx
+++ b/docs/vendor/enterprise-portal-v2-terraform.mdx
@@ -141,7 +141,7 @@ When the customer runs `terraform init`, Terraform makes four sequential request
 1. **Discovery**: Worker returns a static registry manifest pointing to the modules API. No auth required.
 1. **List versions**: Worker calls the Replicated API, which validates the license, checks the customer's channel, and returns the allowed `version_label` values. Only version numbers are returned to the customer.
 1. **Download pointer**: Worker calls the Replicated API to create a short-lived server-side session backed by a JWT. The response includes an `X-Terraform-Get` header with the archive URL containing the JWT as a query parameter. The JWT is an opaque, short-lived token. The GitHub credential is stored server-side and never exposed to the customer.
-1. **Tarball download**: Worker validates the JWT, retrieves the GitHub installation credentials from the server-side session, regenerates a fresh GitHub token, fetches the tarball from GitHub, and streams it back. GitHub redirects to a temporary `codeload.github.com` URL; the worker follows this redirect internally so the customer never sees it.
+1. **Tarball download**: Worker validates the JWT against the server-side session. The Replicated API regenerates a fresh, short-lived GitHub token and returns the installation credentials to the worker, which fetches the tarball from GitHub and streams it back. GitHub redirects to a temporary `codeload.github.com` URL; the worker follows this redirect internally so the customer never sees it.
 
 The customer **never sees** the GitHub token, repo URL, or any internal infrastructure. They only ever send their license ID and only ever talk to `proxy.replicated.com`.
 


### PR DESCRIPTION
## What

Corrects the step-4 description of the Terraform proxy registry download flow on the [Include Terraform Modules](https://docs.replicated.com/vendor/enterprise-portal-v2-terraform) page.

## Why

The doc attributed regenerating the fresh GitHub token to the proxy-registry worker. In the actual implementation, the worker validates the JWT and calls the Replicated API's session endpoint, and it is the **API** that regenerates the fresh, short-lived GitHub token server-side and returns the installation credentials to the worker. The worker only uses those credentials to fetch and stream the tarball.

This matters for anyone reasoning about the trust boundary: the token is minted server-side in the API, not at the edge worker.

### Evidence
- Worker receives (does not mint) the token from the session endpoint: `proxy-registry/src/terraform.ts` (`getTerraformSession` → uses `session.githubToken`)
- API regenerates the token per session: `handlers/vendor-api/replv3/proxy/get_terraform_session.go`

The end-state the doc describes (fresh, short-lived, server-side, never exposed to the customer) is unchanged and remains accurate. This is a wording/attribution fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)