### PR TITLE
[deps] Bump serialize-javascript to 7.0.5 to fix CVEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ When you submit a PR in GitHub, Netlify builds a preview automatically. However,
 
 ### Prerequisites
 
-- Node.js version 18 or higher
+- Node.js version 20 or higher
 - npm (comes bundled with Node.js)
 
 ### Start the local dev server with `npm start`

--- a/package-lock.json
+++ b/package-lock.json
@@ -18354,15 +18354,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -19346,12 +19337,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
+      "integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "shell-quote": "^1.7.3",
     "got": "^11.8.5",
     "lodash.template": "^4.5.0",
-    "serialize-javascript": "^6.0.2",
+    "serialize-javascript": "^7.0.5",
     "tough-cookie": "^4.1.3",
     "trim-newlines": "^3.0.1",
     "http-cache-semantics": "^4.1.1",
@@ -58,7 +58,8 @@
   },
   "overrides": {
     "webpack-dev-server": "^5.2.6",
-    "qs": "^6.14.1"
+    "qs": "^6.14.1",
+    "serialize-javascript": "^7.0.5"
   },
   "browserslist": {
     "production": [
@@ -73,6 +74,6 @@
     ]
   },
   "engines": {
-    "node": ">=18.0"
+    "node": ">=20.0"
   }
 }


### PR DESCRIPTION
Bumps the transitive dependency `serialize-javascript` from 6.0.2 to 7.0.5+ to address:

- GHSA-5c6j-r48x-rmvq (RCE via RegExp.flags / Date.prototype.toISOString, high severity, affects `<= 7.0.2`)
- GHSA-qj8w-gfj5-8c6v (CPU exhaustion DoS via crafted array-like objects, moderate severity, affects `>= 5.0.0 < 7.0.5`)

Changes:
- Added `serialize-javascript: ^7.0.5` to npm `overrides`.
- Updated the existing Yarn `resolutions` entry to `^7.0.5`.
- Updated `engines.node` to `>=20.0` and the README prerequisite, since `serialize-javascript@7.0.0` requires Node.js 20+.

Verification:
- `npm ls serialize-javascript` now shows 7.1.0.
- `npm audit` no longer reports `serialize-javascript` vulnerabilities.
- `npm run build` completes successfully.