### PR TITLE
docs: document object store add-on lifecycle and CMX DR limitation

### DIFF
--- a/docs/vendor/testing-about.md
+++ b/docs/vendor/testing-about.md
@@ -43,6 +43,7 @@ Otherwise, to request credits, log in to the Vendor Portal and go to [**Compatib
   - There is no support for IPv6 as a single stack. Dual stack support is available on kind clusters.
   - The `cluster upgrade` feature is available only for kURL distributions. See [cluster upgrade](/reference/replicated-cli-cluster-upgrade).
   - Cloud clusters do not allow for the configuration of CNI, CSI, CRI, Ingress, or other plugins, add-ons, services, and interfaces.
+  - Cloud clusters cannot be used to test disaster recovery scenarios that require restoring to a newly created cluster. Backup storage provisioned by the [object store add-on](/vendor/testing-cluster-addons#object-store-alpha) is deleted with the cluster, and volume snapshots are created in the Replicated-managed cloud account and cannot be accessed from a new cluster. Restoring to the same cluster is supported.
   - The node operating systems for clusters created with CMX cannot be configured nor replaced with different operating systems.
   - The Kubernetes scheduler for clusters created with CMX cannot be replaced with a different scheduler.
 - For additional distribution-specific limitations, see [CMX Cluster and VM Types](testing-supported-clusters).

--- a/docs/vendor/testing-cluster-addons.md
+++ b/docs/vendor/testing-cluster-addons.md
@@ -33,6 +33,12 @@ This will create two service accounts in a namespace, one read-write and the oth
 
 Additional service accounts can be created in any namespace with access to the object store by annotating the new service account with the same `eks.amazonaws.com/role-arn` annotation found in the predefined ones (`service_account_name` and `service_account_name_read_only`).
 
+:::note
+The object store add-on is scoped to the lifecycle of the cluster it was created for. When the cluster is deleted, the bucket is emptied and deleted, along with the IAM roles and service accounts that granted access to it. Objects in the bucket are not retained, and the bucket cannot be reattached to a newly created cluster. The same applies when the add-on is removed with `replicated cluster addon rm`.
+
+Treat the bucket as ephemeral test storage. To keep any objects, copy them to storage you control before deleting the add-on or the cluster.
+:::
+
 <table>
   <tr>
     <th width="35%">Type</th>
@@ -45,6 +51,10 @@ Additional service accounts can be created in any namespace with access to the o
   <tr>
     <th>Cost</th>
     <td>Flat fee of $0.50 per bucket.</td>
+  </tr>
+  <tr>
+    <th>Lifecycle</th>
+    <td>Deleted with the cluster, including all objects in the bucket. Not durable storage.</td>
   </tr>
   <tr>
     <th>Options</th>


### PR DESCRIPTION
## What

Documents what happens to the CMX object store add-on bucket when the cluster is deleted, and adds a matching limitation stating that cloud clusters cannot be used to test restore-to-a-new-cluster disaster recovery.

## Why

The [object store (Alpha) add-on](https://docs.replicated.com/vendor/testing-cluster-addons#object-store-alpha) page says nothing about bucket lifecycle. Combined with the snapshots documentation recommending storage external to the cluster for disaster recovery, vendors have reasonably assumed the add-on bucket is durable, cluster-independent backup storage and have hit restore failures on a freshly created cluster.

It is not durable. On cluster delete, the provisioner enqueues each add-on for deletion before tearing down the cluster, and the object store teardown deletes the read-write and read-only service accounts, deletes both OIDC IAM roles and their policies, empties the bucket, and then deletes the bucket. The same path runs on `replicated cluster addon rm`. The cluster's OIDC provider is also deleted during teardown, so the IAM trust relationship cannot be reestablished from a new cluster even in principle.

## Changes

- `docs/vendor/testing-cluster-addons.md` — a note on lifecycle and a `Lifecycle` row in the add-on reference table.
- `docs/vendor/testing-about.md` — a limitations bullet on disaster recovery testing, alongside the existing bullet about cloud clusters not allowing CNI/CSI/plugin configuration.

Documentation only. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)