### PR TITLE
docs(ep-v2): name Groq and the model in the Ask AI disclosure

### DIFF
--- a/docs/vendor/enterprise-portal-v2-portal-features.mdx
+++ b/docs/vendor/enterprise-portal-v2-portal-features.mdx
@@ -38,7 +38,7 @@ The panel displays the disclaimer "Responses are generated using AI and may cont
 
 ### Data sent to the AI provider {#ask-ai-data}
 
-Replicated processes Ask AI requests with a third-party AI provider. When a customer sends a question, the following is transmitted to that provider:
+Replicated processes Ask AI requests with [Groq](https://groq.com), using the `openai/gpt-oss-120b` model. When a customer sends a question, the following is transmitted to Groq:
 
 - The question text
 - Up to the last 10 messages of the current conversation, which the panel sends so that follow-up questions have context
@@ -46,7 +46,7 @@ Replicated processes Ask AI requests with a third-party AI provider. When a cust
 
 Customer identifiers, license fields, and entitlement values are not sent as data to be reasoned about. Entitlements are applied before the request, to select which content is included.
 
-Because enabling Ask AI sends your portal content and your customers' questions to a third-party provider, review the setting against your own agreements with your customers before you turn it on.
+Because enabling Ask AI sends your portal content and your customers' questions to a third-party provider, review the setting against your own agreements with your customers before you turn it on. For the list of third-party providers that Replicated uses, see [Infrastructure and Subprocessors](/vendor/policies-infrastructure-and-subprocessors).
 
 ### Disabling Ask AI
 
@@ -62,3 +62,4 @@ For what each setting does and how to grant a customer access to Security Center
 
 - [Customize Portal Content](/vendor/enterprise-portal-v2-content)
 - [Enable Customer Access to Security Information](/vendor/security-center-enable-customer-access)
+- [Infrastructure and Subprocessors](/vendor/policies-infrastructure-and-subprocessors)


### PR DESCRIPTION
Restores the provider name and model id to the Ask AI privacy disclosure. Final piece of sc-139273.

> [!WARNING]
> **Merge order is load-bearing. This must land after #4396, and after #4391.**
>
> - **#4396** adds Groq to Infrastructure and Subprocessors. Merging *this* PR first publishes a disclosure naming a processor absent from our own published list — precisely the inconsistency #4391 was written to avoid. It also fails CI-less Vale on `Vale.Spelling`, because #4396 owns the vocabulary entry.
> - **#4391** creates the page this PR edits. It is currently the base branch of this PR, so GitHub will retarget this to `main` automatically once #4391 merges.
>
> If #4396 is rejected — that is, if Groq is not an approved subprocessor — **close this PR rather than merging it.** #4391 is correct and complete without it.

## What it changes

Three lines, all in `enterprise-portal-v2-portal-features.mdx`:

1. Names [Groq](https://groq.com) and the `openai/gpt-oss-120b` model as the processor, replacing "a third-party AI provider"
2. Restores the sentence pointing at Infrastructure and Subprocessors
3. Restores the Related topics entry

No change to the substance of the disclosure. What data is transmitted — the question, up to the last 10 messages, and the entitlement-filtered content — was already documented in #4391 and is untouched here. **This PR adds only the identity.**

## Why it was split out in the first place

#4391 documents Ask AI, which is live and was shipping to customers with no documentation at all. Holding that page until a subprocessor listing landed would have kept a live data flow undocumented for an unbounded period, so the naming was deferred and the page shipped with the disclosure intact.

The model id went with the provider deliberately, and the reason is easy to miss: `openai/gpt-oss-120b` reads as OpenAI, and **OpenAI is already listed as a subprocessor**. Naming the model while withholding the provider would have pointed readers at the wrong processor. The two are restored together for the same reason they were removed together.

## Vale

Depends on `Groq` in `styles/config/vocabularies/ThirdPartyProducts/accept.txt`, which **#4396 adds**. Not duplicated here — two PRs adding the same accept-list line would conflict. Verified clean once that entry is present.
