### PR TITLE
Update Security Center navigation documentation

### DIFF
--- a/docs/vendor/security-center-about.mdx
+++ b/docs/vendor/security-center-about.mdx
@@ -56,7 +56,7 @@ The following describes the Security Center CVE scanning process:
 1. Security Center aggregates the vulnerability counts for all images by severity: Critical, High, Medium, and Low.
 1. For each CVE, Security Center includes an identifier, description, CVSS score, affected artifacts, and available fixes.
 1. Security Center displays the results of the CVE scan in the Vendor Portal and Enterprise Portal:
-   - **Vendor Portal**: In the Vendor Portal, you can view a vulnerability overview with a severity breakdown, top risks, a complete image inventory with CVE counts, and detailed CVE information per image.
+   - **Vendor Portal**: In the Vendor Portal, you can assess fleet-wide CVE exposure by customer, release, or CVE. You can also view a release vulnerability overview that includes a severity breakdown, top risks, and a complete image inventory with CVE counts. For each image, you can view detailed CVE information.
    - **Enterprise Portal**: In the Enterprise Portal, your customers can view CVE reports showing known vulnerabilities, per-image details, and CVE reduction metrics when comparing versions.
 
 ### How SBOM generation works
@@ -104,4 +104,3 @@ The following describes the Security Center SBOM generation process:
 * Security Center reporting is available only for Embedded Cluster and Helm CLI installations. It is not available for kURL installations or for KOTS installations in an existing cluster.
 
 * If you have configured the [`builder`](/reference/custom-resource-helmchart-v2#builder) key in any of the HelmChart custom resources in your release, note that the Security Center uses the Helm values provided in the `builder` key to create the list of images that are scanned and reported on for the given Helm chart. The Security Center will scan and report on this same list of images for both air gap and online installations. If there are any images that you want reported on in the Security Center, ensure that they are exposed by the values provided in the `builder` key.
-

--- a/docs/vendor/security-center-view-vendor-portal.mdx
+++ b/docs/vendor/security-center-view-vendor-portal.mdx
@@ -10,19 +10,21 @@ The Security Center is Alpha. The features and functionality described on this p
 
 In the Vendor Portal, the Security Center provides dashboards for monitoring vulnerabilities across your releases and assessing the impact of CVEs across your customer fleet. You can also view security information for a specific release or customer instance.
 
-## Security Center dashboard
+To open the Security Center, go to **[App name] > Security**. The **Customer Impact** dashboard opens by default. Use the section switch to select **Release Security** or return to **Customer Impact**.
 
-The Security Center dashboard is available in the Vendor Portal at **[App name] > Security**.
+## Release Security dashboard
 
-The following shows an example of the Security Center dashboard:
+Select **Release Security** to view security information for the release selected by installation type and channel.
 
-![Security Center dashboard](/images/security-center-dashboard.png)
+The following shows an example of the Release Security dashboard:
+
+![Release Security dashboard](/images/security-center-dashboard.png)
 
 [View a larger version of this image](/images/security-center-dashboard.png)
 
-You can filter for the information on the Security Center dashboard by release type (Linux/Embedded Cluster or Helm) and release channel. The information displayed on the Security Center dashboard applies to the currently promoted release of the selected type on the selected channel.
+You can filter the Release Security dashboard by release type (Linux/Embedded Cluster or Helm) and release channel.
 
-The Security Center dashboard includes the following:
+The Release Security dashboard includes the following:
 * The number of customers affected by Critical or High CVEs, with a link to view the impact by customer
 * An overview of vulnerabilities present in the release, including a breakdown of CVE severity (Critical, High, Medium, Low) and a detailed list of the top security risks
 * The software bill of materials (SBOM) for the release, with a **Download SBOM** option
@@ -35,7 +37,7 @@ The Security Center dashboard includes the following:
 
 ### Software bill of materials (SBOM)
 
-The Security Center dashboard displays the software bill of materials (SBOM) for the release in view. The SBOM includes the format, the number of components and dependencies, the generation date, and the tool used. Select **Download SBOM** to download the SBOM as a JSON file.
+The Release Security dashboard displays the software bill of materials (SBOM) for the release in view. The SBOM includes the format, the number of components and dependencies, the generation date, and the tool used. Select **Download SBOM** to download the SBOM as a JSON file.
 
 ### Filter container images by source
 
@@ -82,8 +84,6 @@ Security Center groups each CVE by its highest severity level across all affecte
 
 The **Customer Impact** dashboard shows fleet-wide CVE exposure for Helm and Embedded Cluster instances that report data to the Vendor Portal.
 
-To open the dashboard, go to **[App name] > Security** and select **Customer Impact**.
-
 The following shows an example of the Customer Impact dashboard:
 
 ![Security Center Customer Impact dashboard](/images/security-center-customer-impact.png)
@@ -113,9 +113,19 @@ Each customer row shows the number and status of its instances and the aggregate
 
 An air gap instance might not have SDK-reported CVE data. In this case, Security Center displays the CVE counts for the latest release on the instance's channel as a reference. These counts represent the release and not the instance's reported security posture.
 
+### View impact by CVE
+
+On the **By CVE** tab, you can:
+
+* Search by CVE ID.
+* Filter CVEs by severity.
+* Select **Show unfixable CVEs** to include CVEs without a known fix.
+
+Each CVE row shows its description and the number of affected releases and customers. Expand a CVE to view the affected releases. Expand a release to view affected customers and the status of each customer instance.
+
 ## Release-specific CVE information
 
-CVE details are available for all current and previously promoted application release versions. To view CVE information for a specific release, go to **Releases > [Release Version] > Security**. This page shows the same container image list, source filter, and SBOM as the [Security Center dashboard](#security-center-dashboard).
+CVE details are available for all current and previously promoted application release versions. To view CVE information for a specific release, go to **Releases > [Release Version] > Security**. This page shows the same container image list, source filter, and SBOM as the [Release Security dashboard](#release-security-dashboard).
 
 ## Customer-specific CVE information
 

--- a/docs/vendor/security-center-view-vendor-portal.mdx
+++ b/docs/vendor/security-center-view-vendor-portal.mdx
@@ -30,7 +30,7 @@ The **Overview** tab includes:
 * The number of actively promoted releases with Critical or High CVEs, compared to the number of promoted releases with security data.
 * The **Actively promoted releases** table, which lists the current release on each active channel. For each release, the table shows the version, channel, CVE counts by severity, number of customers on the channel, number of active instances, and number of instances with Critical CVEs.
 
-By default, the dashboard counts only CVEs that have a known fix. Turn on **Show unfixable CVEs** to include CVEs for which no fix is currently available.
+By default, the dashboard counts only CVEs that have a known fix. Turn on **Show unfixable CVEs** to include CVEs for which no fix is available.
 
 ### View impact by customer
 
@@ -41,7 +41,7 @@ On the **By Customer** tab, you can:
 * Sort the results by Critical CVEs, total CVEs, customer name, or number of instances.
 * Turn on **Show unfixable CVEs** to include CVEs without a known fix.
 
-Each customer row shows the number and status of its instances and the aggregate CVE counts across instances, where each severity count is the highest value reported by any single instance rather than a sum. Expand a row to view each instance's status, installation type, channel, application version, last check-in, and CVE counts reported by the Replicated SDK.
+Each customer row shows its number of instances, instance statuses, and aggregate CVE counts. Each aggregate severity count is the highest value reported by a single instance, rather than a sum. Expand a row to view the status, installation type, channel, application version, last check-in, and SDK-reported CVE counts for each instance.
 
 An air gap instance might not have SDK-reported CVE data. In this case, Security Center displays the CVE counts for the latest release on the instance's channel as a reference. These counts represent the release and not the instance's reported security posture.
 

--- a/docs/vendor/security-center-view-vendor-portal.mdx
+++ b/docs/vendor/security-center-view-vendor-portal.mdx
@@ -12,6 +12,49 @@ In the Vendor Portal, the Security Center provides dashboards for monitoring vul
 
 To open the Security Center, go to **[App name] > Security**. The **Customer Impact** dashboard opens by default. Use the section switch to select **Release Security** or return to **Customer Impact**.
 
+## Customer Impact dashboard
+
+The **Customer Impact** dashboard shows fleet-wide CVE exposure for Helm and Embedded Cluster instances that report data to the Vendor Portal.
+
+The following shows an example of the Customer Impact dashboard:
+
+![Security Center Customer Impact dashboard](/images/security-center-customer-impact.png)
+
+[View a larger version of this image](/images/security-center-customer-impact.png)
+
+### Review the customer impact overview
+
+The **Overview** tab includes:
+
+* A security posture snapshot that compares the number of customers with Critical or High CVEs to the total number of customers.
+* The number of actively promoted releases with Critical or High CVEs, compared to the number of promoted releases with security data.
+* The **Actively promoted releases** table, which lists the current release on each active channel. For each release, the table shows the version, channel, CVE counts by severity, number of customers on the channel, number of active instances, and number of instances with Critical CVEs.
+
+By default, the dashboard counts only CVEs that have a known fix. Turn on **Show unfixable CVEs** to include CVEs for which no fix is currently available.
+
+### View impact by customer
+
+On the **By Customer** tab, you can:
+
+* Search for a customer.
+* Filter customers by one or more CVE severity levels.
+* Sort the results by Critical CVEs, total CVEs, customer name, or number of instances.
+* Turn on **Show unfixable CVEs** to include CVEs without a known fix.
+
+Each customer row shows the number and status of its instances and the aggregate CVE counts across instances, where each severity count is the highest value reported by any single instance rather than a sum. Expand a row to view each instance's status, installation type, channel, application version, last check-in, and CVE counts reported by the Replicated SDK.
+
+An air gap instance might not have SDK-reported CVE data. In this case, Security Center displays the CVE counts for the latest release on the instance's channel as a reference. These counts represent the release and not the instance's reported security posture.
+
+### View impact by CVE
+
+On the **By CVE** tab, you can:
+
+* Search by CVE ID.
+* Filter CVEs by severity.
+* Select **Show unfixable CVEs** to include CVEs without a known fix.
+
+Each CVE row shows its description and the number of affected releases and customers. Expand a CVE to view the affected releases. Expand a release to view affected customers and the status of each customer instance.
+
 ## Release security dashboard
 
 Select **Release Security** to view security information for the release selected by installation type and channel.
@@ -79,49 +122,6 @@ On the **CVE details** tab, you can filter the list of CVEs by severity level. S
 The **Showing X of Y CVEs** label reflects how many CVEs match the current filter.
 
 Security Center groups each CVE by its highest severity level across all affected images. For example, a CVE with a Critical rating in one image and a Low rating in another appears in the **Critical** group. This ensures that each CVE reflects its most severe rating.
-
-## Customer Impact dashboard
-
-The **Customer Impact** dashboard shows fleet-wide CVE exposure for Helm and Embedded Cluster instances that report data to the Vendor Portal.
-
-The following shows an example of the Customer Impact dashboard:
-
-![Security Center Customer Impact dashboard](/images/security-center-customer-impact.png)
-
-[View a larger version of this image](/images/security-center-customer-impact.png)
-
-### Review the customer impact overview
-
-The **Overview** tab includes:
-
-* A security posture snapshot that compares the number of customers with Critical or High CVEs to the total number of customers.
-* The number of actively promoted releases with Critical or High CVEs, compared to the number of promoted releases with security data.
-* The **Actively promoted releases** table, which lists the current release on each active channel. For each release, the table shows the version, channel, CVE counts by severity, number of customers on the channel, number of active instances, and number of instances with Critical CVEs.
-
-By default, the dashboard counts only CVEs that have a known fix. Turn on **Show unfixable CVEs** to include CVEs for which no fix is currently available.
-
-### View impact by customer
-
-On the **By Customer** tab, you can:
-
-* Search for a customer.
-* Filter customers by one or more CVE severity levels.
-* Sort the results by Critical CVEs, total CVEs, customer name, or number of instances.
-* Turn on **Show unfixable CVEs** to include CVEs without a known fix.
-
-Each customer row shows the number and status of its instances and the aggregate CVE counts across instances, where each severity count is the highest value reported by any single instance rather than a sum. Expand a row to view each instance's status, installation type, channel, application version, last check-in, and CVE counts reported by the Replicated SDK.
-
-An air gap instance might not have SDK-reported CVE data. In this case, Security Center displays the CVE counts for the latest release on the instance's channel as a reference. These counts represent the release and not the instance's reported security posture.
-
-### View impact by CVE
-
-On the **By CVE** tab, you can:
-
-* Search by CVE ID.
-* Filter CVEs by severity.
-* Select **Show unfixable CVEs** to include CVEs without a known fix.
-
-Each CVE row shows its description and the number of affected releases and customers. Expand a CVE to view the affected releases. Expand a release to view affected customers and the status of each customer instance.
 
 ## Release-specific CVE information
 

--- a/docs/vendor/security-center-view-vendor-portal.mdx
+++ b/docs/vendor/security-center-view-vendor-portal.mdx
@@ -12,7 +12,7 @@ In the Vendor Portal, the Security Center provides dashboards for monitoring vul
 
 To open the Security Center, go to **[App name] > Security**. The **Customer Impact** dashboard opens by default. Use the section switch to select **Release Security** or return to **Customer Impact**.
 
-## Release Security dashboard
+## Release security dashboard
 
 Select **Release Security** to view security information for the release selected by installation type and channel.
 

--- a/styles/config/vocabularies/ReplicatedTerms/accept.txt
+++ b/styles/config/vocabularies/ReplicatedTerms/accept.txt
@@ -39,6 +39,7 @@ statusInformers
 supportMinimalRBACPrivileges
 targetKotsVersion
 unarchive
+unfixable
 Unarchived
 collab
 Reinvite


### PR DESCRIPTION
## What changed

- Document Customer Impact as the default Security Center dashboard.
- Rename the release-focused dashboard to Release Security and explain the section switch.
- Document the Customer Impact **By CVE** workflow.
- Update the Security Center overview to include fleet-wide exposure.

## Validation

- `npm run build`
- `git diff --check`

