### PR TITLE
docs: clarify EC v2 pod log storage

### DIFF
--- a/docs/partials/embedded-cluster/v2/_requirements.mdx
+++ b/docs/partials/embedded-cluster/v2/_requirements.mdx
@@ -14,7 +14,7 @@
 
 * The data directory used by Embedded Cluster must have 40Gi or more of total space and be less than 80% full. By default, the data directory is `/var/lib/embedded-cluster`. The directory can be changed by passing the `--data-dir` flag with the Embedded Cluster `install` command. For more information, see [install](/embedded-cluster/v2/embedded-cluster-install).
 
-   For new installations that use Kubernetes 1.30 or later, Embedded Cluster stores pod logs in `<data-dir>/k0s/pod-logs`.
+   For new installations created with Embedded Cluster 2.19.8 or later, Embedded Cluster stores pod logs in `<data-dir>/k0s/pod-logs`. Pod log volume counts toward the required space in the data directory. Storing pod logs in this directory lets kubelet account for their disk usage when it manages disk pressure and pod eviction.
 
    Note that in addition to the primary data directory, Embedded Cluster creates directories and files in the following locations:
 
@@ -36,6 +36,7 @@
       - `/var/log/calico`
       - `/var/log/containers`
       - `/var/log/embedded-cluster`
+      - `/var/log/pods` (installations created before Embedded Cluster 2.19.8)
       - `/usr/local/bin/k0s`
 
 * (Online installations only) Access to replicated.app and proxy.replicated.com or your custom domain for each

--- a/docs/partials/embedded-cluster/v2/_requirements.mdx
+++ b/docs/partials/embedded-cluster/v2/_requirements.mdx
@@ -14,7 +14,7 @@
 
 * The data directory used by Embedded Cluster must have 40Gi or more of total space and be less than 80% full. By default, the data directory is `/var/lib/embedded-cluster`. The directory can be changed by passing the `--data-dir` flag with the Embedded Cluster `install` command. For more information, see [install](/embedded-cluster/v2/embedded-cluster-install).
 
-   For new installations created with Embedded Cluster 2.19.8 or later, Embedded Cluster stores pod logs in `<data-dir>/k0s/pod-logs`. Pod log volume counts toward the required space in the data directory. Storing pod logs in this directory lets kubelet account for their disk usage when it manages disk pressure and pod eviction.
+   By default, new Embedded Cluster installations store pod logs in `<data-dir>/k0s/pod-logs`. Pod log volume counts toward the required space in the data directory. Storing pod logs in this directory lets kubelet account for their disk usage when it manages disk pressure and pod eviction.
 
    Note that in addition to the primary data directory, Embedded Cluster creates directories and files in the following locations:
 

--- a/docs/partials/embedded-cluster/v2/_requirements.mdx
+++ b/docs/partials/embedded-cluster/v2/_requirements.mdx
@@ -14,6 +14,8 @@
 
 * The data directory used by Embedded Cluster must have 40Gi or more of total space and be less than 80% full. By default, the data directory is `/var/lib/embedded-cluster`. The directory can be changed by passing the `--data-dir` flag with the Embedded Cluster `install` command. For more information, see [install](/embedded-cluster/v2/embedded-cluster-install).
 
+   For new installations that use Kubernetes 1.30 or later, Embedded Cluster stores pod logs in `<data-dir>/k0s/pod-logs`.
+
    Note that in addition to the primary data directory, Embedded Cluster creates directories and files in the following locations:
 
       - `/etc/cni`
@@ -34,7 +36,6 @@
       - `/var/log/calico`
       - `/var/log/containers`
       - `/var/log/embedded-cluster`
-      - `/var/log/pods`
       - `/usr/local/bin/k0s`
 
 * (Online installations only) Access to replicated.app and proxy.replicated.com or your custom domain for each

--- a/embedded-cluster_versioned_docs/version-2.0.0/embedded-config.mdx
+++ b/embedded-cluster_versioned_docs/version-2.0.0/embedded-config.mdx
@@ -298,8 +298,6 @@ You can configure the Kubelet to customize your worker nodes with Embedded Clust
 
 You can customize the Kubelet configuration settings by adding a _worker profile_ in the Embedded Cluster Config under `unsupportedOverrides.k0s.config.spec.workerProfiles[]`. When a worker profile is defined, Embedded Cluster uses the profile for every node in the cluster during initial installation and when joining nodes to the cluster.
 
