### PR TITLE
docs: state Enterprise Portal must be enabled before Login as customer works

### DIFF
--- a/docs/vendor/customer-reporting.md
+++ b/docs/vendor/customer-reporting.md
@@ -79,6 +79,7 @@ The following shows an example of the **Enterprise Portal** section:
 
 From the **Enterprise Portal** section, you can:
 * Click **View** to access the unique Enterprise Portal for the customer
+* Click **Login as customer** to open the production Enterprise Portal as that customer, for verifying content, entitlements, and branding. For more information, see [Login as customer](/vendor/enterprise-portal-v2-access#login-as-customer).
 * View the status of the customer's access to the Enterprise Portal
 * View the timestamp when the Enterprise Portal was most recently accessed by the customer
 * View the number of users with Enterprise Portal accounts

--- a/docs/vendor/enterprise-portal-v2-access.mdx
+++ b/docs/vendor/enterprise-portal-v2-access.mdx
@@ -57,6 +57,10 @@ The local preview mocks some backend endpoints locally. Install flows, instance 
 
 To view the production Enterprise Portal as a specific customer, use the **Login as customer** button on the customer's **Enterprise Portal access** tab (or the EP card on the customer's Reporting page). This generates a one-time login link and opens the portal in a new tab.
 
+:::note
+**Login as customer** requires the Enterprise Portal to be enabled for the customer. Turn on the **Enable Enterprise Portal for this customer** toggle on the customer's **Enterprise Portal access** tab first. For more information, see [Manage Customer Access](/vendor/enterprise-portal-v2-invite). Without it, **Login as customer** does not produce a logged-in session. Teams using only the new Enterprise Portal have access enabled for all customers, so no per-customer toggle is required.
+:::
+
 This is useful for verifying that a customer sees the correct content, entitlements, and branding without creating a permanent user account in their portal team. The system creates a temporary system user scoped to that customer and generates a magic link nonce that expires after 10 minutes.
 
 The login routes to the correct portal version automatically. If the customer is on the new Enterprise Portal, the link opens `{appSlug}.enterpriseportal.app` (or your custom domain). If the customer is on Classic, the link opens `get.replicated.com`.


### PR DESCRIPTION
Docs portion of sc-139449.

## What
- Add a prerequisite note to the **Login as customer** section in `enterprise-portal-v2-access.mdx`, pointing at the **Enable Enterprise Portal for this customer** toggle and the Manage Customer Access doc.
- Add a discoverability cross-link to the **Login as customer** feature from the Enterprise Portal section of the customer Reporting page (`customer-reporting.md`), since the button lives on that card.

These document **existing product behavior**: the Enterprise Portal must be enabled for a customer for Login as customer to produce a logged-in session. Without it, the link lands on the portal login screen.

## Related (not a blocker)
sc-139448 separately improves the in-product UX (disable the button with an inline explanation when the Enterprise Portal is off). It does not block this PR. When it ships, the note wording can optionally be aligned with the exact in-product message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)