### PR TITLE
docs(release-notes): backfill KOTS 1.131.1 and 1.130.8

### DIFF
--- a/docs/release-notes/rn-app-manager.md
+++ b/docs/release-notes/rn-app-manager.md
@@ -79,7 +79,7 @@ Released on August 7, 2026
 
 Support for Kubernetes: 1.34, 1.35, and 1.36
 
-This release contained internal maintenance changes only, such as dependency and packaging updates, and includes no user-facing features, improvements, or bug fixes.
+This release contained internal release-packaging changes only and includes no user-facing features, improvements, or bug fixes.
 
 ## 1.131.0
 
@@ -116,7 +116,7 @@ Released on July 16, 2026
 
 Support for Kubernetes: 1.34, 1.35, and 1.36
 
-This release contained internal maintenance changes only, such as dependency and packaging updates, and includes no user-facing features, improvements, or bug fixes.
+This release contained routine dependency and tooling updates only and includes no user-facing features, improvements, or bug fixes.
 
 ## 1.130.7
 

--- a/docs/release-notes/rn-app-manager.md
+++ b/docs/release-notes/rn-app-manager.md
@@ -73,6 +73,14 @@ Support for Kubernetes: 1.34, 1.35, and 1.36
 * Resolves following High level CVEs: CVE-2026-27145, CVE-2026-39822, CVE-2026-42504, GHSA-5p4m-2wfm-xmqj, GHSA-2v37-7h3g-55p8.
 * Resolves following Medium level CVEs: CVE-2026-42505, CVE-2026-42507, GHSA-55q2-fjhq-7xh7.
 
+## 1.131.1
+
+Released on August 7, 2026
+
+Support for Kubernetes: 1.34, 1.35, and 1.36
+
+This release contained internal maintenance changes only, such as dependency and packaging updates, and includes no user-facing features, improvements, or bug fixes.
+
 ## 1.131.0
 
 Released on August 6, 2026
@@ -101,6 +109,14 @@ Support for Kubernetes: 1.34, 1.35, and 1.36
 
 ### Bug fixes {#bug-fixes-1-130-9}
 * Fixes a path traversal vulnerability (tar-slip) in archive extraction
+
+## 1.130.8
+
+Released on July 16, 2026
+
+Support for Kubernetes: 1.34, 1.35, and 1.36
+
+This release contained internal maintenance changes only, such as dependency and packaging updates, and includes no user-facing features, improvements, or bug fixes.
 
 ## 1.130.7
 


### PR DESCRIPTION
## Problem

Two KOTS versions are missing from the [App Manager release notes](https://docs.replicated.com/release-notes/rn-app-manager), leaving visible gaps in the version history:

- **1.131.1** — page jumps from 1.131.2 to 1.131.0
- **1.130.8** — page jumps from 1.130.9 to 1.130.7

1.131.1 was reported by a customer via `replicated-collab/swaggerhub-kots#567`.

## Why they're missing

Both were maintenance-only releases (dependency, security, and packaging updates) with no user-facing features, bug fixes, or improvements. The automated release-notes generator produced no content for them, so no entry was ever added.

## Change

Backfill both versions as maintenance-only entries, matching the surrounding format and Kubernetes support line (1.34, 1.35, and 1.36). Dates are each release's published date (1.131.1: 2026-08-07 UTC; 1.130.8: 2026-07-16 UTC).

Docs-only change — no automation/script changes.