### PR TITLE
docs(release-notes): backfill KOTS 1.131.1 and stub no-note releases

### DIFF
--- a/docs/release-notes/rn-app-manager.md
+++ b/docs/release-notes/rn-app-manager.md
@@ -73,6 +73,14 @@ Support for Kubernetes: 1.34, 1.35, and 1.36
 * Resolves following High level CVEs: CVE-2026-27145, CVE-2026-39822, CVE-2026-42504, GHSA-5p4m-2wfm-xmqj, GHSA-2v37-7h3g-55p8.
 * Resolves following Medium level CVEs: CVE-2026-42505, CVE-2026-42507, GHSA-55q2-fjhq-7xh7.
 
+## 1.131.1
+
+Released on August 7, 2026
+
+Support for Kubernetes: 1.34, 1.35, and 1.36
+
+This release contained internal maintenance changes only, such as dependency and packaging updates, and includes no user-facing features, improvements, or bug fixes.
+
 ## 1.131.0
 
 Released on August 6, 2026

--- a/scripts/ci/release-notes.sh
+++ b/scripts/ci/release-notes.sh
@@ -119,8 +119,15 @@ else
 fi
 
 if [[ "$manual_table" == "none" && ! -s "$generated_file" ]]; then
-  echo "The release-notes generator returned no notes; no PR is needed."
-  exit 0
+  echo "The release-notes generator returned no notes; writing a maintenance-only stub entry so the version is still listed."
+  {
+    echo "## $title"
+    echo
+    echo "Released on $(date +'%B %-d, %Y')"
+    echo
+    echo "This release contained internal maintenance changes only, such as dependency and packaging updates, and includes no user-facing features, improvements, or bug fixes."
+    echo
+  } > "$generated_file"
 fi
 
 case "$manual_table" in


### PR DESCRIPTION
## Problem

The KOTS **1.131.1** release is missing from the [App Manager release notes](https://docs.replicated.com/release-notes/rn-app-manager) — the page jumps from 1.131.2 straight to 1.131.0, leaving a visible version gap.

Reported by a customer via `replicated-collab/swaggerhub-kots#567`.

## Root cause

`scripts/ci/release-notes.sh` skips any release whose changes carry no user-facing release-note labels:

```bash
if [[ "$manual_table" == "none" && ! -s "$generated_file" ]]; then
  echo "The release-notes generator returned no notes; no PR is needed."
  exit 0
fi
```

KOTS 1.131.1's only change was a docs/packaging commit ([kots#6009](https://github.com/replicatedhq/kots/pull/6009), "Drop troubleshoot.sh/v1beta3 docs from release files"), so the generator produced no notes and the version was never added. This affects the App Manager notes specifically (`manual_table=none`); the same gap exists for other maintenance-only releases (e.g. 1.130.8).

## Changes

1. **Backfill 1.131.1** into `rn-app-manager.md` as a maintenance-only entry, matching the surrounding format and Kubernetes support line (1.34, 1.35, 1.36). Date is the release's published date (2026-08-07 UTC).
2. **Fix the generator** so that when it returns no notes for a `none`-table product (App Manager), it emits a minimal maintenance-only stub entry instead of skipping the release — keeping future no-note versions listed. This mirrors the existing embedded-cluster stub path (both use the CI run date via `date`).

## Notes / open questions

- The stub deliberately omits a "Support for Kubernetes" line because that value isn't available when the generator produces no notes, and the script's hardcoded fallback `description` is stale. Reviewers may prefer to source it another way — happy to adjust.
- **1.130.8** is an identical pre-existing gap from the same cause. This PR does not backfill it (scoped to the reported version); the generator fix only prevents *future* gaps. Say the word and I'll add 1.130.8 here too.