### PR TITLE
Update CMX supported cluster versions

### DIFF
--- a/docs/vendor/testing-supported-clusters.md
+++ b/docs/vendor/testing-supported-clusters.md
@@ -276,7 +276,7 @@ CMX supports creating [AWS EKS](https://aws.amazon.com/eks/?nc2=type_a) clusters
   </tr>
   <tr>
     <th>Supported Kubernetes Versions</th>
-    <td><p>{/* START_eks_VERSIONS */}1.31, 1.32, 1.33, 1.34, 1.35, 1.36{/* END_eks_VERSIONS */}</p><p>Extended Support Versions: 1.30, 1.31, 1.32</p></td>
+    <td><p>{/* START_eks_VERSIONS */}1.31, 1.32, 1.33, 1.34, 1.35, 1.36{/* END_eks_VERSIONS */}</p><p>Extended Support Versions: 1.31, 1.32, 1.33</p></td>
   </tr>
   <tr>
     <th>Supported Instance Types</th>
@@ -321,7 +321,7 @@ CMX supports creating [Google GKE](https://cloud.google.com/kubernetes-engine) c
   </tr>
   <tr>
     <th>Supported Kubernetes Versions</th>
-    <td>{/* START_gke_VERSIONS */}1.32, 1.33, 1.34, 1.35, 1.36{/* END_gke_VERSIONS */}</td>
+    <td>{/* START_gke_VERSIONS */}1.34, 1.35, 1.36{/* END_gke_VERSIONS */}</td>
   </tr>
   <tr>
     <th>Supported Instance Types</th>


### PR DESCRIPTION
## Summary

- update the GKE support matrix from 1.32–1.36 to 1.34–1.36
- update the EKS extended-support list from 1.30–1.32 to 1.31–1.33
- audit every fixed version list on the page against the current CMX source: kind, k3s, RKE2, OpenShift, EKS, GKE, AKS, OKE, and Ubuntu all match after this change
- confirm kURL intentionally supports any promoted installer rather than a fixed version list

## Validation

- programmatically compared every version marker on `testing-supported-clusters.md` with the corresponding CMX supported-version source
- `npm run build`
- `git diff --check`

The docs build succeeded.