### PR TITLE
Add worked example for KOTS/kURL installer pages

### DIFF
--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -414,6 +414,35 @@ Props: `stepNumber`, `title`, `optional` (boolean).
 </Prerequisites>
 ```
 
+#### Adding KOTS or kURL installer pages
+
+The default content template ships install pages for Embedded Cluster (`pages/installation/linux.md`) and Helm (`pages/installation/helm.md`), already listed in `toc.yaml`. It does not ship pages for KOTS or kURL. To give those customers a dedicated installer page, add one yourself using the `<KotsDownloadAssets />` or `<KurlDownloadAssets />` component.
+
+1. Create a page that embeds the component, for example `pages/installation/kots.md`:
+
+   ```markdown
+   # KOTS Installation
+
+   Download the artifacts for your licensed version below.
+
+   <KotsDownloadAssets stepNumber={1} />
+   ```
+
+1. Add the page to `toc.yaml` under the Installation section, gated with `visible_when` so it only appears for customers whose license includes the KOTS install type with air gap enabled:
+
+   ```yaml
+   - title: KOTS
+     page: pages/installation/kots.md
+     visible_when:
+       entitlements:
+         - isKotsInstallEnabled
+         - isAirgapSupported
+   ```
+
+For kURL, use the `<KurlDownloadAssets />` component and gate the navigation item on `isKurlInstallEnabled` and `isAirgapSupported`.
+
+The download components gate themselves on the same entitlements, so a customer who reaches the page without them sees nothing to download. Matching the `visible_when` conditions to the component keeps the navigation item hidden for those customers instead of showing them an empty page.
+
 ### Update components
 
 **`<LinuxUpdateAssets />`**: Renders Linux/Embedded Cluster upgrade instructions for the customer's current instance. For air gap upgrades, includes a registry hostname input for image relocation when the customer uses a private registry. Props: `stepNumber`.

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -416,6 +416,8 @@ Props: `stepNumber`, `title`, `optional` (boolean).
 
 #### Adding KOTS or kURL installer pages
 
+KOTS and kURL instances already appear on the Instances & Updates page with no setup, where entitled customers can download versioned artifacts and create air gap instance records. This is rendered by the `<InstancesAndUpdates />` component, which ships in the default template. The dedicated installer pages described here are an optional addition that gives KOTS and kURL customers a download page of their own, the same as the Linux and Helm install pages.
+
 The default content template ships install pages for Embedded Cluster (`pages/installation/linux.md`) and Helm (`pages/installation/helm.md`), already listed in `toc.yaml`. It does not ship pages for KOTS or kURL. To give those customers a dedicated installer page, add one yourself using the `<KotsDownloadAssets />` or `<KurlDownloadAssets />` component.
 
 1. Create a page that embeds the component, for example `pages/installation/kots.md`:


### PR DESCRIPTION
Preview link - https://deploy-preview-4318--replicated-docs.netlify.app/vendor/enterprise-portal-v2-content#adding-kots-or-kurl-installer-pages

## What

Adds a short walkthrough on _Customize Portal Content_ ([enterprise-portal-v2-content.mdx](https://github.com/replicatedhq/replicated-docs/blob/main/docs/vendor/enterprise-portal-v2-content.mdx)) showing vendors how to add a dedicated KOTS or kURL installer page.

## Why

The default content template ships Embedded Cluster (`pages/installation/linux.md`) and Helm (`pages/installation/helm.md`) install pages already wired into `toc.yaml`, so vendors never assemble those from scratch — they edit what the template gave them.

KOTS and kURL are the exception. The download components (`<KotsDownloadAssets />` / `<KurlDownloadAssets />`) and the gating flags (`isKotsInstallEnabled` / `isKurlInstallEnabled`) both exist, but nothing ships pre-wired in the template. A vendor who wants those pages had to stitch page + `toc.yaml` entry + `visible_when` gating together from three separate sections, with no worked example.

This is the natural follow-up to #4317, which reframed the KOTS/kURL section on the customer-facing _use_ page to point at "dedicated installer pages, when the vendor includes them" — this PR documents how a vendor actually includes them.

## Changes

- New `#### Adding KOTS or kURL installer pages` subsection under Installation components: create a page embedding the component, list it in `toc.yaml`, and gate the nav item with `visible_when` on `isKotsInstallEnabled` / `isKurlInstallEnabled` plus `isAirgapSupported` so the navigation gating matches the component's own install-type and air gap gating (no empty page for un-entitled customers).

The example mirrors the pattern already in the template's own `toc.yaml` (the Linux/Helm `visible_when` entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)