### PR TITLE
docs: add the Enterprise Portal security-settings RBAC resources

### DIFF
--- a/docs/vendor/team-management-rbac-resource-names.md
+++ b/docs/vendor/team-management-rbac-resource-names.md
@@ -347,6 +347,14 @@ Grants the holder permission to soft-delete Enterprise Portal install options fo
 
 Grants the holder permission to view Enterprise Portal instances for the specified application.
 
+### kots/app/[:appid]/enterprise-portal/security-settings/read
+
+Grants the holder permission to view Enterprise Portal Security Center display settings for the specified application.
+
+### kots/app/[:appid]/enterprise-portal/security-settings/update
+
+Grants the holder permission to update Enterprise Portal Security Center display settings for the specified application.
+
 ### kots/app/[:appid]/enterprise-portal/service-accounts/read
 
 Grants the holder permission to view Enterprise Portal service accounts for the specified application.


### PR DESCRIPTION
Adds two missing entries to the RBAC resource names reference:

| Resource | Grants |
|---|---|
| `kots/app/[:appid]/enterprise-portal/security-settings/read` | View the Enterprise Portal Security Center display settings |
| `kots/app/[:appid]/enterprise-portal/security-settings/update` | Update them |

Both are enforced today — `handlers/vendor-api/replv3/enterprise_portal/security_settings.go:122` and `:193` call `policy.CheckAccessOrAbort` with them, and `pkg/policy/resources.go:777-782` defines the strings. Neither appeared on this page, so a vendor reading it could not write a policy granting either one.

Placed alphabetically between `instances/read` and `service-accounts/read`. Descriptions follow the page's existing "Grants the holder permission to … for the specified application" voice.

Vale: 0 errors, warnings 141 -> 143. The two added warnings are the sentence-case alert that every one of this page's 158 resource headings already trips.

## Why this matters beyond tidiness

Raised in review on #4391, which documents the **Portal Features** settings. Those settings split across two permissions, and #4391 now carries a table naming the resource strings directly *because* linking readers to this page for the security-settings permission was a dead end. Once this lands, that table has a reference behind it.

## Draft, because it is the small half of a bigger problem

While measuring this I compared `pkg/policy/resources.go` against this page. **10 of the 39 Enterprise Portal resources are undocumented**, not 2:

| Missing | Enforced today? |
|---|---|
| `enterprise-portal/security-settings/read`, `/update` | yes — **this PR** |
| `enterprise-portal/custom-instructions/read`, `/create`, `/update`, `/delete` | yes |
| `enterprise-portal/email-history/read` | yes |
| `enterprise-portal/update-attempts/read` | yes |
| `enterprise-portal/build` | no — defined, referenced nowhere |
| `enterprise-portal/publish` | no — same |

Nothing is stale in the other direction: every documented entry still exists in code. The drift is entirely one-directional, which is what you would expect from a hand-maintained index — it does not accumulate dead links, it just never hears about new resources.

Two things worth deciding separately from this PR:

1. **The page claims to be exhaustive.** Its first line reads *"This a list of all available resource names for the Replicated vendor RBAC policy."* That is a completeness claim the page does not currently meet. (That sentence is also missing its verb — "This a list".)
2. **This is probably not EP-specific.** Roughly 158 resources are documented against ~227 string definitions in code. The EP figure is exact; treat the 227 as approximate, since that grep may catch non-resource strings. But a 26% shortfall on the family I measured properly suggests the page is behind generally.

Left as a draft so the narrow fix does not imply the broader gap is closed. The remaining 6 live resources each need a handler traced for an accurate description, and `build`/`publish` are arguably a vandoor cleanup rather than a docs addition — documenting permissions that gate nothing would be worse than omitting them.