### PR TITLE
fix(docs): reword the EC v2 unmaintained banner

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -1,0 +1,10 @@
+{
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "This documentation is for Replicated {versionLabel}.",
+    "description": "The label used to tell the user that they're browsing an unmaintained version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "We recommend using {latestVersionLink} instead, which is the newest product version.",
+    "description": "The label used to tell the user to check the latest version"
+  }
+}


### PR DESCRIPTION
## Why

The banner at the top of every Embedded Cluster **v2** doc reads:

> This documentation for Replicated Embedded Cluster v2 is no longer actively maintained. For up-to-date documentation, see the latest version (Embedded Cluster v3).

A customer read that as "v2 is discontinued" and got spooked about shipping on it — which is the opposite of reality. As Marc confirmed: EC v2 **is** actively maintained (no retirement date planned); we're just not adding new features to it. The "no longer actively maintained" wording is inaccurate and should go.

That text is Docusaurus's built-in `banner: 'unmaintained'` string (set for the `2.0.0` version of the `embedded-cluster` docs plugin in `docusaurus.config.js`). EC v2 is the only version using that banner.

## What

Override the two Docusaurus banner strings via `i18n/en/code.json` (the standard way to retext theme labels for the default locale — no component swizzle needed):

- `theme.docs.versions.unmaintainedVersionLabel` → **"This documentation is for Replicated {versionLabel}."**
- `theme.docs.versions.latestVersionSuggestionLabel` → **"We recommend using {latestVersionLink} instead, which is the newest product version."**

On the EC v2 docs this renders as:

> This documentation is for Replicated **Embedded Cluster v2**. We recommend using [Embedded Cluster v3](/embedded-cluster/v3) instead, which is the newest product version.

This is Amber's suggested wording. It keeps the helpful nudge toward v3 while dropping the false "not maintained" claim.

## Notes

- The override is global to any `unmaintained` version, but EC v2 is currently the only one, and the wording uses placeholders (`{versionLabel}`, `{latestVersionLink}`) so it stays correct if that ever changes.
- Worth eyeballing the Netlify preview on the EC v2 banner to confirm the rendered text.

Context: kryptoslogic-replicated Slack thread (customer confusion → Marc: "the message that ec2 is not actively maintained is right [is wrong] ... we should remove that" → Amber's wording).