### PR TITLE
Fix broken host preflight spec link in EC v2 overview

### DIFF
--- a/embedded-cluster_versioned_docs/version-2.0.0/embedded-overview.mdx
+++ b/embedded-cluster_versioned_docs/version-2.0.0/embedded-overview.mdx
@@ -44,7 +44,7 @@ During installation, Embedded Cluster automatically runs a default set of _host 
 
 If any of the Embedded Cluster host preflight checks fail, installation is blocked and a message describing the failure is displayed.
 
-For the full default host preflight spec for Embedded Cluster, see [`host-preflight.yaml`](https://github.com/replicatedhq/embedded-cluster/blob/main/pkg/preflights/host-preflight.yaml) in the `embedded-cluster` repository in GitHub.
+For the full default host preflight specs for Embedded Cluster, see [`preflights/specs`](https://github.com/replicatedhq/embedded-cluster/tree/main/pkg-new/preflights/specs) in the `embedded-cluster` repository in GitHub.
 
 #### Limitations
 


### PR DESCRIPTION
## Summary

The EC v2 overview page links to the full default host preflight spec at `pkg/preflights/host-preflight.yaml` in the `embedded-cluster` repo. That path no longer exists, so the link 404s.

The spec was split into three files under `pkg-new/preflights/specs` (common, install, upgrade), so this points at that directory and adjusts the wording from "spec" to "specs".

Reported by a vendor who hit the 404.

## Verification

```
$ gh api repos/replicatedhq/embedded-cluster/contents/pkg-new/preflights/specs --jq '.[].name'
host-preflight-common.yaml
host-preflight-install.yaml
host-preflight-upgrade.yaml

$ gh api repos/replicatedhq/embedded-cluster/contents/pkg/preflights/host-preflight.yaml
gh: Not Found (HTTP 404)
```

## Note on the v3 page

The v3 overview has the same section with a different problem. It links to `replicatedhq/ec`, which is a private repo, so every vendor reading it gets a 404, and it is pinned to a commit SHA rather than a branch. That one is not fixed here because there is no public target to point at. Raised separately with the EC team to decide whether we publish the v3 specs or drop the link and expand the on-page summary instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)