### PR TITLE
docs: use blue note styling for EP v2 alpha admonitions

### DIFF
--- a/docs/vendor/enterprise-portal-v2-about.mdx
+++ b/docs/vendor/enterprise-portal-v2-about.mdx
@@ -1,6 +1,6 @@
 # About the Enterprise Portal
 
-:::important Alpha Feature
+:::note Alpha Feature
 Features described on this page are in alpha and subject to change. Some capabilities might require additional access.
 :::
 

--- a/docs/vendor/enterprise-portal-v2-access.mdx
+++ b/docs/vendor/enterprise-portal-v2-access.mdx
@@ -1,6 +1,6 @@
 # Test and Preview the Enterprise Portal
 
-:::important Alpha Feature
+:::note Alpha Feature
 Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
 :::
 

--- a/docs/vendor/enterprise-portal-v2-branding.mdx
+++ b/docs/vendor/enterprise-portal-v2-branding.mdx
@@ -1,6 +1,6 @@
 # Customize Portal Branding
 
-:::important Alpha Feature
+:::note Alpha Feature
 Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
 :::
 

--- a/docs/vendor/enterprise-portal-v2-connect-repo.mdx
+++ b/docs/vendor/enterprise-portal-v2-connect-repo.mdx
@@ -1,6 +1,6 @@
 # Connect a Git Repo
 
-:::important Alpha Feature
+:::note Alpha Feature
 Features described on this page are in alpha and subject to change. Some capabilities might require additional access.
 :::
 

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -1,6 +1,6 @@
 # Customize Portal Content
 
-:::important Alpha Feature
+:::note Alpha Feature
 Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
 :::
 

--- a/docs/vendor/enterprise-portal-v2-domains.mdx
+++ b/docs/vendor/enterprise-portal-v2-domains.mdx
@@ -1,6 +1,6 @@
 # Configure a Custom Domain
 
-:::important Alpha Feature
+:::note Alpha Feature
 Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
 :::
 

--- a/docs/vendor/enterprise-portal-v2-emails.mdx
+++ b/docs/vendor/enterprise-portal-v2-emails.mdx
@@ -1,6 +1,6 @@
 # Customize Customer Emails
 
-:::important Alpha Feature
+:::note Alpha Feature
 Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
 :::
 

--- a/docs/vendor/enterprise-portal-v2-helm-reference.mdx
+++ b/docs/vendor/enterprise-portal-v2-helm-reference.mdx
@@ -1,6 +1,6 @@
 # Generate Helm Docs
 
-:::important Alpha Feature
+:::note Alpha Feature
 Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
 :::
 

--- a/docs/vendor/enterprise-portal-v2-invite.mdx
+++ b/docs/vendor/enterprise-portal-v2-invite.mdx
@@ -1,6 +1,6 @@
 # Manage Customer Access
 
-:::important Alpha Feature
+:::note Alpha Feature
 Features described on this page are in alpha and subject to change. Some capabilities might require additional access.
 :::
 

--- a/docs/vendor/enterprise-portal-v2-self-serve-signup.mdx
+++ b/docs/vendor/enterprise-portal-v2-self-serve-signup.mdx
@@ -1,6 +1,6 @@
 # Enable Self-Service Sign-Ups
 
-:::important Alpha Feature
+:::note Alpha Feature
 Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
 :::
 

--- a/docs/vendor/enterprise-portal-v2-service-account-automation.mdx
+++ b/docs/vendor/enterprise-portal-v2-service-account-automation.mdx
@@ -4,7 +4,7 @@ sidebar_label: Enable Customer Automation
 
 # Enable customer automation
 
-:::important Alpha Feature
+:::note Alpha Feature
 Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
 :::
 

--- a/docs/vendor/enterprise-portal-v2-terraform.mdx
+++ b/docs/vendor/enterprise-portal-v2-terraform.mdx
@@ -1,6 +1,6 @@
 # Include Terraform Modules
 
-:::important Alpha Feature
+:::note Alpha Feature
 Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
 :::
 

--- a/docs/vendor/enterprise-portal-v2-troubleshooting.mdx
+++ b/docs/vendor/enterprise-portal-v2-troubleshooting.mdx
@@ -1,6 +1,6 @@
 # Troubleshoot the Enterprise Portal
 
-:::important Alpha Feature
+:::note Alpha Feature
 Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
 :::
 

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -1,6 +1,6 @@
 # Log in to and Use the Enterprise Portal
 
-:::important Alpha Feature
+:::note Alpha Feature
 Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
 :::
 

--- a/docs/vendor/enterprise-portal-v2-vendor-api-automation.mdx
+++ b/docs/vendor/enterprise-portal-v2-vendor-api-automation.mdx
@@ -4,7 +4,7 @@ sidebar_label: Enterprise Portal Headless Automation
 
 # Enterprise Portal Headless Automation
 
-:::important Alpha Feature
+:::note Alpha Feature
 Features described on this page are in alpha and subject to change. Some capabilities might require additional access.
 :::
 

--- a/docs/vendor/enterprise-portal-v2-versioned-docs.mdx
+++ b/docs/vendor/enterprise-portal-v2-versioned-docs.mdx
@@ -1,6 +1,6 @@
 # Manage Content Versions
 
-:::important Alpha Feature
+:::note Alpha Feature
 Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
 :::
 


### PR DESCRIPTION
## What

Converts the "Alpha Feature" callouts across the Enterprise Portal v2 docs from `:::important` (red) to `:::note` (blue).

## Why

The alpha callouts throughout the EP v2 content currently render in red, which reads as a warning. They're informational, and should match the blue note styling used elsewhere for the same purpose (for example, the [Security Center](https://docs.replicated.com/vendor/security-center-view-vendor-portal) alpha note).

## Scope

16 files under `docs/vendor/enterprise-portal-v2-*.mdx`. Only the admonition type changed (`:::important` → `:::note`); the callout text is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)