### PR TITLE
docs(ep-v2): document KOTS and kURL support bundles and license download gating

### DIFF
--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -514,9 +514,15 @@ In this example, a customer on version 1.5.0 would see the "Upgrading from 1.x" 
 
 **`<HelmBundles />`**: Helm-specific support bundle generation instructions. A download link for the support-bundle plugin binary is always included, regardless of registry access settings. No props.
 
+**`<KurlBundles />`**: kURL-specific support bundle generation instructions. No props.
+
+**`<KotsBundles />`**: KOTS-specific support bundle generation instructions for an existing cluster. No props.
+
+Each of the four support bundle components renders the steps for one installation method and nothing else: no heading and no tab strip of its own. The page is what decides which methods a customer sees. The default template's Support Bundles page wraps all four in a single [`<Tabs>`](#layout-and-callouts) block, with each tab guarded by the [entitlement](#entitlements) for that installation method.
+
 **`<ContactInfo />`**: Displays the support contact information configured in `theme.yaml`. No props.
 
-**`<LicenseDownload />`**: Renders a button that lets customers download their license file. No props.
+**`<LicenseDownload />`**: Renders a button that lets customers download their license file. The button appears only for customers whose license enables Embedded Cluster, KOTS, or kURL installations, which are the installation methods that use a license file. Helm customers do not see it. No props.
 
 **`<InstancesAndUpdates />`**: Renders the full instances and updates management page inline. Helm and Embedded Cluster instances expand into inline upgrade instructions, while KOTS and kURL instances expand into a panel for downloading versioned install and update artifacts. No props.
 

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -129,7 +129,7 @@ Revoking or rotating a token affects every system that authenticates with it. Wh
 
 Customers can generate and upload support bundles from the portal:
 
-- **Generate bundles**: Follow the instructions on the Support Bundles page to generate a diagnostic bundle from their Linux or Helm installation
+- **Generate bundles**: Follow the instructions on the Support Bundles page to generate a diagnostic bundle. The page provides instructions for Embedded Cluster, kURL, Helm, and KOTS installations, and each customer sees only the methods that their license enables
 - **Upload bundles**: Upload an existing bundle file for vendor analysis. The maximum upload size is 2 GB. For larger bundles, use the [Replicated SDK API](/reference/replicated-sdk-apis#post-supportbundle) upload endpoint, which has no size restriction.
 - **View history**: See previously uploaded bundles and their status
 
@@ -149,4 +149,6 @@ Security Center data is available for Helm and Embedded Cluster installations on
 
 ## License information
 
-Customers can view their license details including expiration date, license type, assigned channel, and any custom license fields configured by the vendor. This information is accessible from the portal but is read-only for customers.
+Customers can view their license details including expiration date, license type, assigned channel, and any custom license fields configured by the vendor. Customers cannot edit their license from the portal.
+
+Customers whose license enables Embedded Cluster, KOTS, or kURL installations can also download their `license.yaml` file, which those installation methods require. Helm installations do not use a license file, so Helm customers do not see a download option.


### PR DESCRIPTION
Part 2 of 3 for sc-139273. Two features shipped without documentation.

## Why

- KOTS and kURL support bundle collection shipped in replicatedhq/vandoor#10351 (sc-139149), merged 2026-08-13. `KotsBundles.tsx` and `KurlBundles.tsx` exist; the component reference listed only `<LinuxBundles />` and `<HelmBundles />`.
- The kURL license download shipped in replicatedhq/vandoor#10292 (sc-139148). `<LicenseDownload />` was documented as "Renders a button that lets customers download their license file. No props." — with no mention that the button is install-type gated, which is the part vendors ask about.

## Changes

`enterprise-portal-v2-content.mdx`
- Add `<KurlBundles />` and `<KotsBundles />` to the portal component reference
- Note that all four bundle components are headerless by design, so the host page owns the tab strip, and link to the existing `<Tabs>` and entitlement sections on the same page
- Note which install types see `<LicenseDownload />`, and that Helm does not

`enterprise-portal-v2-use.mdx`
- Support bundles: "their Linux or Helm installation" becomes all four installation methods, noting each customer sees only the methods their license enables
- License information: add the `license.yaml` download and the Helm exclusion

## On the Helm exclusion

Helm's absence is intended, not an oversight, so both pages say Helm installations do not use a license file. Neither goes further than that. The underlying mechanism — a Helm install authenticates to the registry with the license ID as a password, and the client gate in `license-download-logic.ts` mirrors the server gate in `handlers/market-api/replicatedapp/customer_license.go` — is recorded here for reviewers and deliberately kept out of the docs. If vendors do start asking why, a troubleshooting entry is the right home for it, not the component reference.

## Out of scope

**No air gap install instructions.** That limitation still holds and was moved to the GA track on 2026-08-18 (sc-136929, sc-137124). Nothing here describes it as working.

**No `enterprise-portal-content` PR needed.** That side already shipped: `pages/support/bundles.md` composes all four tabs with entitlement guards, `<LicenseDownload />` is live on the KOTS and kURL install pages, and `updates/2026-08-14-kots-kurl-support-bundles.md` is a published template-update guide. This PR documents the vendor-facing reference for content that already exists.

## Revision notes

Two things were cut from earlier revisions of this PR, both for the same reason — right fact, wrong altitude for a reference page:

1. A verbatim copy of the default template's 24-line entitlement-guarded `<Tabs>` block. `<Tabs>`/`<Tab>` and `{{#if entitlements.*}}` each already have an example on this page, forking vendors already hold the file, and copied tab titles and ordering were the one thing here that would drift silently.
2. A two-sentence explanation of Helm registry authentication on each of the two pages. Reduced to the gating fact on both.