### PR TITLE
Document registry egress attribution views

### DIFF
--- a/docs/vendor/packaging-private-images.md
+++ b/docs/vendor/packaging-private-images.md
@@ -367,7 +367,9 @@ You can also use the Replicated Vendor API `/v3/external_registry/logs` endpoint
 
 ## View registry egress
 
-The **Image Registries** page displays a **Registry egress this month** summary at the top, showing the total volume of image data downloaded through Replicated during the current calendar month (in UTC). This is the outbound data transfer generated when your customers, or your own systems, pull images through the Replicated proxy registry or the Replicated registry.
+The **Image Registries** page displays a **Registry egress this month** summary at the top. It shows the volume of image data downloaded through Replicated during the current calendar month in Coordinated Universal Time (UTC).
+
+This egress includes image pulls by your customers and your systems through the Replicated proxy registry or the Replicated registry.
 
 The summary breaks the total down as follows:
 
@@ -393,6 +395,18 @@ The summary breaks the total down as follows:
     <td>The portion of the team total attributable to the application you are currently viewing.</td>
   </tr>
 </table>
+
+### View egress by customer and image
+
+The **Customer egress** section shows which customers account for the current application's egress during the month. The table shows each customer's egress and percentage of the application total. It also identifies archived customers and groups traffic without a customer ID as **Unattributed**.
+
+You can sort the table by egress volume or customer name. Each expandable customer row contains egress totals for its images, including the registry host, image name, and image reference.
+
+You must have permission to view all customers for the application to see customer-level egress. If your role cannot view one or more customers, the section does not display customer-level egress.
+
+### View daily egress
+
+The **Daily egress** section charts the current application's egress for each UTC day in the month.
 
 :::note
 To get alerted when your monthly registry egress reaches a configured volume, use the **Egress Threshold Reached** notification event. For more information, see [Event types and filters](/reference/notifications-events-filters#egress-threshold-reached).

--- a/docs/vendor/team-management-rbac-resource-names.md
+++ b/docs/vendor/team-management-rbac-resource-names.md
@@ -28,7 +28,8 @@ Grants the holder permission to delete an application.
 Grants the holder permission to modify application settings, such as renaming the application, toggling trial signup, configuring security center settings, and managing support bundle upload visibility.
 
 ### kots/externalregistry/list
-Grants the holder the ability to list external docker registry for applications.
+
+Grants the holder permission to list external Docker registries for applications and view registry egress totals. Customer-level egress also requires permission to view every customer for the application.
 
 ### kots/externalregistry/create
 
@@ -136,7 +137,7 @@ Grants the holder permission to create a new license in the specified applicatio
 
 ### kots/app/[:appid]/license/[:customerid]/read
 
-Grants the holder permission to view the license specified by ID. If you deny this permission, the licenses do not appear in search, CSV export, or the Vendor Portal.
+Grants the holder permission to view the license specified by ID. If you deny this permission, the licenses do not appear in search, CSV export, or the Vendor Portal. Customer-level registry egress requires this permission for every customer with attributed egress.
 
 ### kots/app/[:appid]/license/[:customerid]/update
 


### PR DESCRIPTION
## Summary

- document customer-level registry egress and per-image drill-downs
- document the daily egress chart
- clarify the custom RBAC permissions required for registry totals and customer attribution

## Testing

- `npm run build` (passes; reports existing broken-link and broken-anchor warnings unrelated to this change)
- `git diff --check`

## Related product change

- replicatedhq/vandoor#10323