### PR TITLE
docs: balance on-this-page nav on Inspect support bundles page

### DIFF
--- a/docs/vendor/support-inspecting-support-bundles.md
+++ b/docs/vendor/support-inspecting-support-bundles.md
@@ -2,6 +2,8 @@
 
 You can use the Vendor Portal to get a visual analysis of customer support bundles and use the file inspector to drill down into the details and logs files. Use this information to get insights and help troubleshoot your customer issues.
 
+## Inspect a support bundle
+
 To inspect a support bundle:
 
 1. In the Vendor Portal, go to the [**Troubleshoot**](https://vendor.replicated.com/troubleshoot) page and click **Add support bundle > Upload a support bundle**.


### PR DESCRIPTION
## What

Adds an `## Inspect a support bundle` H2 above the numbered steps on the [Inspect support bundles](https://docs.replicated.com/vendor/support-inspecting-support-bundles) page.

## Why

The page's main content (inspecting a bundle) sat directly under the H1 with no H2 of its own. The only H2 was `## Delete a support bundle`, so the right-hand on-this-page nav only surfaced "Delete a support bundle" — making Delete look like the entire page when it's actually a small section at the bottom.

With this change the nav shows both **Inspect a support bundle** and **Delete a support bundle** (plus its subsections).

No existing anchors change; the intro content previously had no anchor, so there is nothing to redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)