### PR TITLE
docs: add Groq to the subprocessor list and name it in the Ask AI disclosure

### DIFF
--- a/docs/vendor/enterprise-portal-v2-portal-features.mdx
+++ b/docs/vendor/enterprise-portal-v2-portal-features.mdx
@@ -52,7 +52,7 @@ The panel displays the disclaimer "Responses are generated using AI and may cont
 
 ### Data sent to the AI provider {#ask-ai-data}
 
-Replicated processes Ask AI requests with [Groq](https://groq.com), using the `openai/gpt-oss-120b` model. When a customer sends a question, the following is transmitted to Groq:
+When the Ask AI capability is enabled, Replicated processes any Ask AI requests with [Groq](https://groq.com), using the `openai/gpt-oss-120b` model. When a customer sends a question, the following is transmitted to Groq:
 
 - The question text
 - Up to the last 10 messages of the current conversation, for context on follow-up questions. The panel sends the whole conversation to Replicated, which forwards only the most recent messages to the provider

--- a/docs/vendor/enterprise-portal-v2-portal-features.mdx
+++ b/docs/vendor/enterprise-portal-v2-portal-features.mdx
@@ -52,7 +52,7 @@ The panel displays the disclaimer "Responses are generated using AI and may cont
 
 ### Data sent to the AI provider {#ask-ai-data}
 
-Replicated processes Ask AI requests with a third-party AI provider. When a customer sends a question, the following is transmitted to that provider:
+Replicated processes Ask AI requests with [Groq](https://groq.com), using the `openai/gpt-oss-120b` model. When a customer sends a question, the following is transmitted to Groq:
 
 - The question text
 - Up to the last 10 messages of the current conversation, for context on follow-up questions. The panel sends the whole conversation to Replicated, which forwards only the most recent messages to the provider
@@ -63,7 +63,7 @@ Replicated does not send the license document itself. Two things derived from th
 - **Values rendered from template variables.** Replicated resolves template variables before sending the content. Any app, customer, channel, or release value your content renders therefore travels with it, including `customer.email`, `customer.id`, `customer.name`, and `channel.name`. If you use these variables, review where they appear before you turn on Ask AI. For more information, see [Template variables](/vendor/enterprise-portal-v2-content#template-variables) in _Customize Portal Content_.
 - **The capabilities the customer's license excludes.** The request names a fixed set of installation and recovery capabilities the customer is not entitled to, so the assistant does not offer them.
 
-Review the setting against your own agreements with your customers before you turn it on.
+Review the setting against your own agreements with your customers before you turn it on. For the list of third-party providers that Replicated uses, see [Infrastructure and Subprocessors](/vendor/policies-infrastructure-and-subprocessors).
 
 ### Disabling Ask AI
 
@@ -89,3 +89,4 @@ For what each setting does, see [Configure Security Center display settings](/ve
 
 - [Customize Portal Content](/vendor/enterprise-portal-v2-content)
 - [Enable Customer Access to Security Information](/vendor/security-center-enable-customer-access)
+- [Infrastructure and Subprocessors](/vendor/policies-infrastructure-and-subprocessors)

--- a/docs/vendor/policies-infrastructure-and-subprocessors.md
+++ b/docs/vendor/policies-infrastructure-and-subprocessors.md
@@ -5,17 +5,17 @@ This lists describes the infrastructure environment, subprocessors and other ent
 
 Prior to engaging any third party, Replicated performs diligence to evaluate their privacy, security and confidentiality practices. Whenever possible, Replicated uses encryption for data at rest and in motion so that all information is not available to these third parties. 
 
-Replicated does not engage in the business of selling or trading personal information. Any personally identifible information Replicated might possibly hold is data that a customer has provided to us. 
+Replicated does not engage in the business of selling or trading personal information. Any personally identifiable information Replicated might possibly hold is data that a customer has provided to us. 
 
-The fields that Replicated may posess as identifiable to a physical person may include:
+The fields that Replicated may possess as identifiable to a physical person may include:
 - Name
 - Email
 - Phone Number
 - Job Title
 - Business Address
-- Github Username
+- GitHub Username
 
-Note: This does not imply that all these fields are collected for each person. It also does not mean all these datapoints are used with each declared provider.
+Note: This does not imply that all these fields are collected for each person. It also does not mean all these data points are used with each declared provider.
 
 
 ## Replicated infrastructure providers
@@ -31,13 +31,13 @@ Replicated might use the following entities to provide infrastructure that helps
 | Datadog | Performance monitoring | United States |
 | DBT Labs | Data transformation or migration | United States |
 | FiveTran | Data transformation or migration  | United States |
-| Github | Customer support  | United States | Replicated's customers may engage with our customer support team using Github issues in a private repo.
+| GitHub | Customer support  | United States | Replicated's customers may engage with our customer support team using GitHub issues in a private repo.
 | Omni Analytics | Product usage metrics  | United States |
 | Hex | Data transformation or migration | United States |
 | Postmark | Transactional emails from Vendor Portal. Marketing related communications. | United States |
-| Attio |Customer and sales relationship management| United States | 
+| Attio | Customer and sales relationship management | United States |
 | Snowflake | Usage data analysis and transformation   | United States |
-| Google Workspace | Email, calednar, docs/drive   | United States |
+| Google Workspace | Email, calendar, docs/drive   | United States |
 | Slack | Customer and internal communication   | United States |
 | OpenAI | Platform level services and LLMs   | United States |
 | FireworksAI | Platform level services and LLMs   | United States |

--- a/docs/vendor/policies-infrastructure-and-subprocessors.md
+++ b/docs/vendor/policies-infrastructure-and-subprocessors.md
@@ -41,5 +41,6 @@ Replicated might use the following entities to provide infrastructure that helps
 | Slack | Customer and internal communication   | United States |
 | OpenAI | Platform level services and LLMs   | United States |
 | FireworksAI | Platform level services and LLMs   | United States |
+| Groq | Platform level services and LLMs | United States | Powers the Ask AI assistant in the Enterprise Portal. Receives end-customer questions and the portal content that the asking customer is entitled to see, including any customer name, email address, ID, or channel name that template variables render into that content.
 
-Last modified July 14, 2026
+Last modified August 21, 2026

--- a/styles/config/vocabularies/TechJargon/accept.txt
+++ b/styles/config/vocabularies/TechJargon/accept.txt
@@ -131,3 +131,5 @@ CRs
 BackupRepository
 preconfigured
 crashloop
+LLM
+LLMs

--- a/styles/config/vocabularies/ThirdPartyProducts/accept.txt
+++ b/styles/config/vocabularies/ThirdPartyProducts/accept.txt
@@ -56,3 +56,4 @@ Minio
 Ceph
 VMware
 Tanzu
+Groq


### PR DESCRIPTION
Adds Groq to the Infrastructure and Subprocessors list, and names it in the Ask AI data disclosure.

## Changes

**`policies-infrastructure-and-subprocessors.md`**

- Adds a Groq row: `Platform level services and LLMs`, United States. Its Notes column describes what Groq receives — end-customer questions, the portal content the asking customer can see, and any customer name, email address, ID, or channel name that template variables render into that content.
- Bumps `Last modified`.

**`enterprise-portal-v2-portal-features.mdx`**

- Names [Groq](https://groq.com) and the `openai/gpt-oss-120b` model in the Ask AI data disclosure, in place of "a third-party AI provider".
- Adds links to Infrastructure and Subprocessors.

**Vale vocabularies** — adds `Groq` to ThirdPartyProducts, and `LLM`/`LLMs` to TechJargon. The second also clears two pre-existing spelling errors on the OpenAI and FireworksAI rows.

The disclosure and the list change together in one commit so the two remain consistent.

Note that the model id reads as `openai/gpt-oss-120b` but the provider is Groq, not OpenAI — `gpt-oss` is an open-weights model served by Groq. OpenAI is listed separately on the subprocessor page, and the two should not be conflated.

## Also in this PR

Pre-existing fixes on the subprocessor page, unrelated to Groq and kept in their own commit:

| Was | Now |
|---|---|
| personally **identifible** information | **identifiable** |
| Replicated may **posess** | **possess** |
| Email, **calednar**, docs/drive | **calendar** |
| **Github** (three occurrences) | **GitHub** |
| all these **datapoints** | **data points** |

Plus cell padding on the Attio row, which was the only data row in the table missing spaces around its delimiters. No rendered change.

Vale on that page goes from 14 errors to 5. The remaining five are proper nouns absent from the accept vocabularies, plus `subprocessor` and `subprocessors`.

2 commits, 4 files, +15/-10.