-On new installations created with Embedded Cluster 2.19.8 or later, Embedded Cluster internally configures k0s's reserved `default` worker profile to store pod logs in `<data-dir>/k0s/pod-logs`. Custom worker profiles must not use `default`; defining `workerProfiles` replaces this internal profile and its pod log directory configuration. To use a different worker profile while storing pod logs in the data directory, set `podLogsDir: <data-dir>/k0s/pod-logs` in that profile's `values`.
-
 The worker profile has the following required fields:
 * `name`: The name of the worker profile. Do not use the name `default` for your custom worker profile. `default` is reserved by k0s.
 * `values`: The Kubelet configuration settings for the profile. For a complete list of the available Kubelet configuration options that you can set in a worker profile, see [KubeletConfiguration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration) in the Kubernetes documentation.

--- a/embedded-cluster_versioned_docs/version-2.0.0/embedded-config.mdx
+++ b/embedded-cluster_versioned_docs/version-2.0.0/embedded-config.mdx
@@ -298,6 +298,8 @@ You can configure the Kubelet to customize your worker nodes with Embedded Clust
 
 You can customize the Kubelet configuration settings by adding a _worker profile_ in the Embedded Cluster Config under `unsupportedOverrides.k0s.config.spec.workerProfiles[]`. When a worker profile is defined, Embedded Cluster uses the profile for every node in the cluster during initial installation and when joining nodes to the cluster.
 
+On new installations that use Kubernetes 1.30 or later, Embedded Cluster internally configures the `default` worker profile to store pod logs in `<data-dir>/k0s/pod-logs`. Defining `workerProfiles` replaces this internal profile and its pod log directory configuration. To use a different worker profile while storing pod logs in the data directory, set `podLogsDir` in that profile's `values`.
+
 The worker profile has the following required fields:
 * `name`: The name of the worker profile. Do not use the name `default` for your custom worker profile. `default` is reserved by k0s.
 * `values`: The Kubelet configuration settings for the profile. For a complete list of the available Kubelet configuration options that you can set in a worker profile, see [KubeletConfiguration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration) in the Kubernetes documentation.

--- a/embedded-cluster_versioned_docs/version-2.0.0/embedded-config.mdx
+++ b/embedded-cluster_versioned_docs/version-2.0.0/embedded-config.mdx
@@ -298,7 +298,7 @@ You can configure the Kubelet to customize your worker nodes with Embedded Clust
 
 You can customize the Kubelet configuration settings by adding a _worker profile_ in the Embedded Cluster Config under `unsupportedOverrides.k0s.config.spec.workerProfiles[]`. When a worker profile is defined, Embedded Cluster uses the profile for every node in the cluster during initial installation and when joining nodes to the cluster.
 
-On new installations that use Kubernetes 1.30 or later, Embedded Cluster internally configures the `default` worker profile to store pod logs in `<data-dir>/k0s/pod-logs`. Defining `workerProfiles` replaces this internal profile and its pod log directory configuration. To use a different worker profile while storing pod logs in the data directory, set `podLogsDir` in that profile's `values`.
+On new installations created with Embedded Cluster 2.19.8 or later, Embedded Cluster internally configures k0s's reserved `default` worker profile to store pod logs in `<data-dir>/k0s/pod-logs`. Custom worker profiles must not use `default`; defining `workerProfiles` replaces this internal profile and its pod log directory configuration. To use a different worker profile while storing pod logs in the data directory, set `podLogsDir: <data-dir>/k0s/pod-logs` in that profile's `values`.
 
 The worker profile has the following required fields:
 * `name`: The name of the worker profile. Do not use the name `default` for your custom worker profile. `default` is reserved by k0s.


### PR DESCRIPTION
## Summary
- document the default pod-log location for new Embedded Cluster v2 installations
- explain that pod-log usage counts toward the required data-directory space and kubelet disk-pressure accounting
- remove the worker-profile workaround that told vendors to set podLogsDir from the install data directory

## Note
This documentation relies on the product behavior in replicatedhq/embedded-cluster#3936. Merge this PR after that fix is released. Vendors only need to set podLogsDir when they deliberately want a different location.

## Validation
- git diff --check
- docs build was not run because dependencies are not installed locally