### PR TITLE
docs(enterprise-portal): document namespace prop for HelmInstallAssets

### DIFF
--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -357,7 +357,7 @@ When a customer selects limited or no registry access, `<HelmInstallAssets />` a
 
 **`<LinuxAirgapInstallAssets />`**: Linux air gap installation commands. Shows an unavailable notice if the air gap bundle is not yet built. Props: `stepNumber`.
 
-**`<HelmAirgapInstallAssets />`**: Helm air gap installation commands. Props: `stepNumber`, `registryAvailability`, `charts` (optional), `exclude` (optional).
+**`<HelmAirgapInstallAssets />`**: Helm air gap installation commands. Props: `stepNumber`, `registryAvailability`, `charts` (optional), `exclude` (optional), `namespace` (optional, string; when set, the generated install command includes `--namespace <namespace>` so the app installs into that namespace. When omitted, the install uses the default namespace).
 
 When a customer selects limited or no registry access, `<HelmAirgapInstallAssets />` automatically includes browser download links for Helm chart tarballs. These links are also shown in the update flow for customers in the same registry mode.
 
@@ -397,7 +397,7 @@ The `charts` and `exclude` props accept comma-separated chart names. Use `charts
 
 #### Installing into a specific namespace
 
-By default, `<HelmInstallAssets />` generates an install command that uses the default namespace. If your application always installs into a fixed namespace, set the `namespace` prop to add `--namespace <namespace>` to the generated command:
+By default, the Helm instruction components generate commands that use the default namespace. If your application always installs into a fixed namespace, set the `namespace` prop on `<HelmInstallAssets />`, `<HelmAirgapInstallAssets />`, or `<HelmUpdateAssets />` to add `--namespace <namespace>` to the generated install and upgrade commands:
 
 ```markdown
 <HelmInstallAssets namespace="my-namespace" />
@@ -465,7 +465,7 @@ The download components gate themselves on the same entitlements, so a customer 
 
 **`<LinuxUpdateAssets />`**: Renders Linux/Embedded Cluster upgrade instructions for the customer's current instance. For air gap upgrades, includes a registry hostname input for image relocation when the customer uses a private registry. Props: `stepNumber`.
 
-**`<HelmUpdateAssets />`**: Renders Helm upgrade instructions. Props: `stepNumber`, `charts` (optional), `exclude` (optional).
+**`<HelmUpdateAssets />`**: Renders Helm upgrade instructions. Props: `stepNumber`, `charts` (optional), `exclude` (optional), `namespace` (optional, string; when set, the generated upgrade command includes `--namespace <namespace>` so the upgrade targets that namespace. When omitted, the upgrade uses the default namespace).
 
 **`<UpgradePath>`**: Conditionally shows content based on the customer's current version. Lets you show different upgrade instructions depending on which version the customer is upgrading *from*.
 

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -397,21 +397,23 @@ The `charts` and `exclude` props accept comma-separated chart names. Use `charts
 
 #### Installing into a specific namespace
 
-By default, the Helm instruction components generate commands that use the default namespace. If your application always installs into a fixed namespace, set the `namespace` prop on `<HelmInstallAssets />`, `<HelmAirgapInstallAssets />`, or `<HelmUpdateAssets />` to add `--namespace <namespace>` to the generated install and upgrade commands:
+By default, the Helm instruction components generate commands that install into the default namespace. To install into a specific namespace, set the `namespace` prop on `<HelmInstallAssets />` or `<HelmAirgapInstallAssets />`:
 
 ```markdown
 <HelmInstallAssets namespace="my-namespace" />
 ```
 
-To set a default namespace while letting individual customers override it, reference a custom license field with a fallback:
+The generated install command adds `--namespace my-namespace --create-namespace`, so the namespace is created if it does not already exist. You do not set a namespace on `<HelmUpdateAssets />`. Upgrades automatically target the namespace the customer installed into.
+
+To let each customer's namespace come from their license, reference a custom license field with a template expression:
 
 ```markdown
