### PR TITLE
docs: state that install mode is fixed at install time

### DIFF
--- a/docs/enterprise/installing-existing-cluster-airgapped.mdx
+++ b/docs/enterprise/installing-existing-cluster-airgapped.mdx
@@ -13,6 +13,7 @@ import PushKotsImages from "../partials/install/_push-kotsadm-images.mdx"
 import PlaceholderRoCreds from "../partials/install/_placeholder-ro-creds.mdx"
 import KotsVersionMatch from "../partials/install/_kots-airgap-version-match.mdx"
 import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+import InstallModeFixed from "../partials/install/_install-mode-fixed.mdx"
 
 # Air gap installation in existing clusters with KOTS
 
@@ -21,6 +22,8 @@ This topic describes how to use Replicated KOTS to install an application in an 
 <IntroAirGap/>
 
 <KotsAvailability/>
+
+<InstallModeFixed/>
 
 ## Prerequisites
 

--- a/docs/enterprise/installing-existing-cluster.mdx
+++ b/docs/enterprise/installing-existing-cluster.mdx
@@ -3,12 +3,15 @@ import LicenseFile from "../partials/install/_license-file-prereq.mdx"
 import InstallCommandPrompts from "../partials/install/_kots-install-prompts.mdx"
 import AppNameUI from "../partials/install/_placeholder-app-name-UI.mdx"
 import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+import InstallModeFixed from "../partials/install/_install-mode-fixed.mdx"
 
 # Online installation in existing clusters with KOTS
 
 This topic describes how to use Replicated KOTS to install an application in an existing Kubernetes cluster.
 
 <KotsAvailability/>
+
+<InstallModeFixed/>
 
 ## Prerequisites
 

--- a/docs/enterprise/installing-kurl-airgap.mdx
+++ b/docs/enterprise/installing-kurl-airgap.mdx
@@ -11,6 +11,7 @@ import LoginPassword from "../partials/install/_embedded-login-password.mdx"
 import DownloadKurlBundle from "../partials/install/_download-kurl-bundle.mdx"
 import ExtractKurlBundle from "../partials/install/_extract-kurl-bundle.mdx"
 import KurlAvailability from "../partials/kurl/_kurl-availability.mdx"
+import InstallModeFixed from "../partials/install/_install-mode-fixed.mdx"
 
 # Air gap installation with kURL
 
@@ -21,6 +22,8 @@ The procedures in this topic apply to installation environments that do not have
 <KurlAbout/>
 
 <KurlAvailability/>
+
+<InstallModeFixed/>
 
 ## Prerequisites
 

--- a/docs/enterprise/updating-app-manager.mdx
+++ b/docs/enterprise/updating-app-manager.mdx
@@ -5,6 +5,7 @@ import BuildAirGapBundle from "../partials/install/_airgap-bundle-build.mdx"
 import DownloadAirGapBundle from "../partials/install/_airgap-bundle-download.mdx"
 import ViewAirGapBundle from "../partials/install/_airgap-bundle-view-contents.mdx"
 import KotsAvailability from "../partials/kots/_kots-availability.mdx"
+import InstallModeFixed from "../partials/install/_install-mode-fixed.mdx"
 
 # Perform updates in existing clusters
 
