### PR TITLE
docs(ep-v2): document hidden: true page frontmatter

### DIFF
--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -105,10 +105,10 @@ The `toc.yaml` file at the root of your repo defines the sidebar navigation. Eac
 
 Every item also supports `icon` and `visible_when` (see [Visibility](#visibility) below).
 
-The `toc.yaml` acts as an allowlist: pages that exist in your repo but are not listed in `toc.yaml` are not reachable through the portal navigation or direct URL. This means you can hide a page by simply omitting it from `toc.yaml`.
+The `toc.yaml` acts as an allowlist: pages that exist in your repo but are not listed in `toc.yaml` are not reachable through the portal navigation or direct URL. Omitting a page from `toc.yaml` hides it entirely. To keep the page in the repo and listed in the TOC without publishing it, set `hidden: true` in the page frontmatter. See [Hide unpublished pages](#hide-unpublished-pages).
 
 :::note
-The `overrides.home` page bypasses the TOC allowlist and remains accessible even if it is not listed in `toc.yaml`. If you need to hide the home page, use `visible_when` in its frontmatter instead.
+The `overrides.home` page bypasses the TOC allowlist and remains accessible even if it is not listed in `toc.yaml`. To hide the home landing page, set `hidden: true` or `visible_when` in its frontmatter. `overrides.home` cannot restore a hidden page or a child of a hidden parent.
 :::
 
 Supported icon values: `rocket`, `download`, `cloud`, `settings`, `wrench`, `life-buoy`, `file-text`, `star`, `book`, `shield`, `package`, `refresh-cw`, `database`, `key`. If omitted, defaults to `book`.
@@ -182,6 +182,8 @@ navigation:
 In this example, **Configuration** expands to show **Required Values** and **Optional Values**. **Required Values** further expands to show **Authentication** and **Networking**. Each level is collapsible in the sidebar.
 
 Any item with `items` can also have its own `page`, `visible_when`, and `icon`. If all children of a parent are hidden by `visible_when`, the parent is also hidden automatically.
+
+If a TOC node has a `page` with `hidden: true`, the portal drops that node and its subtree, including nested `helm_chart` and `terraform_module` items. A section that is only a title (no `page`) cannot use `hidden`. For more information, see [Hide unpublished pages](#hide-unpublished-pages).
 
 ### External links {#external-links}
 
@@ -610,7 +612,7 @@ For production deployments, enable HA mode...
 
 ## Visibility {#visibility}
 
-Use `visible_when` to control which customers see which content. All conditions must be satisfied (AND logic).
+Use `visible_when` to control which customers see which content. All conditions must be satisfied (AND logic). To keep a page unpublished for every customer, set `hidden: true` in the page frontmatter. `hidden` is not a license or entitlement gate. See [Hide unpublished pages](#hide-unpublished-pages).
 
 ### Navigation visibility (toc.yaml)
 
@@ -631,7 +633,7 @@ Apply `visible_when` on any navigation item in `toc.yaml`:
 
 All three filter types (`entitlements`, `channel`, and `customer_type`) are fully evaluated server-side. Unrecognized filter dimensions are rejected (fail closed).
 
-To hide a page entirely, you can also omit it from `toc.yaml`. Pages not listed in the TOC are not reachable through navigation or direct URL (see [Table of contents](#table-of-contents) above).
+To hide a page entirely, you can also omit it from `toc.yaml`. Pages not listed in the TOC are not reachable through navigation or direct URL (see [Table of contents](#table-of-contents) above). To keep the page listed in `toc.yaml` but unpublished, use `hidden: true` in the page frontmatter instead.
 
 #### Per-user permissions in visible_when
 
@@ -701,7 +703,7 @@ Like `channel`, `customer_type` supports both `include` and `exclude` lists.
 
 ### Page-level visibility (frontmatter)
 
-You can also apply `visible_when` in a page's YAML frontmatter. This adds a per-page access gate on top of the navigation rules in `toc.yaml`.
+You can also apply `visible_when` or `hidden: true` in a page's YAML frontmatter. `visible_when` adds a per-page access gate on top of the navigation rules in `toc.yaml`. `hidden: true` keeps the page unpublished for every customer.
 
 ```markdown
 ---
@@ -719,6 +721,42 @@ Ensure your environment meets these requirements...
 The same `entitlements` conditions available in `toc.yaml` work in frontmatter, including built-in entitlements, custom license fields, and per-user permissions. Use this when you want to keep the gating condition on the page itself rather than on its `toc.yaml` navigation entry.
 
 Frontmatter `visible_when` is an additional gate, not a replacement for navigation. A page must still be reachable through the navigation (or declared as an `overrides` target) for a customer to access it directly. A page that is not referenced anywhere in `toc.yaml` is not accessible, regardless of its frontmatter.
+
+#### Hide unpublished pages {#hide-unpublished-pages}
+
+To keep a page in the repo and listed in `toc.yaml` without publishing it, set `hidden: true` in the page YAML frontmatter. Put `hidden` on the markdown page, not on `toc.yaml`.
+
+```markdown
+---
+title: Q3 announcement
+hidden: true
+---
+```
+
+Keep the page listed in `toc.yaml` as a normal page entry:
+
+```yaml
+- title: Q3 announcement
+  page: pages/announcements/q3.md
+```
+
+Customers do not see the page until you remove `hidden` or set it to `false`, then re-sync the content.
+
+`hidden: true` marks unpublished content. It is not a license or entitlement gate. `visible_when` for built-in entitlements, custom license fields, and permissions is unchanged. `hidden: true` takes precedence over `visible_when`. Even if the customer would pass `visible_when`, the page stays unpublished. Entitlements cannot unhide it.
+
+If a TOC node has a `page` with `hidden: true`, the portal drops that node and its subtree. The subtree includes child pages, nested `helm_chart` items, and `terraform_module` items. This is the same ancestor-gating behavior as `visible_when` on a parent.
+
+A section that is only a title (no `page`) cannot use `hidden`. Set `hidden` on each child page, or use `visible_when` on the TOC node.
+
+`overrides.home` cannot restore a hidden page or a child of a hidden parent. To hide the home landing page, set `hidden: true` on that page.
+
+Omitting a page from `toc.yaml` still hides it entirely. Use `hidden` when you want to keep the page in the TOC and publish it later.
+
+:::note
+If you sync `hidden` against an Enterprise Portal binary that does not support it, the portal drops unknown YAML keys. After a binary that supports `hidden` is deployed, re-sync so the flag is stored.
+
+Local preview matches production. Hidden pages are also hidden in preview.
+:::
 
 ## Downloadable assets
 
@@ -753,7 +791,7 @@ The tag expands to a URL that authenticates the customer via their session and s
 The path inside the tag is relative to the repo root and must start with `assets/`.
 
 :::note
-Any asset referenced by an `\{\{asset\}\}` tag on a page that a customer can see is downloadable by that customer. Asset access is controlled by the visibility of the page that references them, not by the file path or directory structure. If you need to restrict an asset to specific customers, use template conditionals (like `\{\{#ifEquals customer.name\}\}`) around the asset reference, or place the asset reference on a page gated with `visible_when`. See the example below.
+Any asset referenced by an `\{\{asset\}\}` tag on a page that a customer can see is downloadable by that customer. Asset access is controlled by the visibility of the page that references them, not by the file path or directory structure. A page with `hidden: true` does not authorize asset downloads. If you need to restrict an asset to specific customers, use template conditionals (like `\{\{#ifEquals customer.name\}\}`) around the asset reference, or place the asset reference on a page gated with `visible_when`. See the example below.
 :::
 
 ### Per-customer asset delivery

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -724,7 +724,11 @@ Frontmatter `visible_when` is an additional gate, not a replacement for navigati
 
 #### Hide unpublished pages {#hide-unpublished-pages}
 
-To keep a page in the repo and listed in `toc.yaml` without publishing it, set `hidden: true` in the page YAML frontmatter. Put `hidden` on the markdown page, not on `toc.yaml`.
+`hidden` controls whether a page is published, not who can see it. Use `visible_when` to show a page to some customers and not others based on their license. Use `hidden: true` to keep a page out of every customer's portal until you are ready to publish it, regardless of license.
+
+Set `hidden: true` in a page's YAML frontmatter when the page belongs in your content repo but is not ready for customers yet. For example, stage a product announcement, a new install guide, or a revised section next to your live docs, keep its entry in `toc.yaml` so local preview shows where it sits in the navigation, then publish it by removing the flag when you are ready. Draft pages stay under version control in the same repo and pull request flow as your published content, so nothing lives in a stray branch or an unwired file you have to remember later.
+
+Put `hidden` on the markdown page, not on `toc.yaml`.
 
 ```markdown
 ---

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -726,7 +726,7 @@ Frontmatter `visible_when` is an additional gate, not a replacement for navigati
 
 `hidden` controls whether a page is published, not who can see it. Use `visible_when` to show a page to some customers and not others based on their license. Use `hidden: true` to keep a page out of every customer's portal until you are ready to publish it, regardless of license.
 
-Set `hidden: true` in a page's YAML frontmatter when the page belongs in your content repo but is not ready for customers yet. For example, stage a product announcement, a new install guide, or a revised section next to your live docs, keep its entry in `toc.yaml` so local preview shows where it sits in the navigation, then publish it by removing the flag when you are ready. Draft pages stay under version control in the same repo and pull request flow as your published content, so nothing lives in a stray branch or an unwired file you have to remember later.
+Set `hidden: true` in a page's YAML frontmatter when the page belongs in your content repo but is not ready for customers yet. For example, stage a product announcement, a new install guide, or a revised section next to your live docs, then publish it by removing the flag when you are ready. Keep the page listed in `toc.yaml` while it is hidden so the navigation slot is already wired when you publish, rather than leaving the draft in a stray branch or an unwired file you have to remember later. Local preview hides the page the same as production, so it does not appear in the preview sidebar while `hidden` is set.
 
 Put `hidden` on the markdown page, not on `toc.yaml`.
 
@@ -758,8 +758,6 @@ Omitting a page from `toc.yaml` still hides it entirely. Use `hidden` when you w
 
 :::note
 If you sync `hidden` against an Enterprise Portal binary that does not support it, the portal drops unknown YAML keys. After a binary that supports `hidden` is deployed, re-sync so the flag is stored.
-
-Local preview matches production. Hidden pages are also hidden in preview.
 :::
 
 ## Downloadable assets

--- a/docs/vendor/enterprise-portal-v2-troubleshooting.mdx
+++ b/docs/vendor/enterprise-portal-v2-troubleshooting.mdx
@@ -39,6 +39,7 @@ See [Manage Content Versions](/vendor/enterprise-portal-v2-versioned-docs) for h
 - Verify visibility rules (entitlements, channels)
 - Check frontmatter `visible_when` conditions
 - Confirm the page frontmatter does not set `hidden: true`. Hidden pages stay unpublished for every customer, including in local preview
+- Confirm the page frontmatter parses as valid YAML. Frontmatter that Enterprise Portal cannot parse is treated as unpublished, so the page is hidden from every customer, including in local preview
 - Confirm customer has required entitlements enabled
 
 ## Local preview "Page not found"

--- a/docs/vendor/enterprise-portal-v2-troubleshooting.mdx
+++ b/docs/vendor/enterprise-portal-v2-troubleshooting.mdx
@@ -38,6 +38,7 @@ See [Manage Content Versions](/vendor/enterprise-portal-v2-versioned-docs) for h
 - Ensure file path matches `toc.yaml` reference
 - Verify visibility rules (entitlements, channels)
 - Check frontmatter `visible_when` conditions
+- Confirm the page frontmatter does not set `hidden: true`. Hidden pages stay unpublished for every customer, including in local preview
 - Confirm customer has required entitlements enabled
 
 ## Local preview "Page not found"

--- a/docs/vendor/enterprise-portal-v2-troubleshooting.mdx
+++ b/docs/vendor/enterprise-portal-v2-troubleshooting.mdx
@@ -39,7 +39,7 @@ See [Manage Content Versions](/vendor/enterprise-portal-v2-versioned-docs) for h
 - Verify visibility rules (entitlements, channels)
 - Check frontmatter `visible_when` conditions
 - Confirm the page frontmatter does not set `hidden: true`. Hidden pages stay unpublished for every customer, including in local preview
-- Confirm the page frontmatter parses as valid YAML. Frontmatter that Enterprise Portal cannot parse is treated as unpublished, so the page is hidden from every customer, including in local preview
+- Confirm the page frontmatter is valid YAML. Invalid YAML is treated as unpublished, so the page is hidden from every customer, including in local preview
 - Confirm customer has required entitlements enabled
 
 ## Local preview "Page not found"

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -37,7 +37,7 @@ Once logged in, customers see a sidebar with the navigation defined by the vendo
 - **Updates**: Check for updates and follow upgrade instructions
 - **Support**: FAQ and contact support information
 
-The vendor controls which sections and pages appear for each customer through entitlements and `visible_when` rules. Customers only see content relevant to their license.
+The vendor controls which sections and pages appear for each customer through entitlements, `visible_when` rules, and unpublished pages marked `hidden: true`. Customers only see published content that is relevant to their license.
 
 A **version dropdown** in the header lets customers switch between documentation versions when multiple are available on their channel.
 


### PR DESCRIPTION
## Summary

Document Enterprise Portal v2 page frontmatter `hidden: true` so vendors can keep a page in the content repo and `toc.yaml` without publishing it.

Implements docs for [sc-138380](https://app.shortcut.com/replicated/story/138380). Implementation: [vandoor#10449](https://github.com/replicatedhq/vandoor/pull/10449).

## Why

Vendors could omit a page from `toc.yaml` or gate it with `visible_when`, but there was no documented way to leave the nav slot in place and keep the page unpublished. `hidden: true` is unpublished content, not a license or entitlement gate. It takes precedence over `visible_when`.

## Changes

- `enterprise-portal-v2-content.mdx`
  - Distinguish omitting a page from `toc.yaml` (allowlist) from `hidden: true` (keep the TOC entry, unpublished)
  - Note that `overrides.home` cannot restore a hidden page, and `hidden: true` can hide the home landing page
  - Nested nav: a TOC node whose `page` is hidden is dropped with its subtree; title-only sections cannot use `hidden`
  - Add `hidden: true` next to frontmatter `visible_when`, with a page example and a matching `toc.yaml` entry
  - Asset access: a hidden page does not authorize downloads
- `enterprise-portal-v2-troubleshooting.mdx` — pages missing from navigation can be unpublished with `hidden: true`
- `enterprise-portal-v2-use.mdx` — customer-facing nav also respects unpublished pages

No changes to `enterprise-portal-v2-versioned-docs.mdx`. Hiding `main` as a draft branch is a different feature.

## Validation

- `git diff --check`
- Did not run Vale or a Docusaurus build locally