### PR TITLE
Add 3.12.0-beta.1 release notes for Embedded Cluster v3

### DIFF
--- a/docs/release-notes/rn-embedded-cluster-v3.md
+++ b/docs/release-notes/rn-embedded-cluster-v3.md
@@ -12,6 +12,29 @@ Additionally, these release notes list the versions of Kubernetes that are avail
 
 <!--RELEASE_NOTES_PLACEHOLDER-->
 
+## 3.12.0-beta.1
+
+Released on August 21, 2026
+
+<table>
+  <tr>
+    <th>Version</th>
+    <td id="center">3.12.0-beta.1+k8s-1.36</td>
+    <td id="center">3.12.0-beta.1+k8s-1.35</td>
+    <td id="center">3.12.0-beta.1+k8s-1.34</td>
+  </tr>
+  <tr>
+    <th>Kubernetes Version</th>
+    <td id="center">1.36.3</td>
+    <td id="center">1.35.7</td>
+    <td id="center">1.34.10</td>
+  </tr>
+</table>
+
+### Bug fixes {#bug-fixes-3-12-0}
+
+* Tightens the permissions on the license file, which is now written as `0600` instead of `0644`. Upgrading updates the permissions on existing installations.
+
 ## 3.11.1-beta.1
 
 Released on August 11, 2026


### PR DESCRIPTION
Adds the `3.12.0-beta.1` section to the Embedded Cluster v3 release notes, covering [3.11.1-beta.1...3.12.0-beta.1](https://github.com/replicatedhq/ec/compare/3.11.1-beta.1...3.12.0-beta.1).

Kubernetes versions are taken from `pkg/versions/versions.go` at the `3.12.0-beta.1` tag (k0s `v1.36.3+k0s.0` / `v1.35.7+k0s.0` / `v1.34.10+k0s.0`) — unchanged from 3.11.x.

The disaster recovery / lifecycle handler work in this range is intentionally not documented here yet, so the release lists only the license file permissions fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)