### PR TITLE
docs: clarify that EC v3 upgrades preserve application configuration

### DIFF
--- a/embedded-cluster/updating-embedded.mdx
+++ b/embedded-cluster/updating-embedded.mdx
@@ -12,7 +12,7 @@ Each Embedded Cluster binary that you download targets a particular application 
 
 You can upgrade interactively in the browser or headlessly from the command line. To change configuration or redeploy without moving to a newer application version, run `upgrade` using the binary for the version that is already installed.
 
-An upgrade preserves the application configuration from the installed version. To change configuration during an upgrade, edit the values on the **Configure** page in the UI, or pass `--config-values` when you upgrade headlessly. Configuration items that are new in the target version take that version's default value.
+An upgrade preserves the application configuration from the installed version. To change configuration during an upgrade, edit the values on the **Configure** page in the UI, or pass `--config-values` when you upgrade headlessly. Configuration items that are new in the target version take that version's default value. For items whose `value` uses a template function such as `RandomString`, the `readonly` and `hidden` properties determine whether the generated value persists or is regenerated. See [Generating Persistent and Ephemeral Strings](/reference/template-functions-static-context#generating-persistent-and-ephemeral-strings).
 
 ## Multi-node clusters
 

--- a/embedded-cluster/updating-embedded.mdx
+++ b/embedded-cluster/updating-embedded.mdx
@@ -12,6 +12,8 @@ Each Embedded Cluster binary that you download targets a particular application 
 
 You can upgrade interactively in the browser or headlessly from the command line. To change configuration or redeploy without moving to a newer application version, run `upgrade` using the binary for the version that is already installed.
 
+An upgrade preserves the application configuration from the installed version. To change configuration during an upgrade, edit the values on the **Configure** page in the UI, or pass `--config-values` when you upgrade headlessly. Configuration items that are new in the target version take that version's default value.
+
 ## Multi-node clusters
 
 In multi-node clusters, run the `upgrade` command on the primary controller (the first controller installed). The upgrade proceeds in two stages:
@@ -63,7 +65,7 @@ To upgrade more directly from the Vendor Portal:
 
 1. When prompted, enter the password you set during installation to log in to the installer. To set a different password for the installer, use the `--installer-password` flag.
 
-1. On the **Configure** page, change any application configuration you need.
+1. On the **Configure** page, change any application configuration you need. The page is pre-filled with the configuration from the installed version, so you can continue without making changes to keep it as is.
 
 1. On the **Upgrade** page, start the upgrade and wait for it to finish.
 
@@ -79,7 +81,7 @@ If the [persistent admin console](embedded-persistent-console) is installed on a
 
    The dashboard handles the fetch, prepare, restart, and binary swap, then redirects into the upgrade wizard.
 
-1. On the **Configure** page, change any application configuration you need.
+1. On the **Configure** page, change any application configuration you need. The page is pre-filled with the configuration from the installed version, so you can continue without making changes to keep it as is.
 
 1. On the **Upgrade** page, start the upgrade and wait for it to finish.
 
@@ -103,7 +105,7 @@ To perform a headless upgrade from the CLI:
 
    * Use `upgrade` instead of `install`.
    * Pass `--headless` to run without the interactive installer UI.
-   * (Optional) Pass `--config-values` with the path to your [ConfigValues](/reference/custom-resource-configvalues) file to change configuration.
+   * (Optional) Pass `--config-values` with the path to your [ConfigValues](/reference/custom-resource-configvalues) file to change configuration. If you omit this flag, the existing configuration is preserved.
    * (Optional) Pass `--installer-password` to change the installer password.
 
    Example:
@@ -199,7 +201,7 @@ To perform a headless upgrade in an air-gapped environment, pass `--headless` al
 sudo ./APP_SLUG upgrade --license LICENSE_FILE --headless
 ```
 
-Optionally pass `--config-values` with the path to your [ConfigValues](/reference/custom-resource-configvalues) file to change configuration during the upgrade. Embedded Cluster automatically detects the air gap installation.
+Optionally pass `--config-values` with the path to your [ConfigValues](/reference/custom-resource-configvalues) file to change configuration during the upgrade. If you omit this flag, the existing configuration is preserved. Embedded Cluster automatically detects the air gap installation.
 
 ## Upgrade failure handling {#upgrade-failures}
 


### PR DESCRIPTION
Preview link - https://deploy-preview-4488--replicated-docs.netlify.app/embedded-cluster/v3/updating-embedded

## Summary

The upgrade docs list `--config-values` as optional but never say what omitting it does, so a reader cannot tell whether an upgrade preserves the existing application configuration or resets it to defaults. The only section that discusses configuration on upgrade is scoped to the opposite scenario, reconfiguring without changing the application version.

This came up as a direct question from a vendor.

Related shortcut to improve the CLI command https://app.shortcut.com/replicated/story/139546/chore-ec-config-values-help-text-implies-config-comes-only-from-the-flag

## Changes

- Overview states the rule once. An upgrade preserves the installed configuration, you change it through the **Configure** page or `--config-values`, and items new in the target version take that version's default.
- Overview links the existing `readonly` and `hidden` persistence matrix on the RandomString page, since a follow-up question in the same thread turned on whether a hidden generated secret survives an upgrade.
- Headless and air gap `--config-values` bullets say that omitting the flag preserves the existing configuration.
- Both UI flows note that the **Configure** page is pre-filled, so you can continue without changes.

## Source

Behavior confirmed against `replicatedhq/ec`.

- `runHeadlessUpgrade` only submits config values when the flag is set, with the comment "if not provided, previously persisted / resolved values are preserved."
- `runHeadlessInstall` always submits, passing an empty map when no file is given, so there is always a persisted value to carry forward.
- Air gap uses the same `runHeadlessUpgrade` path. `IsAirgap` affects bundle setup and registry mode, not config handling.
- `mergeConfigValues` walks the target version's config items and overlays stored values by name, which is where the new-items-take-defaults behavior comes from.
- The persistent console flow redirects to `/upgrade/configure`, the same wizard as the Vendor Portal flow.

The `readonly` and `hidden` matrix on the RandomString page matches the code, including `readonly: false, hidden: true` being persistent. `isReadOnly` ignores `hidden` entirely and `password` is in the editable type set. That is why this PR links the table rather than restating it. If you would rather the link also appear in the headless section, say so.
