### PR TITLE
docs(ep-v2): relabel Enterprise Portal from Alpha to Beta

### DIFF
--- a/docs/vendor/custom-domains-using.md
+++ b/docs/vendor/custom-domains-using.md
@@ -73,7 +73,7 @@ After you add one or more custom domains in the Vendor Portal, you can configure
 
 The Classic Enterprise Portal and the Download Portal share a domain that you add and manage on the **Custom Domains** page, using the steps in [Add a custom domain in the Vendor Portal](#add-domain).
 
-The New Enterprise Portal, which is in alpha, is the exception. It manages its own domains from **Enterprise Portal > Domains** instead of the **Custom Domains** page. For the steps, see [Configure a Custom Domain](/vendor/enterprise-portal-v2-domains). Teams that use only the New Enterprise Portal do not see Download Portal domains on the **Custom Domains** page.
+The New Enterprise Portal is the exception. It manages its own domains from **Enterprise Portal > Domains** instead of the **Custom Domains** page. For the steps, see [Configure a Custom Domain](/vendor/enterprise-portal-v2-domains). Teams that use only the New Enterprise Portal do not see Download Portal domains on the **Custom Domains** page.
 
 ### Configure Embedded Cluster to use custom domains {#ec}
 

--- a/docs/vendor/enterprise-portal-v2-about.mdx
+++ b/docs/vendor/enterprise-portal-v2-about.mdx
@@ -1,7 +1,7 @@
 # About the Enterprise Portal
 
 :::note Beta Feature
-The new Enterprise Portal is Beta and is available to all vendors. Some capabilities might require additional access.
+The Enterprise Portal is Beta and is available to all vendors. Some capabilities might require additional access.
 :::
 
 The Enterprise Portal gives your customers one central place to view their install and upgrade instructions for each version of your software, set up their environment, manage their team, and get troubleshooting support by uploading support bundles.

--- a/docs/vendor/enterprise-portal-v2-about.mdx
+++ b/docs/vendor/enterprise-portal-v2-about.mdx
@@ -1,7 +1,7 @@
 # About the Enterprise Portal
 
-:::note Alpha Feature
-Features described on this page are in alpha and subject to change. Some capabilities might require additional access.
+:::note Beta Feature
+The new Enterprise Portal is Beta and is available to all vendors. Some capabilities might require additional access.
 :::
 
 The Enterprise Portal gives your customers one central place to view their install and upgrade instructions for each version of your software, set up their environment, manage their team, and get troubleshooting support by uploading support bundles.

--- a/docs/vendor/enterprise-portal-v2-access.mdx
+++ b/docs/vendor/enterprise-portal-v2-access.mdx
@@ -1,7 +1,7 @@
 # Test and Preview the Enterprise Portal
 
-:::note Alpha Feature
-Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
+:::note Beta Feature
+The new Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 This topic describes how to preview and test the Enterprise Portal before and after inviting customers, including local preview for content development and logging in as a specific customer for production checks.

--- a/docs/vendor/enterprise-portal-v2-access.mdx
+++ b/docs/vendor/enterprise-portal-v2-access.mdx
@@ -1,7 +1,7 @@
 # Test and Preview the Enterprise Portal
 
 :::note Beta Feature
-The new Enterprise Portal is Beta. Features described on this page are subject to change.
+The Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 This topic describes how to preview and test the Enterprise Portal before and after inviting customers, including local preview for content development and logging in as a specific customer for production checks.

--- a/docs/vendor/enterprise-portal-v2-branding.mdx
+++ b/docs/vendor/enterprise-portal-v2-branding.mdx
@@ -1,7 +1,7 @@
 # Customize Portal Branding
 
-:::note Alpha Feature
-Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
+:::note Beta Feature
+The new Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 Branding for the new Enterprise Portal is configured entirely through your content repo. There is no branding UI in the Vendor Portal. Include a `theme.yaml` file in your repo to override branding for any version of your docs.

--- a/docs/vendor/enterprise-portal-v2-branding.mdx
+++ b/docs/vendor/enterprise-portal-v2-branding.mdx
@@ -1,7 +1,7 @@
 # Customize Portal Branding
 
 :::note Beta Feature
-The new Enterprise Portal is Beta. Features described on this page are subject to change.
+The Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 Branding for the new Enterprise Portal is configured entirely through your content repo. There is no branding UI in the Vendor Portal. Include a `theme.yaml` file in your repo to override branding for any version of your docs.

--- a/docs/vendor/enterprise-portal-v2-connect-repo.mdx
+++ b/docs/vendor/enterprise-portal-v2-connect-repo.mdx
@@ -1,7 +1,7 @@
 # Connect a Git Repo
 
-:::note Alpha Feature
-Features described on this page are in alpha and subject to change. Some capabilities might require additional access.
+:::note Beta Feature
+The new Enterprise Portal is Beta. Features described on this page are subject to change. Some capabilities might require additional access.
 :::
 
 :::note

--- a/docs/vendor/enterprise-portal-v2-connect-repo.mdx
+++ b/docs/vendor/enterprise-portal-v2-connect-repo.mdx
@@ -1,7 +1,7 @@
 # Connect a Git Repo
 
 :::note Beta Feature
-The new Enterprise Portal is Beta. Features described on this page are subject to change. Some capabilities might require additional access.
+The Enterprise Portal is Beta. Features described on this page are subject to change. Some capabilities might require additional access.
 :::
 
 :::note

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -1,7 +1,7 @@
 # Customize Portal Content
 
 :::note Beta Feature
-The new Enterprise Portal is Beta. Features described on this page are subject to change.
+The Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 This topic describes how to customize the content in the new Enterprise Portal, including the content template structure, table of contents configuration, MDX components, template variables, visibility rules, and downloadable assets.

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -1,7 +1,7 @@
 # Customize Portal Content
 
-:::note Alpha Feature
-Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
+:::note Beta Feature
+The new Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 This topic describes how to customize the content in the new Enterprise Portal, including the content template structure, table of contents configuration, MDX components, template variables, visibility rules, and downloadable assets.

--- a/docs/vendor/enterprise-portal-v2-domains.mdx
+++ b/docs/vendor/enterprise-portal-v2-domains.mdx
@@ -1,7 +1,7 @@
 # Configure a Custom Domain
 
-:::note Alpha Feature
-Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
+:::note Beta Feature
+The new Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 Every Enterprise Portal has a default domain that is always available. You can also add your own custom domain so that customers access the portal at a branded URL.

--- a/docs/vendor/enterprise-portal-v2-domains.mdx
+++ b/docs/vendor/enterprise-portal-v2-domains.mdx
@@ -1,7 +1,7 @@
 # Configure a Custom Domain
 
 :::note Beta Feature
-The new Enterprise Portal is Beta. Features described on this page are subject to change.
+The Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 Every Enterprise Portal has a default domain that is always available. You can also add your own custom domain so that customers access the portal at a branded URL.

--- a/docs/vendor/enterprise-portal-v2-emails.mdx
+++ b/docs/vendor/enterprise-portal-v2-emails.mdx
@@ -1,7 +1,7 @@
 # Customize Customer Emails
 
-:::note Alpha Feature
-Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
+:::note Beta Feature
+The new Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 This topic describes how to configure and customize the emails sent to your customers through the Enterprise Portal, including setting up a verified sender address, customizing email templates, and viewing email delivery history.

--- a/docs/vendor/enterprise-portal-v2-emails.mdx
+++ b/docs/vendor/enterprise-portal-v2-emails.mdx
@@ -1,7 +1,7 @@
 # Customize Customer Emails
 
 :::note Beta Feature
-The new Enterprise Portal is Beta. Features described on this page are subject to change.
+The Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 This topic describes how to configure and customize the emails sent to your customers through the Enterprise Portal, including setting up a verified sender address, customizing email templates, and viewing email delivery history.

--- a/docs/vendor/enterprise-portal-v2-helm-reference.mdx
+++ b/docs/vendor/enterprise-portal-v2-helm-reference.mdx
@@ -1,7 +1,7 @@
 # Generate Helm Docs
 
-:::note Alpha Feature
-Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
+:::note Beta Feature
+The new Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 If your releases contain Helm charts, Enterprise Portal can automatically generate reference documentation when you promote a release. No manual authoring is required.

--- a/docs/vendor/enterprise-portal-v2-helm-reference.mdx
+++ b/docs/vendor/enterprise-portal-v2-helm-reference.mdx
@@ -1,7 +1,7 @@
 # Generate Helm Docs
 
 :::note Beta Feature
-The new Enterprise Portal is Beta. Features described on this page are subject to change.
+The Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 If your releases contain Helm charts, Enterprise Portal can automatically generate reference documentation when you promote a release. No manual authoring is required.

--- a/docs/vendor/enterprise-portal-v2-invite.mdx
+++ b/docs/vendor/enterprise-portal-v2-invite.mdx
@@ -1,7 +1,7 @@
 # Manage Customer Access
 
-:::note Alpha Feature
-Features described on this page are in alpha and subject to change. Some capabilities might require additional access.
+:::note Beta Feature
+The new Enterprise Portal is Beta. Features described on this page are subject to change. Some capabilities might require additional access.
 :::
 
 This topic describes how to control which customers can access the new Enterprise Portal and how to manage their portal users from the Vendor Portal.

--- a/docs/vendor/enterprise-portal-v2-invite.mdx
+++ b/docs/vendor/enterprise-portal-v2-invite.mdx
@@ -1,7 +1,7 @@
 # Manage Customer Access
 
 :::note Beta Feature
-The new Enterprise Portal is Beta. Features described on this page are subject to change. Some capabilities might require additional access.
+The Enterprise Portal is Beta. Features described on this page are subject to change. Some capabilities might require additional access.
 :::
 
 This topic describes how to control which customers can access the new Enterprise Portal and how to manage their portal users from the Vendor Portal.

--- a/docs/vendor/enterprise-portal-v2-portal-features.mdx
+++ b/docs/vendor/enterprise-portal-v2-portal-features.mdx
@@ -1,5 +1,9 @@
 # Configure Portal Features
 
+:::note Beta Feature
+The Enterprise Portal is Beta. Features described on this page are subject to change. Some capabilities might require additional access.
+:::
+
 This topic describes the app-level Enterprise Portal settings in the **Portal Features** section of the Vendor Portal, including the Ask AI assistant and the Security Center settings.
 
 ## About Portal Features

--- a/docs/vendor/enterprise-portal-v2-self-serve-signup.mdx
+++ b/docs/vendor/enterprise-portal-v2-self-serve-signup.mdx
@@ -1,7 +1,7 @@
 # Enable Self-Service Sign-Ups
 
 :::note Beta Feature
-The new Enterprise Portal is Beta. Features described on this page are subject to change.
+The Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 Allow potential customers to sign up for a trial or community license directly from the Enterprise Portal, without a vendor-initiated invitation.

--- a/docs/vendor/enterprise-portal-v2-self-serve-signup.mdx
+++ b/docs/vendor/enterprise-portal-v2-self-serve-signup.mdx
@@ -1,7 +1,7 @@
 # Enable Self-Service Sign-Ups
 
-:::note Alpha Feature
-Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
+:::note Beta Feature
+The new Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 Allow potential customers to sign up for a trial or community license directly from the Enterprise Portal, without a vendor-initiated invitation.

--- a/docs/vendor/enterprise-portal-v2-service-account-automation.mdx
+++ b/docs/vendor/enterprise-portal-v2-service-account-automation.mdx
@@ -4,8 +4,8 @@ sidebar_label: Enable Customer Automation
 
 # Enable customer automation
 
-:::note Alpha Feature
-Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
+:::note Beta Feature
+The new Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 This topic describes how to add service account automation docs to the new Enterprise Portal. Service account automation lets your customers call Enterprise Portal API endpoints from CI/CD systems or other scripts.

--- a/docs/vendor/enterprise-portal-v2-service-account-automation.mdx
+++ b/docs/vendor/enterprise-portal-v2-service-account-automation.mdx
@@ -5,7 +5,7 @@ sidebar_label: Enable Customer Automation
 # Enable customer automation
 
 :::note Beta Feature
-The new Enterprise Portal is Beta. Features described on this page are subject to change.
+The Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 This topic describes how to add service account automation docs to the new Enterprise Portal. Service account automation lets your customers call Enterprise Portal API endpoints from CI/CD systems or other scripts.

--- a/docs/vendor/enterprise-portal-v2-terraform.mdx
+++ b/docs/vendor/enterprise-portal-v2-terraform.mdx
@@ -1,7 +1,7 @@
 # Include Terraform Modules
 
-:::note Alpha Feature
-Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
+:::note Beta Feature
+The new Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 :::note

--- a/docs/vendor/enterprise-portal-v2-terraform.mdx
+++ b/docs/vendor/enterprise-portal-v2-terraform.mdx
@@ -1,7 +1,7 @@
 # Include Terraform Modules
 
 :::note Beta Feature
-The new Enterprise Portal is Beta. Features described on this page are subject to change.
+The Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 :::note

--- a/docs/vendor/enterprise-portal-v2-troubleshooting.mdx
+++ b/docs/vendor/enterprise-portal-v2-troubleshooting.mdx
@@ -1,7 +1,7 @@
 # Troubleshoot the Enterprise Portal
 
 :::note Beta Feature
-The new Enterprise Portal is Beta. Features described on this page are subject to change.
+The Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 This topic provides solutions for common issues when setting up and using the new Enterprise Portal.

--- a/docs/vendor/enterprise-portal-v2-troubleshooting.mdx
+++ b/docs/vendor/enterprise-portal-v2-troubleshooting.mdx
@@ -1,7 +1,7 @@
 # Troubleshoot the Enterprise Portal
 
-:::note Alpha Feature
-Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
+:::note Beta Feature
+The new Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 This topic provides solutions for common issues when setting up and using the new Enterprise Portal.

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -1,7 +1,7 @@
 # Log in to and Use the Enterprise Portal
 
 :::note Beta Feature
-The new Enterprise Portal is Beta. Features described on this page are subject to change.
+The Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 This topic describes the new Enterprise Portal experience from the customer's perspective, including how to log in and use the portal features.

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -1,7 +1,7 @@
 # Log in to and Use the Enterprise Portal
 
-:::note Alpha Feature
-Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
+:::note Beta Feature
+The new Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 This topic describes the new Enterprise Portal experience from the customer's perspective, including how to log in and use the portal features.

--- a/docs/vendor/enterprise-portal-v2-vendor-api-automation.mdx
+++ b/docs/vendor/enterprise-portal-v2-vendor-api-automation.mdx
@@ -4,8 +4,8 @@ sidebar_label: Enterprise Portal Headless Automation
 
 # Enterprise Portal Headless Automation
 
-:::note Alpha Feature
-Features described on this page are in alpha and subject to change. Some capabilities might require additional access.
+:::note Beta Feature
+The new Enterprise Portal is Beta. Features described on this page are subject to change. Some capabilities might require additional access.
 :::
 
 The Enterprise Portal can be operated headlessly through the Vendor API v3. This lets you integrate Enterprise Portal functionality into your existing distribution portal, support portal, or internal tooling rather than directing customers to the Enterprise Portal UI. Common use cases include automating customer onboarding, embedding portal access into your own product, and programmatically managing install profiles and instructions.

--- a/docs/vendor/enterprise-portal-v2-vendor-api-automation.mdx
+++ b/docs/vendor/enterprise-portal-v2-vendor-api-automation.mdx
@@ -5,7 +5,7 @@ sidebar_label: Enterprise Portal Headless Automation
 # Enterprise Portal Headless Automation
 
 :::note Beta Feature
-The new Enterprise Portal is Beta. Features described on this page are subject to change. Some capabilities might require additional access.
+The Enterprise Portal is Beta. Features described on this page are subject to change. Some capabilities might require additional access.
 :::
 
 The Enterprise Portal can be operated headlessly through the Vendor API v3. This lets you integrate Enterprise Portal functionality into your existing distribution portal, support portal, or internal tooling rather than directing customers to the Enterprise Portal UI. Common use cases include automating customer onboarding, embedding portal access into your own product, and programmatically managing install profiles and instructions.

--- a/docs/vendor/enterprise-portal-v2-versioned-docs.mdx
+++ b/docs/vendor/enterprise-portal-v2-versioned-docs.mdx
@@ -1,7 +1,7 @@
 # Manage Content Versions
 
-:::note Alpha Feature
-Features described on this page are in alpha and subject to change. For access, contact your Replicated account representative.
+:::note Beta Feature
+The new Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 Use versioned docs if you need to maintain different documentation for different versions of your software, for example, distinct install steps or caveats for specific releases.

--- a/docs/vendor/enterprise-portal-v2-versioned-docs.mdx
+++ b/docs/vendor/enterprise-portal-v2-versioned-docs.mdx
@@ -1,7 +1,7 @@
 # Manage Content Versions
 
 :::note Beta Feature
-The new Enterprise Portal is Beta. Features described on this page are subject to change.
+The Enterprise Portal is Beta. Features described on this page are subject to change.
 :::
 
 Use versioned docs if you need to maintain different documentation for different versions of your software, for example, distinct install steps or caveats for specific releases.

--- a/docs/vendor/security-center-enable-customer-access.mdx
+++ b/docs/vendor/security-center-enable-customer-access.mdx
@@ -43,7 +43,7 @@ To enable Security Center for all customers across Enterprise Portal (Classic) a
 
 This setting is the same app-level setting as **Enable Security Center for all customers** under **Enterprise Portal > Content > Portal Features**.
 
-## Enterprise Portal (New) (Alpha)
+## Enterprise Portal (New) (Beta) {#enterprise-portal-new}
 
 In Enterprise Portal (New), you add a Security page to your content repository. The page can include a release selector, CVE report, and SBOM report. For more information, see [Security components](/vendor/enterprise-portal-v2-content#security-components) in _Customize Enterprise Portal Content_.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -208,7 +208,7 @@ const sidebars = {
     },
     {
       type: "category",
-      label: "Enterprise Portal (New) (Alpha)",
+      label: "Enterprise Portal (New) (Beta)",
       items: [
         "vendor/enterprise-portal-v2-about",
         "vendor/enterprise-portal-v2-connect-repo",


### PR DESCRIPTION
Docs half of the EP v2 Alpha -> Beta relabel.

## What changed

**The 16 page-level admonitions.** Every `enterprise-portal-v2-*` page opens with the same `:::note Alpha Feature` block. Retitled to `Beta Feature` and rewritten two-tier, mirroring what #4231 did for Security Center — the availability claim goes only on the about page, the sub-pages get the shorter subject-to-change line.

| Pages | New text |
|---|---|
| `about` | The new Enterprise Portal is Beta and is available to all vendors. Some capabilities might require additional access. |
| `connect-repo`, `invite`, `vendor-api-automation` | The new Enterprise Portal is Beta. Features described on this page are subject to change. Some capabilities might require additional access. |
| the other twelve | The new Enterprise Portal is Beta. Features described on this page are subject to change. |