### PR TITLE
docs: clarify EC v3 pod log storage

### DIFF
--- a/docs/partials/embedded-cluster/v3/_requirements.mdx
+++ b/docs/partials/embedded-cluster/v3/_requirements.mdx
@@ -14,6 +14,8 @@
 
 * The data directory used by Embedded Cluster must have 40Gi or more of total space and be less than 80% full. By default, the data directory is `/var/lib/APP_SLUG`, where `APP_SLUG` is the unique slug of the application. The directory can be changed by passing the `--data-dir` flag with the Embedded Cluster `install` command. For more information, see [install](/embedded-cluster/v3/embedded-cluster-install).
 
+   For new installations that use Kubernetes 1.30 or later, Embedded Cluster stores pod logs in `<data-dir>/k0s/pod-logs`.
+
    Note that in addition to the primary data directory, Embedded Cluster creates directories and files in the following locations:
 
       - `/etc/cni`
@@ -34,7 +36,6 @@
       - `/var/log/calico`
       - `/var/log/containers`
       - `/var/log/APP_SLUG`, where `APP_SLUG` is the unique slug for the application
-      - `/var/log/pods`
       - `/usr/local/bin/k0s`
 
 * (Online installations only) Access to replicated.app and proxy.replicated.com or your custom domain for each

--- a/embedded-cluster/embedded-config.mdx
+++ b/embedded-cluster/embedded-config.mdx
@@ -307,6 +307,8 @@ You can configure the Kubelet to customize worker nodes with Embedded Cluster. O
 
 Add a _worker profile_ in `unsupportedOverrides.k0s` at `config.spec.workerProfiles[]`. When you define a worker profile, Embedded Cluster uses it for every node during initial installation and when joining nodes.
 
+On new installations that use Kubernetes 1.30 or later, Embedded Cluster internally configures the `default` worker profile to store pod logs in `<data-dir>/k0s/pod-logs`. Defining `workerProfiles` replaces this internal profile and its pod log directory configuration. To use a different worker profile while storing pod logs in the data directory, set `podLogsDir` in that profile's `values`.
+
 Each profile requires:
 
 * `name`: Profile name. Do not use `default` because k0s reserves that name.


### PR DESCRIPTION
## Summary
- document the EC v3 pod log location for new Kubernetes 1.30+ installations
- remove `/var/log/pods` from the EC v3 requirements list
- explain how vendor worker-profile overrides replace the internal EC pod-log configuration