-<HelmInstallAssets namespace={entitlements.helm_namespace || "my-namespace"} />
+<HelmInstallAssets namespace="{{entitlements.helm_namespace}}" />
 ```
 
-This installs into `my-namespace` for most customers, but a customer whose license defines a `helm_namespace` custom field installs into that namespace instead. For more on custom license fields, see [Entitlements](#entitlements).
+A customer whose license defines a `helm_namespace` custom field installs into that namespace. A customer without it installs into the default namespace. For more on custom license fields, see [Entitlements](#entitlements).
 
-The generated commands do not include `--create-namespace`, so the target namespace must already exist in the customer's cluster before they run the install command.
+Namespace values are validated as DNS-1123 labels, so an invalid value surfaces an error in the portal preview instead of silently installing into the default namespace.
 
 **`<InstallStep>`**: Wraps content in a numbered step container.
 

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -351,13 +351,13 @@ Props: `installType` (`"linux"` or `"helm"`).
 
 **`<LinuxInstallAssets />`**: Renders the full Linux/Embedded Cluster installation command sequence. Adapts to the customer's selected version and network availability. For air gap installations, includes an optional toggle for private registry image relocation. When enabled, the customer enters their registry hostname and the commands update to include image pull, tag, and push steps targeting that registry. Props: `stepNumber` (optional, starting step number).
 
-**`<HelmInstallAssets />`**: Renders the full Helm installation command sequence. Props: `stepNumber` (optional), `charts` (optional, comma-separated list of chart names to include), `exclude` (optional, comma-separated list of chart names to hide), `namespace` (optional, string; when set, the generated install command includes `--namespace <namespace>` so the app installs into that namespace. When omitted, the install uses the default namespace).
+**`<HelmInstallAssets />`**: Renders the full Helm installation command sequence. Props: `stepNumber` (optional), `charts` (optional, comma-separated list of chart names to include), `exclude` (optional, comma-separated list of chart names to hide), `namespace` (optional, adds `--namespace <namespace>` to the generated install commands).
 
 When a customer selects limited or no registry access, `<HelmInstallAssets />` automatically includes browser download links for the Helm chart tarballs needed for their install. A download link for the preflight plugin binary is always included, regardless of registry access settings. No additional configuration is required.
 
 **`<LinuxAirgapInstallAssets />`**: Linux air gap installation commands. Shows an unavailable notice if the air gap bundle is not yet built. Props: `stepNumber`.
 
-**`<HelmAirgapInstallAssets />`**: Helm air gap installation commands. Props: `stepNumber`, `registryAvailability`, `charts` (optional), `exclude` (optional), `namespace` (optional, string; when set, the generated install command includes `--namespace <namespace>` so the app installs into that namespace. When omitted, the install uses the default namespace).
+**`<HelmAirgapInstallAssets />`**: Helm air gap installation commands. Props: `stepNumber`, `registryAvailability`, `charts` (optional), `exclude` (optional), `namespace` (optional, adds `--namespace <namespace>` to the generated install commands).
 
 When a customer selects limited or no registry access, `<HelmAirgapInstallAssets />` automatically includes browser download links for Helm chart tarballs. These links are also shown in the update flow for customers in the same registry mode.
 
@@ -410,6 +410,8 @@ To set a default namespace while letting individual customers override it, refer
 ```
 
 This installs into `my-namespace` for most customers, but a customer whose license defines a `helm_namespace` custom field installs into that namespace instead. For more on custom license fields, see [Entitlements](#entitlements).
+
+The generated commands do not include `--create-namespace`, so the target namespace must already exist in the customer's cluster before they run the install command.
 
 **`<InstallStep>`**: Wraps content in a numbered step container.
 
@@ -465,7 +467,7 @@ The download components gate themselves on the same entitlements, so a customer 
 
 **`<LinuxUpdateAssets />`**: Renders Linux/Embedded Cluster upgrade instructions for the customer's current instance. For air gap upgrades, includes a registry hostname input for image relocation when the customer uses a private registry. Props: `stepNumber`.
 
-**`<HelmUpdateAssets />`**: Renders Helm upgrade instructions. Props: `stepNumber`, `charts` (optional), `exclude` (optional), `namespace` (optional, string; when set, the generated upgrade command includes `--namespace <namespace>` so the upgrade targets that namespace. When omitted, the upgrade uses the default namespace).
+**`<HelmUpdateAssets />`**: Renders Helm upgrade instructions. Props: `stepNumber`, `charts` (optional), `exclude` (optional), `namespace` (optional, adds `--namespace <namespace>` to the generated upgrade commands).
 
 **`<UpgradePath>`**: Conditionally shows content based on the customer's current version. Lets you show different upgrade instructions depending on which version the customer is upgrading *from*.
 

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -400,16 +400,16 @@ The `charts` and `exclude` props accept comma-separated chart names. Use `charts
 By default, `<HelmInstallAssets />` generates an install command that uses the default namespace. If your application always installs into a fixed namespace, set the `namespace` prop to add `--namespace <namespace>` to the generated command:
 
 ```markdown
-<HelmInstallAssets namespace="salt-os" />
+<HelmInstallAssets namespace="my-namespace" />
 ```
 
 To set a default namespace while letting individual customers override it, reference a custom license field with a fallback:
 
 ```markdown
-<HelmInstallAssets namespace={entitlements.helm_namespace || "salt-os"} />
+<HelmInstallAssets namespace={entitlements.helm_namespace || "my-namespace"} />
 ```
 
-This installs into `salt-os` for most customers, but a customer whose license defines a `helm_namespace` custom field installs into that namespace instead. For more on custom license fields, see [Entitlements](#entitlements).
+This installs into `my-namespace` for most customers, but a customer whose license defines a `helm_namespace` custom field installs into that namespace instead. For more on custom license fields, see [Entitlements](#entitlements).
 
 **`<InstallStep>`**: Wraps content in a numbered step container.
 

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -351,7 +351,7 @@ Props: `installType` (`"linux"` or `"helm"`).
 
 **`<LinuxInstallAssets />`**: Renders the full Linux/Embedded Cluster installation command sequence. Adapts to the customer's selected version and network availability. For air gap installations, includes an optional toggle for private registry image relocation. When enabled, the customer enters their registry hostname and the commands update to include image pull, tag, and push steps targeting that registry. Props: `stepNumber` (optional, starting step number).
 
-**`<HelmInstallAssets />`**: Renders the full Helm installation command sequence. Props: `stepNumber` (optional), `charts` (optional, comma-separated list of chart names to include), `exclude` (optional, comma-separated list of chart names to hide).
+**`<HelmInstallAssets />`**: Renders the full Helm installation command sequence. Props: `stepNumber` (optional), `charts` (optional, comma-separated list of chart names to include), `exclude` (optional, comma-separated list of chart names to hide), `namespace` (optional, string; when set, the generated install command includes `--namespace <namespace>` so the app installs into that namespace. When omitted, the install uses the default namespace).
 
 When a customer selects limited or no registry access, `<HelmInstallAssets />` automatically includes browser download links for the Helm chart tarballs needed for their install. A download link for the preflight plugin binary is always included, regardless of registry access settings. No additional configuration is required.
 
@@ -394,6 +394,22 @@ For applications with multiple Helm charts, you can control which charts appear 
 ```
 
 The `charts` and `exclude` props accept comma-separated chart names. Use `charts` to include only the listed charts, or `exclude` to show all charts except the listed ones.
+
+#### Installing into a specific namespace
+
+By default, `<HelmInstallAssets />` generates an install command that uses the default namespace. If your application always installs into a fixed namespace, set the `namespace` prop to add `--namespace <namespace>` to the generated command:
+
+```markdown
+<HelmInstallAssets namespace="salt-os" />
+```
+
+To set a default namespace while letting individual customers override it, reference a custom license field with a fallback:
+
+```markdown
+<HelmInstallAssets namespace={entitlements.helm_namespace || "salt-os"} />
+```
+
+This installs into `salt-os` for most customers, but a customer whose license defines a `helm_namespace` custom field installs into that namespace instead. For more on custom license fields, see [Entitlements](#entitlements).
 
 **`<InstallStep>`**: Wraps content in a numbered step container.
 


### PR DESCRIPTION
## What

Documents a new optional `namespace` prop on the `<HelmInstallAssets />` component in the Enterprise Portal v2 content reference (`docs/vendor/enterprise-portal-v2-content.mdx`).

When set, the generated Helm install command includes `--namespace <namespace>`, so the app installs into that namespace. When omitted, the install uses the default namespace, so existing content is unchanged.

## Why

Some customers always install into a fixed namespace. Today the generated command uses the default namespace, so those customers have to hand-edit the copied command every time. The `namespace` prop lets vendors bake the right namespace straight into the install page and remove that friction.

## Examples added

The common case, a single fixed namespace for everyone:

```markdown
<HelmInstallAssets namespace="my-namespace" />
```

And an extensible version that defaults to `my-namespace` but lets a `helm_namespace` custom license field override it per customer:

```markdown
<HelmInstallAssets namespace={entitlements.helm_namespace || "my-namespace"} />
```

## Notes

This pairs with the vandoor code PR that adds the `namespace` prop to `<HelmInstallAssets />`. The docs shouldn't land ahead of that, so I'm leaving this as a draft until the code side is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

