### PR TITLE
docs: note air gap Helm image relocation limitation (digests + multi-arch)

### DIFF
--- a/docs/vendor/enterprise-portal-about.mdx
+++ b/docs/vendor/enterprise-portal-about.mdx
@@ -47,6 +47,8 @@ For information about using the Enterprise Portal, see [Access and Use the Enter
 
 * There is a known issue when using a custom domain for the Enterprise Portal if any of your customers use link transformers such as Microsoft Defender Safe Links. For more information, see [Known Issue](custom-domains#known-issue) in _About Custom Domains_. 
 
+* Air gap Helm installations relocate images to the customer's private registry using `docker tag` and `docker push`, which does not preserve image digests or multi-architecture image manifests. If your application references images by digest (`@sha256:...`) or ships multi-architecture images, the relocated images might not match what your chart expects, which can cause image pull failures.
+
 ## Comparison to the Download Portal
 
 The Enterprise Portal is the next generation version of the Replicated Download Portal. Compared to the Download Portal, the Enterprise Portal not only provides access to installation assets and instructions, but also allows users to track available updates, manage their team and service accounts, view the status of their instances, view license details, and more. These features are designed to make it easier for your customers to manage their instances of your application from a centralized location outside of the installation environment.

--- a/docs/vendor/enterprise-portal-v2-about.mdx
+++ b/docs/vendor/enterprise-portal-v2-about.mdx
@@ -51,6 +51,7 @@ Customers moving from the Download Portal gain the same content and automation c
 - Air gap instance records do not appear until the customer creates one from the Instances & Updates page, either by manually entering instance information or by extracting details from an uploaded support bundle. Availability depends on the customer's license having the corresponding install type and air gap option enabled.
 - Security Center data (CVE reports and SBOMs) is available for Helm and Embedded Cluster installations only. Customers whose only instances are KOTS or kURL see an explanatory message instead of security data. Customers with a mix of instance types see Security Center data for their Helm and Embedded Cluster instances.
 - If you have many version branches and need to make a change across all versions, you must update each branch individually.
+- Air gap Helm installations relocate images to the customer's private registry using `docker tag` and `docker push`, which does not preserve image digests or multi-architecture image manifests. If your application references images by digest (`@sha256:...`) or ships multi-architecture images, the relocated images might not match what your chart expects, which can cause image pull failures.
 
 ## Requirements
 


### PR DESCRIPTION
## What

Adds a limitations bullet to both the EP v1 (`enterprise-portal-about.mdx`) and EP v2 (`enterprise-portal-v2-about.mdx`) About pages, documenting a pre-existing constraint:

> Air gap Helm installations relocate images to the customer's private registry using `docker tag` and `docker push`, which does not preserve image digests or multi-architecture image manifests. If your application references images by digest (`@sha256:...`) or ships multi-architecture images, the relocated images might not match what your chart expects, which can cause image pull failures.

## Why

This is long-standing behavior (the `docker tag`/`docker push` relocation dates to EP v1, Feb 2025) shared across EP v1, EP v2, and the Download Portal. It is not a regression. Documenting it as a known limitation sets vendor expectations while a fix is evaluated on the path to GA. Constraint-only by intent — no workaround or fix timeline stated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)