### PR TITLE
Make status informer docs reachable and correct for EC v3 readers

### DIFF
--- a/docs/enterprise/status-viewing-details.md
+++ b/docs/enterprise/status-viewing-details.md
@@ -9,6 +9,8 @@ This topic describes how to view the status of an application on the Replicated 
 
 <KotsAvailability/>
 
+The resources shown here are the status informers configured by the software vendor. For how they are configured, see [Enable and understand application status](/vendor/insights-app-status).
+
 ## View status details
 
 The application status displays on the dashboard of the Admin Console. Viewing the status details can be helpful for troubleshooting.

--- a/docs/partials/replicated-sdk/_overview.mdx
+++ b/docs/partials/replicated-sdk/_overview.mdx
@@ -2,6 +2,7 @@ The Replicated SDK is a Helm chart that can be installed as a small service alon
 
 The Replicated SDK provides access to insights and operational telemetry for instances running in customer environments. You can use the Replicated SDK's in-cluster API to integrate key Replicated functionality with your application. For example:
 
+* Report the status of application resources, which drives the instance status shown in the Vendor Portal. See [Enable and understand application status](/vendor/insights-app-status).
 * Collect custom metrics on instances running in online or air gap environments. See [Configure Custom Metrics](/vendor/custom-metrics).
 * Check customer license entitlements. See [Query Entitlements with the Replicated SDK API](/vendor/licenses-reference-sdk) and [Verify License Field Signatures with the Replicated SDK API](/vendor/licenses-verify-fields-sdk-api). 
 * Provide update checks to alert customers when new versions of your application are available for upgrade. See [Support Update Checks in Your Application](/reference/replicated-sdk-apis#support-update-checks-in-your-application) in _Replicated SDK API_.

--- a/docs/vendor/admin-console-display-app-status.md
+++ b/docs/vendor/admin-console-display-app-status.md
@@ -6,9 +6,13 @@ import KotsAvailability from "../partials/kots/_kots-availability.mdx"
 
 # Add resource status informers
 
-This topic describes how to add status informers for your application. Status informers apply only to applications installed with Replicated KOTS. For information about how to collect application status data for applications installed with Helm, see [Enabling and Understanding Application Status](insights-app-status).
+This topic describes how to add status informers for your application using the Replicated Application custom resource. This method applies to applications installed with Replicated KOTS, including Embedded Cluster v2.
 
 <KotsAvailability/>
+
+For all other installation methods, including Helm CLI installations and Embedded Cluster v3, status informers are provided by the Replicated SDK. See [Enable and understand application status](/vendor/insights-app-status).
+
+For what your end customers see on the Admin Console dashboard, see [Understand application status details in the Admin Console](/enterprise/status-viewing-details).
 
 ## About status informers
 

--- a/docs/vendor/insights-app-status.md
+++ b/docs/vendor/insights-app-status.md
@@ -18,6 +18,14 @@ To compute and display these insights, the Vendor Portal interprets and aggregat
 
 For more information about how instance data is sent to the Vendor Portal, see [About Instance and Event Data](instance-insights-event-data).
 
+## Where application status appears
+
+Status informers determine what the Vendor Portal shows, and the same informers drive the application status that your end customers see.
+
+* **Vendor Portal.** Instance status and per-resource status insights, described on this page.
+* **Replicated KOTS Admin Console.** End customers see the aggregate status and per-resource details on the dashboard. See [Understand application status details in the Admin Console](/enterprise/status-viewing-details).
+* **Embedded Cluster v2.** Includes the KOTS Admin Console, so application status displays the same way as an existing cluster KOTS installation.
+
 ## Enable application status insights
 
 To display insights on application status, the Vendor Portal requires that your application has one or more _status informers_. Status informers indicate the Kubernetes resources deployed as part of your application that are monitored for changes in state.
@@ -36,7 +44,7 @@ To enable application status with the SDK:
 
 1. If either of the following are true, list all the resources that you want the SDK to report on in the SDK's [`statusInformers`](https://github.com/replicatedhq/replicated-sdk/blob/main/chart/values.yaml#L287) field:
 
-     * You want the SDK to report on resources outside the Helm release for the chart where it is included as a dependency. For example, your application is installed as multiple charts and you want status data for resources created by subcharts.
+     * You want the SDK to report on resources outside the Helm release that contains it. Subcharts of that release are detected automatically, because their resources are part of the same release manifest. Resources belonging to a separate Helm release are not.
      * Your application is installed by running `helm template` then `kubectl apply`, rather than `helm install` or `helm upgrade`. In this case, the SDK is unable to automatically detect resources in the Helm release.
 
      **Example:**
@@ -55,9 +63,11 @@ To enable application status with the SDK:
      When `statusInformers` is set, the SDK reports the status of only the resources included in the `statusInformers` field.
      :::
 
-### Configure status with the Application custom resource (KOTS existing cluster only) {#replicated-installers}
+### Configure status with the Application custom resource (Replicated installers) {#replicated-installers}
 
-For existing cluster installations with KOTS that do not include the Replicated SDK, you can configure status informers in the Replicated [Application custom resource](/reference/custom-resource-application). This is not required if you already include the SDK as a dependency of your Helm chart.
+For installations with a Replicated installer, you can configure status informers in the Replicated [Application custom resource](/reference/custom-resource-application). This applies to existing cluster KOTS installations, Embedded Cluster v2, and Embedded Cluster v3.
+
+For existing cluster KOTS and Embedded Cluster v2, this is not required if you already include the SDK as a dependency of your Helm chart. For Embedded Cluster v3, which does not include KOTS, the installer passes the informers you configure here to the SDK.
 
 :::note
 When Helm-based applications that include the Replicated SDK are deployed by a Replicated installer, the SDK inherits the status informers configured in the Application custom resource. In this case, the SDK does _not_ automatically report the status of the resources that are part of the Helm release. This prevents discrepancies in the instance data in the Vendor Portal.

--- a/embedded-cluster/embedded-v3-migrate.mdx
+++ b/embedded-cluster/embedded-v3-migrate.mdx
@@ -22,9 +22,11 @@ The KOTS CLI does not work with Embedded Cluster v3, and there is no KOTS Admin 
 
 Embedded Cluster v3 still requires the Replicated HelmChart v2 custom resource to process and deploy Helm charts. Embedded Cluster v3 also still uses Replicated custom resources like the Replicated Application and Replicated Config resources to define aspects of the installation experience.
 
-### Replicated SDK required for application status informers
+### Replicated SDK required for instance status reporting
 
-Because Embedded Cluster v3 removes KOTS, you must include the [Replicated SDK](/vendor/replicated-sdk-overview) in your application to get instance reporting in the Vendor Portal from application status informers.
+Because Embedded Cluster v3 removes KOTS, you must include the [Replicated SDK](/vendor/replicated-sdk-overview) in your application for application status informers to report instance status to the Vendor Portal.
+
+Continue to configure status informers in the Replicated Application custom resource. Embedded Cluster v3 passes them to the SDK. For more information, see [Enable and understand application status](/vendor/insights-app-status).
 
 ### Preflight specs must use v1beta3
 


### PR DESCRIPTION
An Embedded Cluster v3 vendor looking for status informers is steered wrong at every step today.

- `embedded-v3-migrate.mdx` says the SDK is required for status informers and links nowhere.
- `replicated-sdk-overview.mdx` has zero mentions of status, so a reader sent there finds nothing about the thing they were sent for.
- Searching "status informers" lands on `admin-console-display-app-status.md`, which opens "Status informers apply only to applications installed with Replicated KOTS." Its pointer onward names only Helm, which an EC v3 reader does not self-identify as.
- The page that is correct and current, `insights-app-status.md`, is framed as a Vendor Portal insights topic and nothing links to it from the first two.

Mostly cross-linking and scoping. Two things are corrections.

tied to https://app.shortcut.com/replicated/story/139494/chore-docs-status-informer-docs-still-read-as-kots-only-for-ec-v3-readers

## Corrections

**The Application custom resource section was scoped "KOTS existing cluster only."** Embedded Cluster v3 reads `spec.statusInformers` and passes it to the SDK, unconditionally, and Embedded Cluster v2 is KOTS. So the parenthetical excluded two installers that do use this path. Retitled to "Replicated installers" and the body now names all three, including what EC v3 does with the informers you configure.

**The Helm CLI section conflated charts with releases.** It told readers to declare informers explicitly if "your application is installed as multiple charts and you want status data for resources created by subcharts." Auto-detection walks the entire Helm release manifest, so subcharts of the same release are already covered. The real boundary is a separate Helm release. As written, a vendor either declares informers they do not need or concludes an umbrella chart will not work.

## New section

`insights-app-status.md` gains "Where application status appears." The same informers drive the KOTS Admin Console dashboard that end customers see, and nothing connected those two ideas. `enterprise/status-viewing-details.md` had no inbound links from anywhere in the docs, so the page answering "what does my customer actually see" was reachable only through the nav. It now links both ways.

Embedded Cluster v3 is deliberately absent from that list. There is no status surface for end customers yet, that work is tracked separately, and a "coming soon" line is not something we put in docs. The docs task is recorded on that story so the link gets added with the feature.

## Files

| File | Change |
|---|---|
| `embedded-cluster/embedded-v3-migrate.mdx` | Narrow the heading to instance status reporting, say Application CR informers still apply, link onward |
| `docs/partials/replicated-sdk/_overview.mdx` | Add status reporting to what the SDK does |
| `docs/vendor/admin-console-display-app-status.md` | Keep the KOTS scoping, name installation methods rather than only Helm, fix the stale link title, link to the customer-facing page |
| `docs/vendor/insights-app-status.md` | New cross-link section, fix the installer scoping, fix charts versus releases |
| `docs/enterprise/status-viewing-details.md` | Link back to how a vendor configures the informers behind the dashboard |

The SDK overview change is in a shared partial, so it also reaches `intro-replicated`, `replicated-onboarding-helm-only` and `kots-faq`. That seems right, since status reporting is arguably the most prominent thing missing from that list of what the SDK does, but flagging the wider blast radius.

## Swept, no changes needed

Checked the other files that mention `statusInformers` for stale KOTS-only scoping and found none. `custom-resource-application.mdx` already links here and already carries an EC v3 note. The "KOTS existing cluster installations only" lines in that file are about the minimal RBAC properties, not status informers.

`custom-resource-lintconfig.mdx`, `linter.mdx`, `replicated-onboarding.mdx`, `replicated-sdk-customizing.mdx`, `_application-statusInformers.mdx`, `_sdk-values.mdx` are all fine as they stand.