### PR TITLE
docs: fix three typos on the Infrastructure and Subprocessors page

### DIFF
--- a/docs/vendor/policies-infrastructure-and-subprocessors.md
+++ b/docs/vendor/policies-infrastructure-and-subprocessors.md
@@ -5,9 +5,9 @@ This lists describes the infrastructure environment, subprocessors and other ent
 
 Prior to engaging any third party, Replicated performs diligence to evaluate their privacy, security and confidentiality practices. Whenever possible, Replicated uses encryption for data at rest and in motion so that all information is not available to these third parties. 
 
-Replicated does not engage in the business of selling or trading personal information. Any personally identifible information Replicated might possibly hold is data that a customer has provided to us. 
+Replicated does not engage in the business of selling or trading personal information. Any personally identifiable information Replicated might possibly hold is data that a customer has provided to us. 
 
-The fields that Replicated may posess as identifiable to a physical person may include:
+The fields that Replicated may possess as identifiable to a physical person may include:
 - Name
 - Email
 - Phone Number
@@ -37,7 +37,7 @@ Replicated might use the following entities to provide infrastructure that helps
 | Postmark | Transactional emails from Vendor Portal. Marketing related communications. | United States |
 | Attio |Customer and sales relationship management| United States | 
 | Snowflake | Usage data analysis and transformation   | United States |
-| Google Workspace | Email, calednar, docs/drive   | United States |
+| Google Workspace | Email, calendar, docs/drive   | United States |
 | Slack | Customer and internal communication   | United States |
 | OpenAI | Platform level services and LLMs   | United States |
 | FireworksAI | Platform level services and LLMs   | United States |


### PR DESCRIPTION
Three misspellings in customer-facing policy text on `docs/vendor/policies-infrastructure-and-subprocessors.md`.

| Line | Was | Now |
|---|---|---|
| 8 | personally **identifible** information | personally **identifiable** information |
| 10 | Replicated may **posess** as identifiable | Replicated may **possess** as identifiable |
| 40 | Email, **calednar**, docs/drive | Email, **calendar**, docs/drive |

Lines 8 and 10 are in the "personal information" section of a published privacy policy — the sentence describing what personally identifiable information Replicated holds. Line 40 is the Purpose column of the Google Workspace subprocessor row.

Repo-wide check: these three occurrences are the only ones. `git grep -in "identifible\|posess\|calednar" -- docs/` returns nothing else.

Vale goes from 14 errors to 11 on the page, confirming exactly three fixes and no side effects. The remaining 11 are proper nouns not in the accept vocabularies (`Datadog`, `Attio`, `Omni`, `Github`) plus `subprocessor`/`subprocessors` themselves.

**`Last modified` is deliberately not bumped.** The substance of the policy is unchanged, and bumping the date on a published policy page signals a revision to the terms. Spelling is not a revision.

## Why this is separate

Split out of #4396 (adding Groq to the subprocessor list), which needs a compliance sign-off. Typo fixes should not be coupled to that decision in either direction — this can merge now regardless of how the Groq question resolves.

Touches lines 8, 10, and 40; #4396 touches line 44 and the `Last modified` line, so the two are independent.

## Noticed but not fixed

Same page, adjacent but a different call to make:

- **`Github` should be `GitHub`** (lines 16, 34, and again at 34) — a brand name rather than a typo.
- **`datapoints`** (line 18) — usually two words.
- Line 38's Google-adjacent row has inconsistent cell padding: `| Attio |Customer and sales relationship management| United States |` with a trailing space.

Happy to fold any of these in if you want them.