### PR TITLE
docs(embedded-cluster): document SELinux support and hardened-image limitation for v3

### DIFF
--- a/embedded-cluster/embedded-overview.mdx
+++ b/embedded-cluster/embedded-overview.mdx
@@ -17,6 +17,8 @@ This topic provides an introduction to Replicated Embedded Cluster.
 
 * The following Replicated template functions are not supported in Embedded Cluster v3: `HasLocalRegistry`, `LocalRegistryAddress`, `LocalRegistryHost`, `LocalRegistryNamespace`, and `LocalImageName`. Use `ReplicatedImageName` and `ReplicatedImageRegistry` instead. See [Template Functions for Embedded Cluster](template-functions).
 
+* **Installing on STIG- and CIS-hardened OS images is not supported**: Embedded Cluster isn't tested on these images, and issues have arisen when trying to install on them. Embedded Cluster does install in standard SELinux environments, including SELinux in enforcing mode, by setting appropriate SELinux file contexts on the bin directory and restoring SELinux contexts for the data directory after creation.
+
 ## Built-in extensions {#built-in-extensions}
 
 The built-in extensions installed by Embedded Cluster include:


### PR DESCRIPTION
## Summary

The Embedded Cluster **v3** overview Limitations section didn't mention SELinux at all, so a v3 reader had no positive statement that installing under SELinux **enforcing** mode is supported. This fills that gap by carrying the existing v2.0.0 overview bullet forward to v3.

This is a doc *addition* (closing an omission), not a correction — nothing in the current docs was wrong. The v2.0.0 overview already correctly states 2.8.0+ installs in standard SELinux environments; v3 simply never restated it.

## Changes

- Add a Limitations bullet to `embedded-cluster/embedded-overview.mdx` stating that STIG/CIS-hardened OS images are unsupported, and that EC installs in standard SELinux environments **including enforcing mode** (via bin-dir file contexts + data-dir context restore). Drops the "2.8.0 and later" qualifier since all v3 supports it.

## Context

Prompted by a field question: *does EC support SELinux enforcing, or permissive-only?* The permissive-only behavior was real but pre-2.8.0 (the `2.1.0` release note added a preflight that failed on enforcing; `2.8.0` reversed it). Sources:
- Release notes `2.1.0` (enforcing preflight) and `2.8.0` (SELinux enablement)
- `embedded-cluster_versioned_docs/version-2.0.0/embedded-overview.mdx` (the v2 bullet this mirrors)

## UAT

1. Check out the branch, run the docs site locally.
2. Navigate to Embedded Cluster overview (v3, Beta) → Limitations.
3. Confirm the new bullet renders and reads clearly, and that the enforcing-mode statement is present.