### PR TITLE
Document deleting support bundles from the Vendor Portal (UI + API)

### DIFF
--- a/docs/vendor/preflight-support-bundle-about.mdx
+++ b/docs/vendor/preflight-support-bundle-about.mdx
@@ -191,7 +191,7 @@ As shown in the image above, the **Support bundle analysis** page includes infor
 * An analysis overview that can be filtered to show errors and warnings
 * A file inspector for more detailed analaysis
 
-From the **Support bundle analysis** page, you can also share the bundle with Replicated or download the bundle for offline analysis.
+From the **Support bundle analysis** page, you can also share the bundle with Replicated or download the bundle for offline analysis. To delete a bundle, use the options menu on the **Troubleshoot** page. For more information, see [Delete a support bundle](/vendor/support-inspecting-support-bundles#delete-a-support-bundle).
 
 For more information about using the **Support bundle analysis** page, see [Inspect Support Bundles](/vendor/support-inspecting-support-bundles).
 

--- a/docs/vendor/preflight-support-bundle-about.mdx
+++ b/docs/vendor/preflight-support-bundle-about.mdx
@@ -177,7 +177,7 @@ When customers upload their support bundle in the Enterprise Portal or Admin Con
 
 Support bundles are automatically uploaded to the Vendor Portal when customers share bundles through the Enterprise Portal or Admin Console. You can also manually upload support bundle `.tar.gz` files to the Vendor Portal.
 
-From the Vendor Portal, you have control over uploaded support bundles, including sharing bundles with Replicated or deleting previously uploaded bundles. Support bundles uploaded to the Vendor Portal are stored per Replicated's data and security standards. For more information, see [Security at Replicated](https://www.replicated.com/security).
+From the Vendor Portal, you have control over uploaded support bundles, including sharing bundles with Replicated or [deleting previously uploaded bundles](/vendor/support-inspecting-support-bundles#delete-a-support-bundle). Support bundles uploaded to the Vendor Portal are stored per Replicated's data and security standards. For more information, see [Security at Replicated](https://www.replicated.com/security).
 
 You can inspect uploaded support bundles on the Vendor Portal **Support bundle analysis** page:
 

--- a/docs/vendor/support-inspecting-support-bundles.md
+++ b/docs/vendor/support-inspecting-support-bundles.md
@@ -56,9 +56,9 @@ Deleting a support bundle is permanent and cannot be undone. If the bundle was s
 
 1. In the Vendor Portal, go to the [**Troubleshoot**](https://vendor.replicated.com/troubleshoot) page.
 
-1. Find the support bundle that you want to delete, and click the delete (trash) icon for that bundle.
+1. In the row for the support bundle that you want to delete, click the options (three-dot) menu, then click **Delete**.
 
-1. Confirm the deletion when prompted.
+1. In the **Delete bundle** dialog, click **Delete bundle** to confirm.
 
 ### Delete with the Vendor API
 

--- a/docs/vendor/support-inspecting-support-bundles.md
+++ b/docs/vendor/support-inspecting-support-bundles.md
@@ -41,3 +41,25 @@ To inspect a support bundle:
    ![Submit a Support Request](/images/support.png)
 
    [View larger version of this image](/images/support.png)
+
+## Delete a support bundle
+
+You can delete a support bundle that has been uploaded to the Vendor Portal. Deleting a bundle permanently removes it and its analysis from the Vendor Portal.
+
+Delete a bundle when it contains sensitive data that should not be retained, such as customer credentials, secrets, or other confidential information that was captured in collected logs or files.
+
+:::note
+Deleting a support bundle is permanent and cannot be undone. If the bundle was shared with Replicated as part of a support issue, deleting it removes your uploaded copy from the Vendor Portal.
+:::
+
+### Delete from the Vendor Portal
+
+1. In the Vendor Portal, go to the [**Troubleshoot**](https://vendor.replicated.com/troubleshoot) page.
+
+1. Find the support bundle that you want to delete, and click the delete (trash) icon for that bundle.
+
+1. Confirm the deletion when prompted.
+
+### Delete with the Vendor API
+
+To delete a bundle programmatically, such as for bulk cleanup or as part of an automated data-retention workflow, use the [deleteSupportBundle](https://replicated-vendor-api.readme.io/reference/deletesupportbundle) endpoint. This requires a Vendor API token with the `team/support-issues/write` RBAC policy and the ID of the bundle you want to delete. For more information about API tokens, see [Using Vendor API v3](/reference/vendor-api-using).


### PR DESCRIPTION
Preview links
* https://deploy-preview-4413--replicated-docs-upgrade.netlify.app/vendor/support-inspecting-support-bundles#delete-a-support-bundle
* xref added here https://deploy-preview-4413--replicated-docs-upgrade.netlify.app/vendor/preflight-support-bundle-about#upload-inspect

## What

Adds a **Delete a support bundle** section to `support-inspecting-support-bundles.md` covering:

- Deleting a bundle from the Vendor Portal Troubleshoot UI (row options menu → **Delete** → **Delete bundle** confirmation dialog)
- The `deleteSupportBundle` Vendor API endpoint for programmatic / bulk cleanup, with its required `team/support-issues/write` RBAC policy
- A note on when to use it (bundles containing sensitive data) and that deletion is permanent

## Why

Deleting a support bundle is supported today (Troubleshoot UI + `deleteSupportBundle` API) but was not documented anywhere on docs.replicated.com. This surfaced from a case where a vendor with live customer credentials leaked into a hosted support bundle needed to purge that data and had to be pointed at an undocumented capability.

Resolves sc-139344.

## Verification

The UI flow was verified against `vendor-web`: the control is the per-row options (three-dot) menu with a red **Delete** item (`SupportBundleRow.jsx`), and the confirmation dialog is titled **Delete bundle** with a **Delete bundle** confirm button (`DeleteBundleModal.tsx`, which fires `DELETE /supportbundle/{id}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)