### PR TITLE
docs(ep-v2): add Portal Features page documenting Ask AI

### DIFF
--- a/docs/vendor/enterprise-portal-v2-portal-features.mdx
+++ b/docs/vendor/enterprise-portal-v2-portal-features.mdx
@@ -12,9 +12,9 @@ The section contains the following settings:
 
 | Setting | Default | Description |
 |---|---|---|
-| **Enable Ask AI** | Disabled | Adds an AI assistant to the portal that answers customer questions from your portal content. See [Ask AI](#ask-ai) below. |
-| **Display only fixable CVEs in Security Center report** | Enabled | Limits the CVE report to vulnerabilities with an available fix. Disable it to let customers switch between all CVEs and fixable CVEs. See [Security Center display settings](#security-center-display-settings) below. |
-| **Enable raw CVE scan to be downloadable** | Disabled | Lets customers download the raw Grype scan JSON for a release. See [Security Center display settings](#security-center-display-settings) below. |
+| **Enable Ask AI** | Disabled | Adds an AI assistant to the portal that answers customer questions from your portal content. See [Ask AI](#ask-ai). |
+| **Display only fixable CVEs in Security Center report** | Enabled | Limits the CVE report to vulnerabilities with an available fix. Disable it to let customers switch between all CVEs and fixable CVEs. See [Security Center display settings](#security-center-display-settings). |
+| **Enable raw CVE scan to be downloadable** | Disabled | Lets customers download the raw Grype scan JSON for a release. See [Security Center display settings](#security-center-display-settings). |
 
 The two Security Center settings appear only when Security Center is enabled for your team. If **Portal Features** shows only **Enable Ask AI**, contact your Replicated account representative about Security Center.
 
@@ -22,9 +22,9 @@ Access to the settings also depends on your Vendor Portal permissions. The Secur
 
 ## Ask AI {#ask-ai}
 
-When you enable **Enable Ask AI**, the portal adds an **Ask AI** button to the header of every content page. The button opens an assistant panel on the right side of the page, where the customer can ask questions and receive streamed answers. The setting is disabled by default, and it applies to all of your customers at once.
+When you turn on **Enable Ask AI**, the portal adds an **Ask AI** button to the header of every content page. The button opens an assistant panel on the right side of the page, where the customer can ask questions and receive streamed answers. The setting is disabled by default, and it applies to all of your customers.
 
-The assistant is delivered in the page header only. It is not a navigation item, and there is currently no supported way to move it, rename it, or hide it from a subset of customers. The **Enable Ask AI** setting is the only control over whether customers see it.
+The assistant is delivered in the page header only. It is not a navigation item, and there is no supported way to move it, rename it, or hide it from a subset of customers. The **Enable Ask AI** setting is the only control over whether customers see it.
 
 ### What the assistant answers from
 

--- a/docs/vendor/enterprise-portal-v2-portal-features.mdx
+++ b/docs/vendor/enterprise-portal-v2-portal-features.mdx
@@ -4,7 +4,7 @@ This topic describes the app-level Enterprise Portal settings in the **Portal Fe
 
 ## About Portal Features
 
-**Portal Features** is a set of app-level settings that control optional capabilities in the Enterprise Portal. The settings apply to every customer of the application. They are separate from the per-customer settings on a customer's **Enterprise Portal access** tab, which control whether an individual customer has portal access at all.
+**Portal Features** is a set of app-level settings that control optional capabilities in the Enterprise Portal. The settings apply to every customer of the application. They are separate from the per-customer settings on a customer's **Enterprise Portal access** tab. Those control whether an individual customer has portal access at all.
 
 To open the settings, go to **Enterprise Portal > Content** in the Vendor Portal and find the **Portal Features** section. Changes are saved automatically.
 
@@ -32,17 +32,21 @@ Because the two groups use separate permissions, a team member can have access t
 
 When you turn on **Enable Ask AI**, the portal adds an **Ask AI** button to the header of every content page. The button opens an assistant panel on the right side of the page, where the customer can ask questions and receive streamed answers. The setting is disabled by default, and it applies to all of your customers.
 
-The assistant is delivered in the page header only. It is not a navigation item, and there is no supported way to move it, rename it, or hide it from a subset of customers. The **Enable Ask AI** setting is the only control over whether customers see it.
+The assistant appears only in the page header. It is not a navigation item, and there is no supported way to move it, rename it, or hide it from some customers. **Enable Ask AI** is the only control over whether customers see it.
 
 ### What the assistant answers from
 
-Each question is answered from the portal content the asking customer can see, for the version they are viewing, so two customers on different licenses can receive different answers to the same question. Content is excluded based on the `visible_when` conditions on your TOC entries and on page frontmatter, so the gating that you already configured for the portal also applies to the assistant.
+The assistant answers each question from the portal content the asking customer can see, for the version they are viewing. Two customers on different licenses can therefore get different answers to the same question.
 
-Separately, the request instructs the assistant not to mention entitlements, licenses, or feature flags, and not to bring up a fixed set of installation and recovery capabilities that the customer's license does not include. That instruction is a prompt to the model, not an enforced filter, so do not rely on it alone to keep a feature's existence confidential.
+The `visible_when` conditions on your `toc.yaml` entries and page frontmatter decide what the assistant receives. The gating you already configured for the portal applies to the assistant too.
+
+The request also instructs the assistant not to mention entitlements, licenses, or feature flags. It further tells the assistant not to bring up installation or recovery capabilities the customer's license excludes.
+
+Both are prompts to the model, not enforced filters. Do not rely on them alone to keep a feature's existence confidential.
 
 For questions about your application itself, the assistant uses only your portal content. If your content does not cover a topic, it says that it does not have information rather than inferring an answer. It does not draw on outside knowledge about your application, because published information about your application can be out of date or wrong. For dependencies and infrastructure — Kubernetes, the Helm CLI, Linux administration, Docker, cloud providers, networking, TLS, and DNS — it may also use general public knowledge.
 
-Long pages and large content sets are truncated to fit the request, so the assistant can miss a topic that your content does cover.
+Replicated truncates long pages and large content sets to fit the request. The assistant can therefore miss a topic that your content does cover.
 
 When an answer draws on a specific portal page, the assistant is instructed to cite that page as the source.
 
@@ -58,10 +62,10 @@ Replicated processes Ask AI requests with a third-party AI provider. When a cust
 
 Replicated does not send the license document itself. Two things derived from the customer do reach the provider:
 
-- **Values rendered from template variables.** Template variables are resolved before the content is sent, so any app, customer, channel, or release values that your content renders are transmitted as part of it, including `customer.email`, `customer.id`, `customer.name`, and `channel.name`. If you use these variables, review where they appear before you turn on Ask AI. For more information, see [Template variables](/vendor/enterprise-portal-v2-content#template-variables) in _Customize Portal Content_.
+- **Values rendered from template variables.** Replicated resolves template variables before sending the content. Any app, customer, channel, or release value your content renders therefore travels with it, including `customer.email`, `customer.id`, `customer.name`, and `channel.name`. If you use these variables, review where they appear before you turn on Ask AI. For more information, see [Template variables](/vendor/enterprise-portal-v2-content#template-variables) in _Customize Portal Content_.
 - **The capabilities the customer's license excludes.** The request names a fixed set of installation and recovery capabilities the customer is not entitled to, so the assistant does not offer them.
 
-Because enabling Ask AI sends your portal content and your customers' questions to a third-party provider, review the setting against your own agreements with your customers before you turn it on.
+Enabling Ask AI sends your portal content and your customers' questions to a third-party provider. Review the setting against your own agreements with your customers before you turn it on.
 
 ### Disabling Ask AI
 

--- a/docs/vendor/enterprise-portal-v2-portal-features.mdx
+++ b/docs/vendor/enterprise-portal-v2-portal-features.mdx
@@ -19,7 +19,9 @@ The section contains the following settings:
 
 The three Security Center settings are available to all teams.
 
-Access to the settings also depends on your Vendor Portal permissions. One permission controls **Enable Ask AI** and **Enable Security Center for all customers**; the two Security Center display settings use a separate one. A team member can therefore be able to change the first two settings and still see a message that the display settings are unavailable. For more information, see [Configure RBAC policies](/vendor/team-management-rbac-configuring).
+Access to these settings depends on your Vendor Portal permissions, and they are not all governed by the same one. **Enable Ask AI** and **Enable Security Center for all customers** use the application read and update permissions. The two Security Center display settings use a separate Security Center settings permission.
+
+Because the permissions are separate, a team member can be able to change **Enable Ask AI** and **Enable Security Center for all customers** while the display settings are unavailable to them. Without read permission, a setting is replaced by a message explaining that. Without update permission, it appears but cannot be changed. For more information, see [Configure RBAC policies](/vendor/team-management-rbac-configuring).
 
 ## Ask AI {#ask-ai}
 
@@ -29,7 +31,7 @@ The assistant is delivered in the page header only. It is not a navigation item,
 
 ### What the assistant answers from
 
-Each question is answered from the portal content that the asking customer can see. The assistant receives the same entitlement-filtered and version-filtered content that the customer would get by browsing the portal, so two customers on different licenses can receive different answers to the same question. Content that the customer is not entitled to is excluded before the request is sent, so the assistant cannot quote it.
+Each question is answered from the portal content that the asking customer can see. The assistant receives content drawn from what that customer can see in the portal, for the version they are viewing, so two customers on different licenses can receive different answers to the same question. Content is excluded based on the `visible_when` conditions on your TOC entries and on page frontmatter, so the gating that you already configured for the portal also applies to the assistant.
 
 Separately, the request instructs the assistant not to mention entitlements, licenses, or feature flags, and not to bring up a fixed set of installation and recovery capabilities that the customer's license does not include. That instruction is a prompt to the model rather than an enforced filter, so do not rely on it alone to keep the existence of a feature confidential from a customer.
 
@@ -37,7 +39,7 @@ For questions about your application, the assistant uses only your portal conten
 
 Long pages and large content sets are truncated to fit the request, so the assistant can report that it lacks information about a topic that your content does cover.
 
-When an answer draws on a specific portal page, the assistant cites that page so that the customer can find the source.
+When an answer draws on a specific portal page, the assistant is instructed to cite that page so that the customer can find the source.
 
 The panel displays the disclaimer "Responses are generated using AI and may contain mistakes." on every conversation.
 
@@ -49,9 +51,9 @@ Replicated processes Ask AI requests with a third-party AI provider. When a cust
 - Up to the last 10 messages of the current conversation, so that follow-up questions have context. The panel sends the whole conversation to Replicated, which forwards only the most recent messages to the provider
 - The portal content that the asking customer is entitled to see, for the version they are viewing
 
-Replicated does not send the customer's license or its entitlement fields to the provider. Two things derived from the customer do reach it:
+Replicated does not send the license document itself. Two things derived from the customer do reach the provider:
 
-- **Values rendered from customer template variables.** Variables such as `customer.email`, `customer.id`, and `customer.name` are resolved before the content is sent, so their values are transmitted as part of the content. If you use these variables, review where they appear before you turn on Ask AI. For more information, see [Template variables](/vendor/enterprise-portal-v2-content#template-variables) in _Customize Portal Content_.
+- **Values rendered from template variables.** Template variables are resolved before the content is sent, so any app, customer, channel, or release values that your content renders are transmitted as part of it, including `customer.email`, `customer.id`, `customer.name`, and `channel.name`. If you use these variables, review where they appear before you turn on Ask AI. For more information, see [Template variables](/vendor/enterprise-portal-v2-content#template-variables) in _Customize Portal Content_.
 - **The capabilities the customer's license excludes.** The request names a fixed set of installation and recovery capabilities that the customer is not entitled to, so that the assistant does not offer them.
 
 Because enabling Ask AI sends your portal content and your customers' questions to a third-party provider, review the setting against your own agreements with your customers before you turn it on.

--- a/docs/vendor/enterprise-portal-v2-portal-features.mdx
+++ b/docs/vendor/enterprise-portal-v2-portal-features.mdx
@@ -13,12 +13,13 @@ The section contains the following settings:
 | Setting | Default | Description |
 |---|---|---|
 | **Enable Ask AI** | Disabled | Adds an AI assistant to the portal that answers customer questions from your portal content. See [Ask AI](#ask-ai). |
+| **Enable Security Center for all customers** | Disabled | Grants Security Center access to all current and future customers, overriding each customer's individual setting. See [Security Center access](#security-center-access). |
 | **Display only fixable CVEs in Security Center report** | Enabled | Limits the CVE report to vulnerabilities with an available fix. Disable it to let customers switch between all CVEs and fixable CVEs. See [Security Center display settings](#security-center-display-settings). |
 | **Enable raw CVE scan to be downloadable** | Disabled | Lets customers download the raw Grype scan JSON for a release. See [Security Center display settings](#security-center-display-settings). |
 
-The two Security Center settings appear only when Security Center is enabled for your team. If **Portal Features** shows only **Enable Ask AI**, contact your Replicated account representative about Security Center.
+The three Security Center settings appear only when Security Center is enabled for your team. If **Portal Features** shows only **Enable Ask AI**, contact your Replicated account representative about Security Center.
 
-Access to the settings also depends on your Vendor Portal permissions. The Security Center display settings use their own permission, so a team member can be able to change **Enable Ask AI** and still see a message that the Security Center settings are unavailable. For more information, see [Configure RBAC policies](/vendor/team-management-rbac-configuring).
+Access to the settings also depends on your Vendor Portal permissions. The Security Center settings use their own permissions, so a team member can be able to change **Enable Ask AI** and still see a message that the Security Center settings are unavailable. For more information, see [Configure RBAC policies](/vendor/team-management-rbac-configuring).
 
 ## Ask AI {#ask-ai}
 
@@ -54,9 +55,17 @@ Disable **Enable Ask AI** to remove the button from the portal header for all cu
 
 ## Security Center display settings {#security-center-display-settings}
 
-The **Display only fixable CVEs in Security Center report** and **Enable raw CVE scan to be downloadable** settings control how Security Center reports appear to customers. They do not grant Security Center access, which is a per-customer setting.
+The **Display only fixable CVEs in Security Center report** and **Enable raw CVE scan to be downloadable** settings control how Security Center reports appear to customers. They do not grant access to the Security Center itself.
 
-For what each setting does and how to grant a customer access to Security Center, see [Configure Security Center display settings](/vendor/security-center-enable-customer-access#configure-security-center-display-settings) in _Enable Customer Access to Security Information_.
+For what each setting does, see [Configure Security Center display settings](/vendor/security-center-enable-customer-access#configure-security-center-display-settings) in _Enable Customer Access to Security Information_.
+
+## Security Center access {#security-center-access}
+
+**Enable Security Center for all customers** grants Security Center access to every current and future customer. It is disabled by default. While it is enabled, each customer's own **Enable Security Center for this customer** setting displays as enabled and cannot be changed; the saved individual settings take effect again when you disable it.
+
+Granting access does not by itself give customers anything to open. The Security page has to exist in your content repository and be listed in `toc.yaml`.
+
+For the full procedure and the per-customer alternative, see [Enable Security Center access](/vendor/security-center-enable-customer-access#enable-security-center-access) in _Enable Customer Access to Security Information_.
 
 ## Related topics
 

--- a/docs/vendor/enterprise-portal-v2-portal-features.mdx
+++ b/docs/vendor/enterprise-portal-v2-portal-features.mdx
@@ -17,9 +17,9 @@ The section contains the following settings:
 | **Display only fixable CVEs in Security Center report** | Enabled | Limits the CVE report to vulnerabilities with an available fix. Disable it to let customers switch between all CVEs and fixable CVEs. See [Security Center display settings](#security-center-display-settings). |
 | **Enable raw CVE scan to be downloadable** | Disabled | Lets customers download the raw Grype scan JSON for a release. See [Security Center display settings](#security-center-display-settings). |
 
-The three Security Center settings appear only when Security Center is enabled for your team. If **Portal Features** shows only **Enable Ask AI**, contact your Replicated account representative about Security Center.
+The three Security Center settings are available to all teams.
 
-Access to the settings also depends on your Vendor Portal permissions. The two Security Center display settings use their own permission, separate from the one that controls **Enable Ask AI** and **Enable Security Center for all customers**. A team member can therefore be able to change those two settings and still see a message that the display settings are unavailable. For more information, see [Configure RBAC policies](/vendor/team-management-rbac-configuring).
+Access to the settings also depends on your Vendor Portal permissions. One permission controls **Enable Ask AI** and **Enable Security Center for all customers**; the two Security Center display settings use a separate one. A team member can therefore be able to change the first two settings and still see a message that the display settings are unavailable. For more information, see [Configure RBAC policies](/vendor/team-management-rbac-configuring).
 
 ## Ask AI {#ask-ai}
 
@@ -29,11 +29,15 @@ The assistant is delivered in the page header only. It is not a navigation item,
 
 ### What the assistant answers from
 
-Each question is answered from the portal content that the asking customer can see. The assistant receives the same entitlement-filtered and version-filtered content that the customer would get by browsing the portal, so two customers on different licenses can receive different answers to the same question. The assistant does not disclose features that the customer is not entitled to, and it does not mention entitlements, licenses, or feature flags.
+Each question is answered from the portal content that the asking customer can see. The assistant receives the same entitlement-filtered and version-filtered content that the customer would get by browsing the portal, so two customers on different licenses can receive different answers to the same question. Content that the customer is not entitled to is excluded before the request is sent, so the assistant cannot quote it.
+
+Separately, the request instructs the assistant not to mention entitlements, licenses, or feature flags, and not to bring up a fixed set of installation and recovery capabilities that the customer's license does not include. That instruction is a prompt to the model rather than an enforced filter, so do not rely on it alone to keep the existence of a feature confidential from a customer.
 
 For questions about your application, the assistant uses only your portal content. If your content does not cover a topic, the assistant says that it does not have information about it rather than inferring an answer. It may also draw on general public knowledge about dependencies and infrastructure, such as Kubernetes, the Helm CLI, Linux administration, Docker, cloud providers, networking, TLS, and DNS. It does not use outside knowledge about your application itself, because published information about your application can be out of date or wrong.
 
-When an answer draws on a specific portal page, the assistant links to that page so that the customer can read the source.
+Long pages and large content sets are truncated to fit the request, so the assistant can report that it lacks information about a topic that your content does cover.
+
+When an answer draws on a specific portal page, the assistant cites that page so that the customer can find the source.
 
 The panel displays the disclaimer "Responses are generated using AI and may contain mistakes." on every conversation.
 
@@ -42,10 +46,13 @@ The panel displays the disclaimer "Responses are generated using AI and may cont
 Replicated processes Ask AI requests with a third-party AI provider. When a customer sends a question, the following is transmitted to that provider:
 
 - The question text
-- Up to the last 10 messages of the current conversation, which the panel sends so that follow-up questions have context
+- Up to the last 10 messages of the current conversation, so that follow-up questions have context. The panel sends the whole conversation to Replicated, which forwards only the most recent messages to the provider
 - The portal content that the asking customer is entitled to see, for the version they are viewing
 
-Customer identifiers, license fields, and entitlement values are not sent as data to be reasoned about. Entitlements are applied before the request, to select which content is included.
+Replicated does not send the customer's license or its entitlement fields to the provider. Two things derived from the customer do reach it:
+
+- **Values rendered from customer template variables.** Variables such as `customer.email`, `customer.id`, and `customer.name` are resolved before the content is sent, so their values are transmitted as part of the content. If you use these variables, review where they appear before you turn on Ask AI. For more information, see [Template variables](/vendor/enterprise-portal-v2-content#template-variables) in _Customize Portal Content_.
+- **The capabilities the customer's license excludes.** The request names a fixed set of installation and recovery capabilities that the customer is not entitled to, so that the assistant does not offer them.
 
 Because enabling Ask AI sends your portal content and your customers' questions to a third-party provider, review the setting against your own agreements with your customers before you turn it on.
 
@@ -61,7 +68,9 @@ For what each setting does, see [Configure Security Center display settings](/ve
 
 ## Security Center access {#security-center-access}
 
-**Enable Security Center for all customers** grants Security Center access to every current and future customer. It is disabled by default. While it is enabled, each customer's own **Enable Security Center for this customer** setting displays as enabled and cannot be changed; the saved individual settings take effect again when you disable it.
+**Enable Security Center for all customers** grants Security Center access to every current and future customer. It is disabled by default. While it is enabled, a new-portal customer's own **Enable Security Center for this customer** setting displays as enabled and cannot be changed. For a customer still on Enterprise Portal (Classic), the per-customer setting is hidden instead. In both cases, the saved individual settings take effect again when you disable the app-level setting.
+
+This is the same app-level setting as the **Enable Security Center** option in **Enterprise Portal > Portal Settings > Optional Features**. Turning it on in either place grants access across both Enterprise Portal (Classic) and the new Enterprise Portal.
 
 Granting access does not by itself give customers anything to open. The Security page has to exist in your content repository and be listed in `toc.yaml`.
 

--- a/docs/vendor/enterprise-portal-v2-portal-features.mdx
+++ b/docs/vendor/enterprise-portal-v2-portal-features.mdx
@@ -38,7 +38,7 @@ The panel displays the disclaimer "Responses are generated using AI and may cont
 
 ### Data sent to the AI provider {#ask-ai-data}
 
-Replicated processes Ask AI requests with [Groq](https://groq.com), using the `openai/gpt-oss-120b` model. When a customer sends a question, the following is transmitted to Groq:
+Replicated processes Ask AI requests with a third-party AI provider. When a customer sends a question, the following is transmitted to that provider:
 
 - The question text
 - Up to the last 10 messages of the current conversation, which the panel sends so that follow-up questions have context
@@ -46,7 +46,7 @@ Replicated processes Ask AI requests with [Groq](https://groq.com), using the `o
 
 Customer identifiers, license fields, and entitlement values are not sent as data to be reasoned about. Entitlements are applied before the request, to select which content is included.
 
-Because enabling Ask AI sends your portal content and your customers' questions to a third-party provider, review the setting against your own agreements with your customers before you turn it on. For the list of third-party providers that Replicated uses, see [Infrastructure and Subprocessors](/vendor/policies-infrastructure-and-subprocessors).
+Because enabling Ask AI sends your portal content and your customers' questions to a third-party provider, review the setting against your own agreements with your customers before you turn it on.
 
 ### Disabling Ask AI
 
@@ -62,4 +62,3 @@ For what each setting does and how to grant a customer access to Security Center
 
 - [Customize Portal Content](/vendor/enterprise-portal-v2-content)
 - [Enable Customer Access to Security Information](/vendor/security-center-enable-customer-access)
-- [Infrastructure and Subprocessors](/vendor/policies-infrastructure-and-subprocessors)

--- a/docs/vendor/enterprise-portal-v2-portal-features.mdx
+++ b/docs/vendor/enterprise-portal-v2-portal-features.mdx
@@ -19,7 +19,7 @@ The section contains the following settings:
 
 The three Security Center settings appear only when Security Center is enabled for your team. If **Portal Features** shows only **Enable Ask AI**, contact your Replicated account representative about Security Center.
 
-Access to the settings also depends on your Vendor Portal permissions. The Security Center settings use their own permissions, so a team member can be able to change **Enable Ask AI** and still see a message that the Security Center settings are unavailable. For more information, see [Configure RBAC policies](/vendor/team-management-rbac-configuring).
+Access to the settings also depends on your Vendor Portal permissions. The two Security Center display settings use their own permission, separate from the one that controls **Enable Ask AI** and **Enable Security Center for all customers**. A team member can therefore be able to change those two settings and still see a message that the display settings are unavailable. For more information, see [Configure RBAC policies](/vendor/team-management-rbac-configuring).
 
 ## Ask AI {#ask-ai}
 

--- a/docs/vendor/enterprise-portal-v2-portal-features.mdx
+++ b/docs/vendor/enterprise-portal-v2-portal-features.mdx
@@ -1,10 +1,10 @@
 # Configure Portal Features
 
-This topic describes the app-level Enterprise Portal settings in the **Portal Features** section of the Vendor Portal, including the Ask AI assistant and the Security Center display settings.
+This topic describes the app-level Enterprise Portal settings in the **Portal Features** section of the Vendor Portal, including the Ask AI assistant and the Security Center settings.
 
 ## About Portal Features
 
-**Portal Features** is a set of app-level settings that control optional capabilities in the new Enterprise Portal. The settings apply to every customer of the application. They are separate from the per-customer settings on a customer's **Enterprise Portal access** tab, which control whether an individual customer has portal access at all.
+**Portal Features** is a set of app-level settings that control optional capabilities in the Enterprise Portal. The settings apply to every customer of the application. They are separate from the per-customer settings on a customer's **Enterprise Portal access** tab, which control whether an individual customer has portal access at all.
 
 To open the settings, go to **Enterprise Portal > Content** in the Vendor Portal and find the **Portal Features** section. Changes are saved automatically.
 
@@ -17,11 +17,16 @@ The section contains the following settings:
 | **Display only fixable CVEs in Security Center report** | Enabled | Limits the CVE report to vulnerabilities with an available fix. Disable it to let customers switch between all CVEs and fixable CVEs. See [Security Center display settings](#security-center-display-settings). |
 | **Enable raw CVE scan to be downloadable** | Disabled | Lets customers download the raw Grype scan JSON for a release. See [Security Center display settings](#security-center-display-settings). |
 
-The three Security Center settings are available to all teams.
+### Permissions
 
-Access to these settings depends on your Vendor Portal permissions, and they are not all governed by the same one. **Enable Ask AI** and **Enable Security Center for all customers** use the application read and update permissions. The two Security Center display settings use a separate Security Center settings permission.
+The **Portal Features** settings are not all controlled by the same permission:
 
-Because the permissions are separate, a team member can be able to change **Enable Ask AI** and **Enable Security Center for all customers** while the display settings are unavailable to them. Without read permission, a setting is replaced by a message explaining that. Without update permission, it appears but cannot be changed. For more information, see [Configure RBAC policies](/vendor/team-management-rbac-configuring).
+| Setting | Read permission | Update permission |
+|---|---|---|
+| **Enable Ask AI**, **Enable Security Center for all customers** | `kots/app/[:appid]/read` | `kots/app/[:appid]/update` |
+| **Display only fixable CVEs in Security Center report**, **Enable raw CVE scan to be downloadable** | `kots/app/[:appid]/enterprise-portal/security-settings/read` | `kots/app/[:appid]/enterprise-portal/security-settings/update` |
+
+Because the two groups use separate permissions, a team member can have access to one group and not the other. If you lack the read permission for a setting, the Vendor Portal replaces it with a message explaining that. If you lack the update permission, the setting appears but is read-only. For more information, see [Configure RBAC policies](/vendor/team-management-rbac-configuring).
 
 ## Ask AI {#ask-ai}
 
@@ -31,15 +36,15 @@ The assistant is delivered in the page header only. It is not a navigation item,
 
 ### What the assistant answers from
 
-Each question is answered from the portal content that the asking customer can see. The assistant receives content drawn from what that customer can see in the portal, for the version they are viewing, so two customers on different licenses can receive different answers to the same question. Content is excluded based on the `visible_when` conditions on your TOC entries and on page frontmatter, so the gating that you already configured for the portal also applies to the assistant.
+Each question is answered from the portal content the asking customer can see, for the version they are viewing, so two customers on different licenses can receive different answers to the same question. Content is excluded based on the `visible_when` conditions on your TOC entries and on page frontmatter, so the gating that you already configured for the portal also applies to the assistant.
 
-Separately, the request instructs the assistant not to mention entitlements, licenses, or feature flags, and not to bring up a fixed set of installation and recovery capabilities that the customer's license does not include. That instruction is a prompt to the model rather than an enforced filter, so do not rely on it alone to keep the existence of a feature confidential from a customer.
+Separately, the request instructs the assistant not to mention entitlements, licenses, or feature flags, and not to bring up a fixed set of installation and recovery capabilities that the customer's license does not include. That instruction is a prompt to the model, not an enforced filter, so do not rely on it alone to keep a feature's existence confidential.
 
-For questions about your application, the assistant uses only your portal content. If your content does not cover a topic, the assistant says that it does not have information about it rather than inferring an answer. It may also draw on general public knowledge about dependencies and infrastructure, such as Kubernetes, the Helm CLI, Linux administration, Docker, cloud providers, networking, TLS, and DNS. It does not use outside knowledge about your application itself, because published information about your application can be out of date or wrong.
+For questions about your application itself, the assistant uses only your portal content. If your content does not cover a topic, it says that it does not have information rather than inferring an answer. It does not draw on outside knowledge about your application, because published information about your application can be out of date or wrong. For dependencies and infrastructure — Kubernetes, the Helm CLI, Linux administration, Docker, cloud providers, networking, TLS, and DNS — it may also use general public knowledge.
 
-Long pages and large content sets are truncated to fit the request, so the assistant can report that it lacks information about a topic that your content does cover.
+Long pages and large content sets are truncated to fit the request, so the assistant can miss a topic that your content does cover.
 
-When an answer draws on a specific portal page, the assistant is instructed to cite that page so that the customer can find the source.
+When an answer draws on a specific portal page, the assistant is instructed to cite that page as the source.
 
 The panel displays the disclaimer "Responses are generated using AI and may contain mistakes." on every conversation.
 
@@ -48,13 +53,13 @@ The panel displays the disclaimer "Responses are generated using AI and may cont
 Replicated processes Ask AI requests with a third-party AI provider. When a customer sends a question, the following is transmitted to that provider:
 
 - The question text
-- Up to the last 10 messages of the current conversation, so that follow-up questions have context. The panel sends the whole conversation to Replicated, which forwards only the most recent messages to the provider
+- Up to the last 10 messages of the current conversation, for context on follow-up questions. The panel sends the whole conversation to Replicated, which forwards only the most recent messages to the provider
 - The portal content that the asking customer is entitled to see, for the version they are viewing
 
 Replicated does not send the license document itself. Two things derived from the customer do reach the provider:
 
 - **Values rendered from template variables.** Template variables are resolved before the content is sent, so any app, customer, channel, or release values that your content renders are transmitted as part of it, including `customer.email`, `customer.id`, `customer.name`, and `channel.name`. If you use these variables, review where they appear before you turn on Ask AI. For more information, see [Template variables](/vendor/enterprise-portal-v2-content#template-variables) in _Customize Portal Content_.
-- **The capabilities the customer's license excludes.** The request names a fixed set of installation and recovery capabilities that the customer is not entitled to, so that the assistant does not offer them.
+- **The capabilities the customer's license excludes.** The request names a fixed set of installation and recovery capabilities the customer is not entitled to, so the assistant does not offer them.
 
 Because enabling Ask AI sends your portal content and your customers' questions to a third-party provider, review the setting against your own agreements with your customers before you turn it on.
 
@@ -62,21 +67,21 @@ Because enabling Ask AI sends your portal content and your customers' questions 
 
 Disable **Enable Ask AI** to remove the button from the portal header for all customers. Disabling the setting stops new requests. It does not affect conversations that have already been sent.
 
-## Security Center display settings {#security-center-display-settings}
-
-The **Display only fixable CVEs in Security Center report** and **Enable raw CVE scan to be downloadable** settings control how Security Center reports appear to customers. They do not grant access to the Security Center itself.
-
-For what each setting does, see [Configure Security Center display settings](/vendor/security-center-enable-customer-access#configure-security-center-display-settings) in _Enable Customer Access to Security Information_.
-
 ## Security Center access {#security-center-access}
 
 **Enable Security Center for all customers** grants Security Center access to every current and future customer. It is disabled by default. While it is enabled, a new-portal customer's own **Enable Security Center for this customer** setting displays as enabled and cannot be changed. For a customer still on Enterprise Portal (Classic), the per-customer setting is hidden instead. In both cases, the saved individual settings take effect again when you disable the app-level setting.
 
 This is the same app-level setting as the **Enable Security Center** option in **Enterprise Portal > Portal Settings > Optional Features**. Turning it on in either place grants access across both Enterprise Portal (Classic) and the new Enterprise Portal.
 
-Granting access does not by itself give customers anything to open. The Security page has to exist in your content repository and be listed in `toc.yaml`.
+Access alone gives customers nothing to open. The Security page must also exist in your content repository and be listed in `toc.yaml`.
 
 For the full procedure and the per-customer alternative, see [Enable Security Center access](/vendor/security-center-enable-customer-access#enable-security-center-access) in _Enable Customer Access to Security Information_.
+
+## Security Center display settings {#security-center-display-settings}
+
+The **Display only fixable CVEs in Security Center report** and **Enable raw CVE scan to be downloadable** settings control how Security Center reports appear to customers. They do not grant access to the Security Center itself.
+
+For what each setting does, see [Configure Security Center display settings](/vendor/security-center-enable-customer-access#configure-security-center-display-settings) in _Enable Customer Access to Security Information_.
 
 ## Related topics
 

--- a/docs/vendor/enterprise-portal-v2-portal-features.mdx
+++ b/docs/vendor/enterprise-portal-v2-portal-features.mdx
@@ -1,0 +1,65 @@
+# Configure Portal Features
+
+This topic describes the app-level Enterprise Portal settings in the **Portal Features** section of the Vendor Portal, including the Ask AI assistant and the Security Center display settings.
+
+## About Portal Features
+
+**Portal Features** is a set of app-level settings that control optional capabilities in the new Enterprise Portal. The settings apply to every customer of the application. They are separate from the per-customer settings on a customer's **Enterprise Portal access** tab, which control whether an individual customer has portal access at all.
+
+To open the settings, go to **Enterprise Portal > Content** in the Vendor Portal and find the **Portal Features** section. Changes are saved automatically.
+
+The section contains the following settings:
+
+| Setting | Default | Description |
+|---|---|---|
+| **Enable Ask AI** | Disabled | Adds an AI assistant to the portal that answers customer questions from your portal content. See [Ask AI](#ask-ai) below. |
+| **Display only fixable CVEs in Security Center report** | Enabled | Limits the CVE report to vulnerabilities with an available fix. Disable it to let customers switch between all CVEs and fixable CVEs. See [Security Center display settings](#security-center-display-settings) below. |
+| **Enable raw CVE scan to be downloadable** | Disabled | Lets customers download the raw Grype scan JSON for a release. See [Security Center display settings](#security-center-display-settings) below. |
+
+The two Security Center settings appear only when Security Center is enabled for your team. If **Portal Features** shows only **Enable Ask AI**, contact your Replicated account representative about Security Center.
+
+Access to the settings also depends on your Vendor Portal permissions. The Security Center display settings use their own permission, so a team member can be able to change **Enable Ask AI** and still see a message that the Security Center settings are unavailable. For more information, see [Configure RBAC policies](/vendor/team-management-rbac-configuring).
+
+## Ask AI {#ask-ai}
+
+When you enable **Enable Ask AI**, the portal adds an **Ask AI** button to the header of every content page. The button opens an assistant panel on the right side of the page, where the customer can ask questions and receive streamed answers. The setting is disabled by default, and it applies to all of your customers at once.
+
+The assistant is delivered in the page header only. It is not a navigation item, and there is currently no supported way to move it, rename it, or hide it from a subset of customers. The **Enable Ask AI** setting is the only control over whether customers see it.
+
+### What the assistant answers from
+
+Each question is answered from the portal content that the asking customer can see. The assistant receives the same entitlement-filtered and version-filtered content that the customer would get by browsing the portal, so two customers on different licenses can receive different answers to the same question. The assistant does not disclose features that the customer is not entitled to, and it does not mention entitlements, licenses, or feature flags.
+
+For questions about your application, the assistant uses only your portal content. If your content does not cover a topic, the assistant says that it does not have information about it rather than inferring an answer. It may also draw on general public knowledge about dependencies and infrastructure, such as Kubernetes, the Helm CLI, Linux administration, Docker, cloud providers, networking, TLS, and DNS. It does not use outside knowledge about your application itself, because published information about your application can be out of date or wrong.
+
+When an answer draws on a specific portal page, the assistant links to that page so that the customer can read the source.
+
+The panel displays the disclaimer "Responses are generated using AI and may contain mistakes." on every conversation.
+
+### Data sent to the AI provider {#ask-ai-data}
+
+Replicated processes Ask AI requests with [Groq](https://groq.com), using the `openai/gpt-oss-120b` model. When a customer sends a question, the following is transmitted to Groq:
+
+- The question text
+- Up to the last 10 messages of the current conversation, which the panel sends so that follow-up questions have context
+- The portal content that the asking customer is entitled to see, for the version they are viewing
+
+Customer identifiers, license fields, and entitlement values are not sent as data to be reasoned about. Entitlements are applied before the request, to select which content is included.
+
+Because enabling Ask AI sends your portal content and your customers' questions to a third-party provider, review the setting against your own agreements with your customers before you turn it on. For the list of third-party providers that Replicated uses, see [Infrastructure and Subprocessors](/vendor/policies-infrastructure-and-subprocessors).
+
+### Disabling Ask AI
+
+Disable **Enable Ask AI** to remove the button from the portal header for all customers. Disabling the setting stops new requests. It does not affect conversations that have already been sent.
+
+## Security Center display settings {#security-center-display-settings}
+
+The **Display only fixable CVEs in Security Center report** and **Enable raw CVE scan to be downloadable** settings control how Security Center reports appear to customers. They do not grant Security Center access, which is a per-customer setting.
+
+For what each setting does and how to grant a customer access to Security Center, see [Configure Security Center display settings](/vendor/security-center-enable-customer-access#configure-security-center-display-settings) in _Enable Customer Access to Security Information_.
+
+## Related topics
+
+- [Customize Portal Content](/vendor/enterprise-portal-v2-content)
+- [Enable Customer Access to Security Information](/vendor/security-center-enable-customer-access)
+- [Infrastructure and Subprocessors](/vendor/policies-infrastructure-and-subprocessors)

--- a/docs/vendor/enterprise-portal-v2-portal-features.mdx
+++ b/docs/vendor/enterprise-portal-v2-portal-features.mdx
@@ -12,7 +12,7 @@ The section contains the following settings:
 
 | Setting | Default | Description |
 |---|---|---|
-| **Enable Ask AI** | Disabled | Adds an AI assistant to the portal that answers customer questions from your portal content. See [Ask AI](#ask-ai). |
+| **Enable Ask AI** | Disabled | Adds an AI assistant that answers customer questions from your portal content. See [Ask AI](#ask-ai). |
 | **Enable Security Center for all customers** | Disabled | Grants Security Center access to all current and future customers, overriding each customer's individual setting. See [Security Center access](#security-center-access). |
 | **Display only fixable CVEs in Security Center report** | Enabled | Limits the CVE report to vulnerabilities with an available fix. Disable it to let customers switch between all CVEs and fixable CVEs. See [Security Center display settings](#security-center-display-settings). |
 | **Enable raw CVE scan to be downloadable** | Disabled | Lets customers download the raw Grype scan JSON for a release. See [Security Center display settings](#security-center-display-settings). |
@@ -26,13 +26,13 @@ The **Portal Features** settings are not all controlled by the same permission:
 | **Enable Ask AI**, **Enable Security Center for all customers** | `kots/app/[:appid]/read` | `kots/app/[:appid]/update` |
 | **Display only fixable CVEs in Security Center report**, **Enable raw CVE scan to be downloadable** | `kots/app/[:appid]/enterprise-portal/security-settings/read` | `kots/app/[:appid]/enterprise-portal/security-settings/update` |
 
-Because the two groups use separate permissions, a team member can have access to one group and not the other. If you lack the read permission for a setting, the Vendor Portal replaces it with a message explaining that. If you lack the update permission, the setting appears but is read-only. For more information, see [Configure RBAC policies](/vendor/team-management-rbac-configuring).
+Because the two groups use separate permissions, a team member can have access to one group and not the other. If you lack the read permission for a setting, the Vendor Portal replaces it with a message saying so. If you lack the update permission, the setting appears but is read-only. For more information, see [Configure RBAC policies](/vendor/team-management-rbac-configuring).
 
 ## Ask AI {#ask-ai}
 
-When you turn on **Enable Ask AI**, the portal adds an **Ask AI** button to the header of every content page. The button opens an assistant panel on the right side of the page, where the customer can ask questions and receive streamed answers. The setting is disabled by default, and it applies to all of your customers.
+When you turn on **Enable Ask AI**, the portal adds an **Ask AI** button to the header of every content page. The button opens an assistant panel on the right side of the page, where the customer can ask questions and receive streamed answers.
 
-The assistant appears only in the page header. It is not a navigation item, and there is no supported way to move it, rename it, or hide it from some customers. **Enable Ask AI** is the only control over whether customers see it.
+The button is the only place the assistant appears. It is not a navigation item, and there is no supported way to move it, rename it, or hide it from some customers. **Enable Ask AI** is the only control over whether customers see it.
 
 ### What the assistant answers from
 
@@ -40,17 +40,15 @@ The assistant answers each question from the portal content the asking customer 
 
 The `visible_when` conditions on your `toc.yaml` entries and page frontmatter decide what the assistant receives. The gating you already configured for the portal applies to the assistant too.
 
-The request also instructs the assistant not to mention entitlements, licenses, or feature flags. It further tells the assistant not to bring up installation or recovery capabilities the customer's license excludes.
+The request also instructs the assistant not to mention entitlements, licenses, or feature flags, and not to bring up installation or recovery capabilities the customer's license excludes. These are prompts to the model, not enforced filters. Do not rely on them alone to keep a feature's existence confidential.
 
-Both are prompts to the model, not enforced filters. Do not rely on them alone to keep a feature's existence confidential.
-
-For questions about your application itself, the assistant uses only your portal content. If your content does not cover a topic, it says that it does not have information rather than inferring an answer. It does not draw on outside knowledge about your application, because published information about your application can be out of date or wrong. For dependencies and infrastructure — Kubernetes, the Helm CLI, Linux administration, Docker, cloud providers, networking, TLS, and DNS — it may also use general public knowledge.
+For questions about your application, the assistant uses only your portal content. If your content does not cover a topic, it says so rather than inferring an answer. It ignores outside knowledge about your application, because published information can be out of date or wrong. For dependencies and infrastructure — Kubernetes, the Helm CLI, Linux administration, Docker, cloud providers, networking, TLS, and DNS — it may also use general public knowledge.
 
 Replicated truncates long pages and large content sets to fit the request. The assistant can therefore miss a topic that your content does cover.
 
 When an answer draws on a specific portal page, the assistant is instructed to cite that page as the source.
 
-The panel displays the disclaimer "Responses are generated using AI and may contain mistakes." on every conversation.
+The panel displays the disclaimer "Responses are generated using AI and may contain mistakes." in every conversation.
 
 ### Data sent to the AI provider {#ask-ai-data}
 
@@ -58,22 +56,22 @@ Replicated processes Ask AI requests with a third-party AI provider. When a cust
 
 - The question text
 - Up to the last 10 messages of the current conversation, for context on follow-up questions. The panel sends the whole conversation to Replicated, which forwards only the most recent messages to the provider
-- The portal content that the asking customer is entitled to see, for the version they are viewing
+- The portal content the asking customer can see, for the version they are viewing
 
 Replicated does not send the license document itself. Two things derived from the customer do reach the provider:
 
 - **Values rendered from template variables.** Replicated resolves template variables before sending the content. Any app, customer, channel, or release value your content renders therefore travels with it, including `customer.email`, `customer.id`, `customer.name`, and `channel.name`. If you use these variables, review where they appear before you turn on Ask AI. For more information, see [Template variables](/vendor/enterprise-portal-v2-content#template-variables) in _Customize Portal Content_.
 - **The capabilities the customer's license excludes.** The request names a fixed set of installation and recovery capabilities the customer is not entitled to, so the assistant does not offer them.
 
-Enabling Ask AI sends your portal content and your customers' questions to a third-party provider. Review the setting against your own agreements with your customers before you turn it on.
+Review the setting against your own agreements with your customers before you turn it on.
 
 ### Disabling Ask AI
 
-Disable **Enable Ask AI** to remove the button from the portal header for all customers. Disabling the setting stops new requests. It does not affect conversations that have already been sent.
+Turn off **Enable Ask AI** to remove the button from the portal header for all customers. Turning it off stops new requests. It does not affect conversations that customers have already sent.
 
 ## Security Center access {#security-center-access}
 
-**Enable Security Center for all customers** grants Security Center access to every current and future customer. It is disabled by default. While it is enabled, a new-portal customer's own **Enable Security Center for this customer** setting displays as enabled and cannot be changed. For a customer still on Enterprise Portal (Classic), the per-customer setting is hidden instead. In both cases, the saved individual settings take effect again when you disable the app-level setting.
+**Enable Security Center for all customers** grants Security Center access to every current and future customer. While it is on, it overrides the per-customer **Enable Security Center for this customer** setting: for a customer on the new Enterprise Portal, that setting displays as enabled and cannot be changed, and for a customer still on Enterprise Portal (Classic), it is hidden. Turning the app-level setting off restores each customer's saved setting.
 
 This is the same app-level setting as the **Enable Security Center** option in **Enterprise Portal > Portal Settings > Optional Features**. Turning it on in either place grants access across both Enterprise Portal (Classic) and the new Enterprise Portal.
 

--- a/docs/vendor/security-center-enable-customer-access.mdx
+++ b/docs/vendor/security-center-enable-customer-access.mdx
@@ -59,7 +59,7 @@ To configure how Security Center reports display in Enterprise Portal (New):
    * When enabled, the CVE Report card displays **Download full CVE report**. Customers can use this button to download the complete raw Grype scan JSON for the selected release.
    * When disabled, the button is not displayed. Customers can still view the CVE report when they have access to the Security Center.
 
-Changes to the Portal Features settings are saved automatically.
+Changes to the Portal Features settings are saved automatically. For the other settings in this section, see [Configure Portal Features](/vendor/enterprise-portal-v2-portal-features).
 
 The downloaded JSON contains the same raw Grype scan data that is available to vendors through the [`securebuild/scan-raw` Vendor API endpoint](/vendor/security-center-retrieve-scan-results#retrieve-the-raw-scan-results). The customer-facing download is controlled by this setting and is distinct from both Vendor API access and the SPDX SBOM download.
 

--- a/docs/vendor/security-center-enable-customer-access.mdx
+++ b/docs/vendor/security-center-enable-customer-access.mdx
@@ -59,7 +59,7 @@ To configure how Security Center reports display in Enterprise Portal (New):
    * When enabled, the CVE Report card displays **Download full CVE report**. Customers can use this button to download the complete raw Grype scan JSON for the selected release.
    * When disabled, the button is not displayed. Customers can still view the CVE report when they have access to the Security Center.
 
-Changes to the Portal Features settings are saved automatically. For the other settings in this section, see [Configure Portal Features](/vendor/enterprise-portal-v2-portal-features).
+Changes to the Portal Features settings are saved automatically. For an overview of every setting in the **Portal Features** section, including **Enable Ask AI**, see [Configure Portal Features](/vendor/enterprise-portal-v2-portal-features).
 
 The downloaded JSON contains the same raw Grype scan data that is available to vendors through the [`securebuild/scan-raw` Vendor API endpoint](/vendor/security-center-retrieve-scan-results#retrieve-the-raw-scan-results). The customer-facing download is controlled by this setting and is distinct from both Vendor API access and the SPDX SBOM download.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -216,6 +216,7 @@ const sidebars = {
         "vendor/enterprise-portal-v2-emails",
         "vendor/enterprise-portal-v2-branding",
         "vendor/enterprise-portal-v2-content",
+        "vendor/enterprise-portal-v2-portal-features",
         "vendor/enterprise-portal-v2-service-account-automation",
         "vendor/enterprise-portal-v2-versioned-docs",
         "vendor/enterprise-portal-v2-helm-reference",

--- a/styles/config/vocabularies/ThirdPartyProducts/accept.txt
+++ b/styles/config/vocabularies/ThirdPartyProducts/accept.txt
@@ -56,4 +56,3 @@ Minio
 Ceph
 VMware
 Tanzu
-Groq

--- a/styles/config/vocabularies/ThirdPartyProducts/accept.txt
+++ b/styles/config/vocabularies/ThirdPartyProducts/accept.txt
@@ -56,3 +56,4 @@ Minio
 Ceph
 VMware
 Tanzu
+Groq


### PR DESCRIPTION
Part 3 of 3 for sc-139273. Ask AI is live and entirely undocumented. Parts 1 and 2 merged as #4389 and #4390.

## The provider is described but not named, deliberately

The data disclosure states what leaves the portal — the question, up to 10 prior messages, and the entitlement-filtered content — but calls the destination "a third-party AI provider" rather than naming it.

The provider is Groq, and it is absent from [Infrastructure and Subprocessors](https://github.com/replicatedhq/replicated-docs/blob/main/docs/vendor/policies-infrastructure-and-subprocessors.md), which today lists OpenAI and FireworksAI. Publishing a disclosure that names a processor missing from our own published list advertises the inconsistency. Adding a subprocessor is not a docs-team editorial call, and the listing is owned outside this PR with no timeline I can state. Rather than hold this page indefinitely — Ask AI is shipping to customers undocumented right now — the naming is deferred to a follow-up.

To be explicit about what that means for review: **this PR is complete and mergeable on its own.** The follow-up is not a loose end in this change, it is a separate change that becomes possible later. If the listing never happens, this page is still correct as written.

The model id is withheld for the same reason, and this part is not obvious: it reads as `openai/gpt-oss-120b`, and **OpenAI is on the subprocessor list**. Naming the model while withholding the provider would imply the processor is OpenAI, which is wrong. Provider and model are restored together or not at all.

The links to Infrastructure and Subprocessors are dropped for the same reason — a reader following one to learn who processes their AI data would find OpenAI and FireworksAI and draw the wrong conclusion.

**Follow-up, once Groq is listed:** restore the provider name and link, the model id, the sentence pointing at the subprocessor page, the Related topics entry, and `Groq` in `styles/config/vocabularies/ThirdPartyProducts/accept.txt` (Vale flags it as a spelling error otherwise). Roughly a five-line diff.

**What this PR does not do:** hide that data leaves. A vendor reading this page learns that enabling Ask AI sends their content and their customers' questions to a third party, and is told to check that against their own customer agreements. Only the identity is deferred.

## Why a new page

The **Portal Features** section of **Enterprise Portal > Content** holds three app-level settings and had no page describing it. sc-139271 needs a single **Learn more** link pointing at documentation covering all the toggles in the box, and #4373 documented the two Security Center toggles by topic on the Security Center page.

Rather than move that merged work, this page documents all three settings and links out to #4373's section for the Security Center detail. sc-139271 gets its single target; #4373 is untouched.

The page is a sibling of Customize Portal Content rather than a section inside it: that page is a content-authoring reference, and these are app settings.

## Changes

- New `docs/vendor/enterprise-portal-v2-portal-features.mdx`
- `security-center-enable-customer-access.mdx` — one reciprocal link (the only line changed outside the new file)
- `sidebars.js` — entry after `vendor/enterprise-portal-v2-content`

## No availability admonition, deliberately

This is currently the only page in the Enterprise Portal (New) section without a `:::note Alpha Feature` block. That is intentional, not an oversight.

sc-138827 is replacing those 16 blocks with `:::note Beta Feature` at the EP v2 Beta launch. Adding one here would introduce, in a brand-new file, the exact string that sweep exists to remove. Publishing a Beta banner now is also not an option: the process rule is that public docs announcing Beta merge at launch, not before.

Note that the earlier version of this PR argued this page would very likely merge *after* the sweep. With the subprocessor gate removed that is no longer a safe bet — this may well land first, and be the only page of 17 with no marker until the sweep runs.

**For whoever runs the sc-138827 sweep:** this page needs the "additional access" variant, not the plain one, since every capability it documents is gated (Security Center by team, Ask AI by a per-vendor toggle, and the Security Center settings by their own RBAC resource):

```
:::note Beta Feature
Features described on this page are Beta and subject to change. Some capabilities might require additional access.
:::
```

## Defaults, and how they were derived

Two of the three defaults are `0` in the schema and read as "Disabled". The third does not, and that is worth a reviewer's eye:

| Setting | Stored field | Stored default | Toggle shows |
|---|---|---|---|
| Enable Ask AI | `kots_app.ask_ai_enabled` | `0` | Disabled |
| Display only fixable CVEs in Security Center report | `enterprise_portal_security_settings.show_unfixable_cves` | `0` | **Enabled** |
| Enable raw CVE scan to be downloadable | `enterprise_portal_security_settings.allow_raw_scan_download` | `0` | Disabled |

The middle row inverts because the toggle is rendered as `checked={!securitySettings.showUnfixableCVEs}` (`PortalFeatureSettings.tsx:199`, label at `:191`). With `show_unfixable_cves` defaulting to false — in both the table schema and `DefaultSecuritySettings()` in `pkg/enterprise-portal/security_settings.go`, which also covers apps with no settings row — the toggle is **on** out of the box, so customers see only fixable CVEs until a vendor turns it off. The page says Enabled for that reason.

I had this backwards in an earlier revision of this PR. #4373 states a default only for the raw scan download, so this page was the only place asserting the other two and the error would have shipped here.

**A note for future edits:** this default is a derived claim, not a value read off a column. If anyone ever normalizes the toggle's polarity so the label matches the stored field, the documented default flips with no schema change to signal it.

## What the page documents

**All three settings**, with the conditions that hide some of them. The two Security Center settings render only for teams with Security Center enabled (`PortalFeatureSettings.tsx:54-57`), so a vendor without it sees one toggle and would otherwise conclude the docs are wrong. The Security Center settings also use a separate RBAC resource, so a team member can be able to change Ask AI and not those.

**Ask AI in full**, since it has no other home:
- Default off (`kots-app.yaml`, `ask_ai_enabled` default `"0"`), app-level, applies to all customers at once
- Header-button-and-right-panel delivery, with no supported way to move, rename, or hide it (sc-139279 is deferred)
- Answer scope, stated precisely. The assistant answers product questions only from the asking customer's entitlement-filtered content, and it *may* use general public knowledge about Kubernetes, Helm, Linux, Docker, networking, TLS, and DNS while refusing outside knowledge about the application (`ask_ai.go:350`). "Only your docs" is the natural summary and it is not quite right, so the page says both halves.
- The data sent to the provider: the question, up to the last 10 messages of the conversation, and the entitlement-filtered content. Not only the question.

## Verified against source

All claims were checked against `replicatedhq/vandoor` at `a56ae15d2`, not against UI copy:

- History cap is **10 messages**, not 10 turns — `historyLimit := 10` (`ask_ai.go:103`) counts user and assistant messages together, so roughly five exchanges. The page says messages.
- Provider and model come from `ask_ai.go:499` and the request target at `ask_ai.go:513`. Withheld from the page per the section above, recorded here so the follow-up does not have to re-derive them.
- The Vendor Portal's own helper text says the assistant is "trained on your documentation". It is retrieval over the content, not training, and the page describes it accurately rather than repeating that phrasing.

## Vale

Clean apart from four deliberate skips: three `Headings` sentence-case warnings, because **Portal Features** and **Ask AI** are UI proper nouns and every sibling EP v2 page H1 is title case and identically flagged; and one `PositionalLanguage` warning on the assistant panel's right-side placement, which is load-bearing description rather than navigation prose.

