### PR TITLE
docs: clarify EPv2 internal link resolution and recommend leading-slash paths

### DIFF
--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -305,15 +305,15 @@ Props: `command`, `label`, `encoded`.
 
 **`<ContentLink>`**: Internal navigation links. Standard markdown links (`[text](path)`) are automatically converted to use client-side navigation, so you don't need to use this component directly.
 
-Link paths are resolved relative to the current page's URL, and the portal automatically injects the customer's selected version into the resolved route. Because resolution is relative, a bare `section/page` path only resolves correctly from a top-level page. From a page inside a subdirectory, the same path resolves against that subdirectory. For example, `[Configure values](installation/values)` authored on the `installation/helm` page resolves to `installation/installation/values`, which does not exist.
+Link paths resolve relative to the current page's URL, and the portal injects the customer's selected version into the resolved route. Because resolution is relative, a bare `section/page` path resolves correctly only from a top-level page. From a page inside a subdirectory, the same path resolves against that subdirectory. For example, `[Configure values](installation/values)` authored on the `installation/helm` page resolves to `installation/installation/values`, which does not exist.
 
-To link reliably from any page regardless of its depth, use a leading-slash absolute path. Absolute paths resolve from the content root, and the selected version is still injected:
+To link reliably from any page, use a leading-slash absolute path. Absolute paths resolve from the content root, and the portal still injects the selected version:
 
 ```markdown
 See [Configure values](/installation/values).
 ```
 
-From any page, this resolves to `/<version>/installation/values`.
+From any page, this path resolves to `/<version>/installation/values`.
 
 ### Installation components
 

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -267,12 +267,12 @@ Props: `title` (required), `defaultOpen` (optional, defaults to false).
 ```markdown
 <OptionSelector label="Install Method" defaultOption="Linux" storageKey="install-method">
 <Option value="Linux">
-- [Linux Installation](installation/linux)
-- [Linux Support Bundles](operations/bundles/linux)
+- [Linux Installation](/installation/linux)
+- [Linux Support Bundles](/operations/bundles/linux)
 </Option>
 <Option value="Helm">
-- [Helm Installation](installation/helm)
-- [Helm Support Bundles](operations/bundles/helm)
+- [Helm Installation](/installation/helm)
+- [Helm Support Bundles](/operations/bundles/helm)
 </Option>
 </OptionSelector>
 ```
@@ -304,6 +304,16 @@ kubectl get pods -A
 Props: `command`, `label`, `encoded`.
 
 **`<ContentLink>`**: Internal navigation links. Standard markdown links (`[text](path)`) are automatically converted to use client-side navigation, so you don't need to use this component directly.
+
+Link paths are resolved relative to the current page's URL, and the portal automatically injects the customer's selected version into the resolved route. Because resolution is relative, a bare `section/page` path only resolves correctly from a top-level page. From a page inside a subdirectory, the same path resolves against that subdirectory. For example, `[Configure values](installation/values)` authored on the `installation/helm` page resolves to `installation/installation/values`, which does not exist.
+
+To link reliably from any page regardless of its depth, use a leading-slash absolute path. Absolute paths resolve from the content root, and the selected version is still injected:
+
+```markdown
+See [Configure values](/installation/values).
+```
+
+From any page, this resolves to `/<version>/installation/values`.
 
 ### Installation components
 


### PR DESCRIPTION
## Summary

Enterprise Portal v2 content resolves internal markdown links **relative to the current page's URL** (browser-relative), and the portal injects the customer's selected version into the resolved route. Neither behavior is documented today, and the only link examples on this page use bare `section/page` paths.

That combination trips people up: a bare `section/page` link only resolves correctly from a top-level page. Authored on a page inside a subdirectory it resolves against that subdirectory and 404s. For example, `[Configure values](installation/values)` on the `installation/helm` page resolves to `installation/installation/values`. (We hit this building out a vendor's portal, and it's also bitten AI agents authoring content.)

## Changes

- Document that internal link paths resolve relative to the current page and that the selected version is injected into the resolved route.
- Recommend leading-slash absolute paths (`/section/page`) for links that resolve the same from any page depth, with an example.
- Update the `<OptionSelector>` example to use leading-slash links so the docs model the recommended form.

## Notes

Alpha feature; docs-only change. Confirmed against live portal behavior: a leading-slash link keeps the selected version in the route (`/installation/values` -> `/<version>/installation/values`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)