@@ -13,6 +14,8 @@ This topic describes how to perform updates in existing cluster installations wi
 It also includes information about how the Admin Console determines version precendence. See [How the Admin Console Determines Version Precendence](/enterprise/updating-app-manager#how-the-admin-console-determines-version-precedence).
 
 <KotsAvailability/>
+
+<InstallModeFixed/>
 
 ## Update an application
 

--- a/docs/enterprise/updating-kurl.mdx
+++ b/docs/enterprise/updating-kurl.mdx
@@ -4,6 +4,7 @@ import AdminConsole from "../partials/updating/_admin-console.mdx"
 import AdminConsoleAirGap from "../partials/updating/_admin-console-air-gap.mdx"
 import DownloadKurlBundle from "../partials/install/_download-kurl-bundle.mdx"
 import KurlAvailability from "../partials/kurl/_kurl-availability.mdx"
+import InstallModeFixed from "../partials/install/_install-mode-fixed.mdx"
 
 # Perform updates in kURL clusters
 
@@ -12,6 +13,8 @@ import KurlAvailability from "../partials/kurl/_kurl-availability.mdx"
 This topic describes how to perform updates in Replicated kURL installations. It includes procedures for updating an application, as well as for updating the versions of Kubernetes, Replicated KOTS, and add-ons in a kURL cluster.
 
 For more information about managing nodes in kURL clusters, including how to safely reset, reboot, and remove nodes when performing maintenance tasks, see [Manage Nodes](https://kurl.sh/docs/install-with-kurl/managing-nodes) in the open source kURL documentation.
+
+<InstallModeFixed/>
 
 ## Update an application
 

--- a/docs/partials/install/_install-mode-fixed.mdx
+++ b/docs/partials/install/_install-mode-fixed.mdx
@@ -1,0 +1,3 @@
+:::note
+Choose the installation mode when you install the application. You cannot change the mode later. An instance installed in an online environment receives updates over the internet and cannot accept an air gap bundle. An instance installed in an air gap environment requires an air gap bundle for each update and does not check for new versions over the internet. To change the mode, reinstall the application in the target mode.
+:::

--- a/docs/vendor/replicated-onboarding-air-gap.mdx
+++ b/docs/vendor/replicated-onboarding-air-gap.mdx
@@ -38,7 +38,7 @@ By default, licenses support online installations only. You can control which of
 * **Helm CLI Air Gap Instructions (Helm CLI only)**: When enabled, a customer will see instructions in the Enterprise Portal for how to pull images into their local repository. This entitlement applies to Helm CLI installations only.
 * **Air Gap Installation Option (Replicated Installers only)**: When enabled, new installations with this license show an option to install from an air gap bundle. This entitlement applies to Replicated installers only.
 
-Licenses with these air gap entitlements support both air gap and online installations.
+Licenses with these air gap entitlements support both air gap and online installations. The customer chooses the mode for each installation, and the mode cannot change afterward. An instance installed in an online environment cannot later accept an air gap bundle. An instance installed in an air gap environment does not check for new versions over the internet. A customer who needs to move an existing instance to the other mode must reinstall in the target mode.
 
 The following shows these license fields in the **Additional install options** section of the **Manager customer** page:
 

--- a/embedded-cluster/installing-embedded-air-gap.mdx
+++ b/embedded-cluster/installing-embedded-air-gap.mdx
@@ -1,8 +1,11 @@
 import Prerequisites from "../docs/partials/embedded-cluster/v3/_ec-prereqs.mdx"
+import InstallModeFixed from "../docs/partials/install/_install-mode-fixed.mdx"
 
 # Air gap installation with Embedded Cluster (Beta)
 
 This topic describes how to install an application with Replicated Embedded Cluster on a virtual machine (VM) or bare metal server with no outbound internet access. For online installations, see [Online installation with Embedded Cluster](installing-embedded). For an introduction to Embedded Cluster, see [Embedded Cluster overview](embedded-overview).
+
+<InstallModeFixed/>
 
 ## Overview
 

--- a/embedded-cluster/installing-embedded.mdx
+++ b/embedded-cluster/installing-embedded.mdx
@@ -1,8 +1,11 @@
 import Prerequisites from "../docs/partials/embedded-cluster/v3/_ec-prereqs.mdx"
+import InstallModeFixed from "../docs/partials/install/_install-mode-fixed.mdx"
 
 # Online installation with Embedded Cluster (Beta)
 
 This topic describes how to install an application in an online (internet-connected) environment with Replicated Embedded Cluster. For air gap installations, see [Air gap installation with Embedded Cluster](installing-embedded-air-gap). For an introduction to Embedded Cluster, see [Embedded Cluster overview](embedded-overview).
+
+<InstallModeFixed/>
 
 ## Prerequisites
 

--- a/embedded-cluster/updating-embedded.mdx
+++ b/embedded-cluster/updating-embedded.mdx
@@ -1,6 +1,10 @@
+import InstallModeFixed from "../docs/partials/install/_install-mode-fixed.mdx"
+
 # Perform updates in embedded clusters (Beta)
 
 This topic describes how to upgrade, redeploy, or reconfigure an application installed with Replicated Embedded Cluster 3.x. For an introduction to Embedded Cluster, see [Embedded Cluster overview](embedded-overview).
+
+<InstallModeFixed/>
 
 ## Overview
 

--- a/embedded-cluster_versioned_docs/version-2.0.0/installing-embedded-air-gap.mdx
+++ b/embedded-cluster_versioned_docs/version-2.0.0/installing-embedded-air-gap.mdx
@@ -1,8 +1,11 @@
 import Prerequisites from "../../docs/partials/embedded-cluster/v2/_ec-prereqs.mdx"
+import InstallModeFixed from "../../docs/partials/install/_install-mode-fixed.mdx"
 
 # Air gap installation with Embedded Cluster
 
 This topic describes how to install applications with Embedded Cluster on a virtual machine (VM) or bare metal server with no outbound internet access.
+
+<InstallModeFixed/>
 
 ## Overview
 

--- a/embedded-cluster_versioned_docs/version-2.0.0/installing-embedded.mdx
+++ b/embedded-cluster_versioned_docs/version-2.0.0/installing-embedded.mdx
@@ -1,10 +1,13 @@
 import Prerequisites from "../../docs/partials/embedded-cluster/v2/_ec-prereqs.mdx"
+import InstallModeFixed from "../../docs/partials/install/_install-mode-fixed.mdx"
 
 # Online installation with Embedded Cluster
 
 This topic describes how to install an application in an online (internet-connected) environment with the Replicated Embedded Cluster installer. For information about air gap installations with Embedded Cluster, see [Air Gap Installation with Embedded Cluster](installing-embedded-air-gap).
 
 For the list of all Embedded Cluster installation options, including how to install behind a proxy, how to use a specific network interface, and more, see [install](embedded-cluster-install).
+
+<InstallModeFixed/>
 
 ## Prerequisites
 

--- a/embedded-cluster_versioned_docs/version-2.0.0/updating-embedded.mdx
+++ b/embedded-cluster_versioned_docs/version-2.0.0/updating-embedded.mdx
@@ -3,10 +3,13 @@ import UpdateAirGapCli from "../../docs/partials/embedded-cluster/v2/_update-air
 import UpdateAirGapOverview from "../../docs/partials/embedded-cluster/v2/_update-air-gap-overview.mdx"
 import DoNotDowngrade from "../../docs/partials/embedded-cluster/_warning-do-not-downgrade.mdx"
 import Overview from "../../docs/partials/embedded-cluster/v2/_update-overview.mdx"
+import InstallModeFixed from "../../docs/partials/install/_install-mode-fixed.mdx"
 
 # Perform updates in embedded clusters
 
 This topic describes how to perform updates for [Replicated Embedded Cluster](embedded-overview) installations.
+
+<InstallModeFixed/>
 
 ## Overview
 


### PR DESCRIPTION
## What

Documents a constraint the platform has always enforced but never stated: an installation is either online or air gap, the mode is chosen at install time, and it cannot change afterward.

Adds a shared note partial (`docs/partials/install/_install-mode-fixed.mdx`) and imports it into the install and update topics for KOTS in existing clusters, kURL, Embedded Cluster v2, and Embedded Cluster v3. Also expands the air gap entitlement statement in the onboarding topic so it separates what the license permits from what an existing instance can do.

## Why

A vendor asked whether an Embedded Cluster instance installed online could accept an air gap bundle for later upgrades. The answer is no, and it is enforced in code in both directions:

- KOTS rejects a bundle uploaded to an online install (`pkg/handlers/update.go`, "Cannot update an online install using an airgap bundle"). The `is_airgap` flag is set only when the app is created from a bundle, not from the license entitlement.
- An air gap install runs the Admin Console with `DISABLE_OUTBOUND_CONNECTIONS=true`, set whenever it is installed with `--airgap`, so it only lists air gap updates and skips license sync.
- The Embedded Cluster internal image registry is deployed for air gap installs only, so an online cluster has nowhere to load bundle images.

None of the install or update topics said this. The closest existing statements arguably pointed the other way:

- The air gap entitlement section said licenses "support both air gap and online installations", which is true of the license but silent on the per-install choice being permanent.
- The Embedded Cluster update topic said Embedded Cluster "automatically detects the air gap installation", which implies the mode persists but never says the opposite direction is refused.
- The only structural hint anywhere was "(Air Gap Only) Image registry" in the v2 overview.

## Testing

- Vale reports no new findings on the changed prose.
- All 11 partial import paths resolve from their importing pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)