### PR TITLE
Clarify that the published IP addresses are ingress only

### DIFF
--- a/docs/partials/install/_firewall-openings-intro.mdx
+++ b/docs/partials/install/_firewall-openings-intro.mdx
@@ -1,5 +1,9 @@
 The domains for the services listed below need to be accessible from servers performing online installations. No outbound internet access is required for air gap installations.
 
-For services hosted at domains owned by Replicated, the table includes a link to the list of IP addresses for the domain at [replicatedhq/ips](https://github.com/replicatedhq/ips/blob/main/ip_addresses.json) in GitHub. Note that the IP addresses listed in the `replicatedhq/ips` repository also include IP addresses for some domains that are _not_ required for installation.
+For services hosted at domains owned by Replicated, the table includes a link to the list of IP addresses for the domain at [replicatedhq/ips](https://github.com/replicatedhq/ips/blob/main/ip_addresses.json) in GitHub. These are the addresses that Replicated services listen on, so they are the addresses that an installation connects to. Note that the IP addresses listed in the `replicatedhq/ips` repository also include IP addresses for some domains that are _not_ required for installation.
 
-For any third-party services hosted at domains not owned by Replicated, consult the third-party's documentation for the IP address range for each domain. 
+:::note
+Replicated does not publish the source IP addresses that its services use for outbound connections, such as when the Replicated proxy registry pulls an image from a vendor's registry, and does not commit to keeping those addresses stable. Do not use the addresses in `replicatedhq/ips` to build an allowlist for traffic originating from Replicated. Where access to a registry must be restricted, use registry credentials rather than a source IP allowlist.
+:::
+
+For any third-party services hosted at domains not owned by Replicated, consult the third-party's documentation for the IP address range for each domain.

--- a/docs/partials/install/_firewall-openings-intro.mdx
+++ b/docs/partials/install/_firewall-openings-intro.mdx
@@ -1,9 +1,11 @@
 The domains for the services listed below need to be accessible from servers performing online installations. No outbound internet access is required for air gap installations.
 
-For services hosted at domains owned by Replicated, the table includes a link to the list of IP addresses for the domain at [replicatedhq/ips](https://github.com/replicatedhq/ips/blob/main/ip_addresses.json) in GitHub. These are the addresses that Replicated services listen on, so they are the addresses that an installation connects to. Note that the IP addresses listed in the `replicatedhq/ips` repository also include IP addresses for some domains that are _not_ required for installation.
+For services hosted at domains owned by Replicated, the table includes a link to the list of IP addresses for the domain at [replicatedhq/ips](https://github.com/replicatedhq/ips/blob/main/ip_addresses.json) in GitHub. These are the addresses that Replicated services listen on, so they are the addresses that an online installation connects to.
+
+That repository covers every Replicated service, so it lists more domains than any one installation needs. Use the table below to determine which of its entries apply to you.
 
 :::note
 Replicated does not publish the source IP addresses that its services use for outbound connections, such as when the Replicated proxy registry pulls an image from a vendor's registry, and does not commit to keeping those addresses stable. Do not use the addresses in `replicatedhq/ips` to build an allowlist for traffic originating from Replicated. Where access to a registry must be restricted, use registry credentials rather than a source IP allowlist.
 :::
 
-For any third-party services hosted at domains not owned by Replicated, consult the third-party's documentation for the IP address range for each domain.
+Some of the domains listed below belong to public services that Replicated does not own, such as Docker Hub, GitHub and Amazon S3. Their IP addresses are not in `replicatedhq/ips`, so consult the provider's documentation for their ranges.


### PR DESCRIPTION
Preview link https://deploy-preview-4477--replicated-docs-upgrade.netlify.app/vendor/firewall-openings

The firewall openings pages link a list of Replicated IP addresses without saying which direction they describe. Three separate readers have now taken that list as the answer to "what source addresses does Replicated connect to my registry from," which it is not. The `proxy.replicated.com` key in `ip_addresses.json` makes the misreading a natural one, since it is the exact domain people are told to allowlist.

This adds one sentence saying the published addresses are the ones Replicated services listen on, and a note stating that Replicated does not publish the source addresses its services use for outbound connections.

Direction agreed with @marccampbell in Slack. The reasoning worth preserving is that ingress is ours to control, we own a static block and can carry it between providers, whereas committing to egress addresses would constrain how the architecture can change. IP allowlisting exists here so that customers can secure their own firewalls, and Replicated does not initiate connections into customer environments.

## Wording choices

**"Outbound connections" rather than naming each path.** The proxy registry is the common case, but it is not the only place Replicated reaches a vendor registry. A general statement covers the others without needing revision when a path moves.

**"Does not publish" rather than "cannot provide."** There is an open question about whether a narrower dedicated egress range is achievable. This wording stays true either way.

**No mention of running a proxy in front of the proxy.** That has come up as a bespoke unblock for a reader who needs a fixed source address. It works, but publishing it would steer people toward an extra self-hosted hop as the standard answer, which seems worse than pointing at credentials.

## For reviewers

The intro partial is shared by four pages, two vendor and two enterprise: `vendor/firewall-openings`, `vendor/install-with-helm`, `enterprise/installing-general-requirements`, `enterprise/installing-kurl-requirements`.

The registry sentence is aimed at the vendor audience. I kept it in the shared intro rather than splitting it, because the misreading happens wherever someone finds the list, and a reader on the enterprise pages is not misled by it, just less interested. Happy to move the note to the vendor pages only if you would rather keep the enterprise requirements pages tightly scoped.

Independent of #4476, which touches the other partials. No overlapping files, either order works.