### PR TITLE
Clarify proxy registry scope and link supported registries

### DIFF
--- a/docs/vendor/private-images-about.md
+++ b/docs/vendor/private-images-about.md
@@ -6,7 +6,13 @@ This topic describes how the Replicated proxy registry can be used to grant prox
 
 If your application images are available in a private image registry exposed to the internet such as Docker Hub or Amazon Elastic Container Registry (ECR), then the Replicated proxy registry can grant proxy, or _pull-through_, access to the images without exposing registry credentials to your customers. When you use the proxy registry, you do not have to modify the process that you already use to build and push images to deploy your application.
 
+The proxy registry works with most registries that conform to the Open Container Initiative (OCI) standard. For the full list of supported registries, see [Supported registries](/vendor/packaging-private-images#supported-registries).
+
 To grant proxy access, the proxy registry uses the customer licenses that you create in the Replicated vendor portal. This allows you to revoke a customer’s ability to pull private images by editing their license, rather than having to manage image access through separate identity or authentication systems. For example, when a trial license expires, the customer's ability to pull private images is automatically revoked.
+
+:::note
+The Replicated proxy registry provides pull-through access to your container images. It is not a general-purpose forward proxy and does not relay arbitrary outbound traffic, such as operating system packages or npm and pip requests. It delivers only content that Replicated supports serving.
+:::
 
 The following diagram demonstrates how the proxy registry pulls images from your external registry, and how deployed instances of your application pull images from the proxy registry:
 


### PR DESCRIPTION
## What

Two small clarifications to [About the Replicated proxy registry](https://docs.replicated.com/vendor/private-images-about):

1. **Scope note.** Adds a `:::note` distinguishing the proxy registry from a general-purpose forward proxy. It clarifies that the proxy registry does not relay arbitrary outbound traffic (OS packages, npm/pip, etc.) and delivers only content Replicated supports serving.
2. **Supported registries pointer.** The overview previously named only Docker Hub and ECR, which reads like the full set. Adds a sentence noting it works with most OCI-conformant registries and links to the canonical [Supported registries](https://docs.replicated.com/vendor/packaging-private-images#supported-registries) list.

## Why

This confusion comes up repeatedly: people read "proxy" as a general-purpose egress/forward proxy and ask whether they can route other external traffic (packages, arbitrary downloads) through it. The answer is no, and stating the boundary up front heads off the question. The registry-list pointer avoids implying the supported set is just Docker Hub and ECR.

The scope note is deliberately open-ended ("content that Replicated supports serving") so it stays accurate as delivery capabilities evolve, without dragging other features onto an images-focused page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)