### PR TITLE
Add replicated-software-factory bot as CODEOWNER for release notes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 *   @replicatedhq/replicated-docs
+docs/release-notes/ @replicatedhq/replicated-docs @replicated-software-factory[bot]


### PR DESCRIPTION
## Summary

Adds `@replicated-software-factory[bot]` as a CODEOWNER for the `docs/release-notes/` directory, alongside the existing docs team.

## Why

This allows the replicated-software-factory app to be automatically requested as a reviewer on release notes PRs, so release-note automation can be required to review and approve changes before merge.

## Changes

- `CODEOWNERS`: add `docs/release-notes/ @replicatedhq/replicated-docs @replicated-software-factory[bot]`

## Deployment note

GitHub may report that `@replicated-software-factory[bot]` is an unknown owner until the bot is granted **write access** to this repository. The bot user exists (`type: Bot`), but CODEOWNERS requires every owner to have write access. To resolve this, add the bot as a collaborator with at least **Write** permission (or ensure the installed GitHub App has the necessary repository permissions).
