### PR TITLE
docs(embedded-cluster): clarify EC v2 upgrade path and KOTS CLI limitation

### DIFF
--- a/embedded-cluster_versioned_docs/version-2.0.0/updating-embedded.mdx
+++ b/embedded-cluster_versioned_docs/version-2.0.0/updating-embedded.mdx
@@ -20,6 +20,12 @@ The following diagram demonstrates how updates are performed with Embedded Clust
 
 As shown in the diagram above, users check for available updates from the KOTS Admin Console. When deploying the new version, both the application and the cluster infrastructure are updated as needed.   
 
+:::note
+Embedded Cluster updates the application and the cluster infrastructure, including Kubernetes and KOTS, together. Updates must be performed using one of the methods described on this page: the Admin Console, the Enterprise Portal guided upgrade, or an air gap upload.
+
+The KOTS CLI is not a supported way to update an Embedded Cluster installation. In particular, `kots upstream upgrade` redeploys the application only and has no awareness of Embedded Cluster infrastructure, so cluster- and KOTS-level changes included in a release are not applied. Embedded Cluster v2 does not support headless or automated updates. Headless updates from the command line are available in [Embedded Cluster v3](/embedded-cluster/updating-embedded#upgrade-using-the-cli-headless).
+:::
+
 ## Update in online clusters
 
 ### Use the Enterprise Portal for a guided upgrade

--- a/embedded-cluster_versioned_docs/version-2.0.0/updating-embedded.mdx
+++ b/embedded-cluster_versioned_docs/version-2.0.0/updating-embedded.mdx
@@ -21,9 +21,11 @@ The following diagram demonstrates how updates are performed with Embedded Clust
 As shown in the diagram above, users check for available updates from the KOTS Admin Console. When deploying the new version, both the application and the cluster infrastructure are updated as needed.   
 
 :::note
-Embedded Cluster updates the application and the cluster infrastructure, including Kubernetes and KOTS, together. Updates must be performed using one of the methods described on this page: the Admin Console, the Enterprise Portal guided upgrade, or an air gap upload.
+Embedded Cluster installs and upgrades the cluster infrastructure (including Kubernetes and KOTS) and the application together, as a single lifecycle. Because there is no separately managed KOTS layer to upgrade on its own, the KOTS CLI is intentionally not included in the Embedded Cluster package.
 
-The KOTS CLI is not a supported way to update an Embedded Cluster installation. In particular, `kots upstream upgrade` redeploys the application only and has no awareness of Embedded Cluster infrastructure, so cluster- and KOTS-level changes included in a release are not applied. Embedded Cluster v2 does not support headless or automated updates. Headless updates from the command line are available in [Embedded Cluster v3](/embedded-cluster/updating-embedded#upgrade-using-the-cli-headless).
+Updates must be performed using one of the methods described on this page: the Admin Console, the Enterprise Portal guided upgrade, or an air gap upload. If you install the standalone KOTS CLI separately and run it against an Embedded Cluster installation, commands such as `kots upstream upgrade` act on the application layer only and do not upgrade the cluster infrastructure, so infrastructure- and KOTS-level changes in a release are not applied.
+
+Embedded Cluster v2 does not support headless or automated updates. Headless updates from the command line are available in [Embedded Cluster v3](/embedded-cluster/updating-embedded#upgrade-using-the-cli-headless).
 :::
 
 ## Update in online clusters

--- a/embedded-cluster_versioned_docs/version-2.0.0/updating-embedded.mdx
+++ b/embedded-cluster_versioned_docs/version-2.0.0/updating-embedded.mdx
@@ -21,9 +21,9 @@ The following diagram demonstrates how updates are performed with Embedded Clust
 As shown in the diagram above, users check for available updates from the KOTS Admin Console. When deploying the new version, both the application and the cluster infrastructure are updated as needed.   
 
 :::note
-Embedded Cluster installs and upgrades the cluster infrastructure (including Kubernetes and KOTS) and the application together, as a single lifecycle. Because there is no separately managed KOTS layer to upgrade on its own, the KOTS CLI is intentionally not included in the Embedded Cluster package.
+Embedded Cluster installs and upgrades the cluster infrastructure (including Kubernetes and KOTS) and the application together, as a single lifecycle. Embedded Cluster does not expose a supported, user-facing KOTS CLI for managing installs or updates; KOTS is managed by Embedded Cluster itself. Updates must be performed using one of the methods described on this page: the Admin Console, the Enterprise Portal guided upgrade, or an air gap upload.
 
-Updates must be performed using one of the methods described on this page: the Admin Console, the Enterprise Portal guided upgrade, or an air gap upload. If you install the standalone KOTS CLI separately and run it against an Embedded Cluster installation, commands such as `kots upstream upgrade` act on the application layer only and do not upgrade the cluster infrastructure, so infrastructure- and KOTS-level changes in a release are not applied.
+If you separately install the standalone KOTS CLI and run it against an Embedded Cluster installation, commands such as `kots upstream upgrade` act on the application layer only and do not upgrade the cluster infrastructure, so infrastructure- and KOTS-level changes in a release are not applied.
 
 Embedded Cluster v2 does not support headless or automated updates. Headless updates from the command line are available in [Embedded Cluster v3](/embedded-cluster/updating-embedded#upgrade-using-the-cli-headless).
 :::

--- a/embedded-cluster_versioned_docs/version-2.0.0/updating-embedded.mdx
+++ b/embedded-cluster_versioned_docs/version-2.0.0/updating-embedded.mdx
@@ -25,7 +25,7 @@ Embedded Cluster installs and upgrades the cluster infrastructure (including Kub
 
 If you separately install the standalone KOTS CLI and run it against an Embedded Cluster installation, commands such as `kots upstream upgrade` act on the application layer only and do not upgrade the cluster infrastructure, so infrastructure- and KOTS-level changes in a release are not applied.
 
-Embedded Cluster v2 does not support headless or automated updates. Headless updates from the command line are available in [Embedded Cluster v3](/embedded-cluster/updating-embedded#upgrade-using-the-cli-headless).
+Embedded Cluster v2 does not support headless or automated updates. Headless updates from the command line are available in [Embedded Cluster v3](/embedded-cluster/v3/updating-embedded#upgrade-using-the-cli-headless).
 :::
 
 ## Update in online clusters


### PR DESCRIPTION
Preview https://deploy-preview-4443--replicated-docs-upgrade.netlify.app/embedded-cluster/v2/updating-embedded#overview

## Summary

Makes explicit that in Embedded Cluster the cluster infrastructure and the application are installed and upgraded together as a single lifecycle, and that Embedded Cluster does not expose a supported, user-facing KOTS CLI. A field question surfaced that a customer, using a separately installed KOTS CLI, scripted upgrades with `kots upstream upgrade --deploy` and silently upgraded only the application layer, never the cluster infrastructure (Kubernetes/KOTS). The command appears to succeed, so the gap is easy to miss.

## Changes

`embedded-cluster_versioned_docs/version-2.0.0/updating-embedded.mdx`:
- Add a `:::note` to the Overview section: EC installs and upgrades infrastructure (Kubernetes and KOTS) and the application together as one lifecycle, and does not expose a supported, user-facing KOTS CLI (KOTS is managed by EC itself).
- State the supported upgrade paths (Admin Console, Enterprise Portal guided upgrade, air gap upload).
- Clarify that a separately installed standalone KOTS CLI pointed at an EC install (`kots upstream upgrade`) acts on the application layer only and does not apply infrastructure- or KOTS-level changes.
- Note that EC v2 has no headless/automated upgrade path, and point to the EC v3 headless CLI upgrade for that use case.

## Accuracy note (verified against embedded-cluster code)

Wording was checked against the EC v2 source. KOTS is embedded but internal-only: `kubectl-kots` lives in `cmd/installer/goods/internal/bins` and is materialized to a temporary path for internal use and deleted after, unlike the user-facing binaries (k0s, helm, kubectl, preflight, support-bundle) written to the embedded-cluster binaries directory. The `shell` command only adds that user binaries directory to PATH, so it does not surface kots, and there is no user-facing `upgrade` or `headless` command in the v2 CLI. The note therefore says KOTS is not exposed as a user-facing CLI, rather than claiming it is absent from the package.

## Why

The behavior is intended, but nothing in the docs explained the shared infra+app lifecycle or that the KOTS CLI is not a supported user-facing interface. Without that, a customer could reasonably bring their own KOTS CLI and script upgrades that silently miss infrastructure-level changes, including security fixes delivered in a release. This closes that documentation gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)