### PR TITLE
Document that Embedded Cluster requires the new air gap bundle format

### DIFF
--- a/docs/partials/embedded-cluster/v3/_support-air-gap-releases.mdx
+++ b/docs/partials/embedded-cluster/v3/_support-air-gap-releases.mdx
@@ -165,7 +165,13 @@ To support air gap installations with Embedded Cluster v3:
     The template functions add the proxy prefix in online installations and rewrite to the local registry in air gap installations.
     </details>
 
-1. In the [Vendor Portal](https://vendor.replicated.com), go to the channel where you promoted the release to build the air gap bundle. Do one of the following:
+1. In the [Vendor Portal](https://vendor.replicated.com), go to the channel where you promoted the release to build the air gap bundle.
+
+   :::note
+   Embedded Cluster requires the **Enable new air gap bundle format** channel setting. If the channel does not use this format, the air gap build fails. To check the setting, click the gear icon on the channel card to open **Edit channel settings**. See [Create and Edit Channels](/vendor/releases-creating-channels).
+   :::
+
+   Do one of the following:
      * If you enabled the **Automatically create airgap builds for newly promoted releases in this channel** setting for the channel, watch for the build status to complete.
      * If automatic air gap builds are not enabled, go to the **Release history** page for the channel and build the air gap bundle manually.
 

--- a/docs/vendor/private-images-tags-digests.md
+++ b/docs/vendor/private-images-tags-digests.md
@@ -35,7 +35,11 @@ You can use image tags and image digests together in any case where both are sup
 
 For applications installed with KOTS v1.82.0 or later, you can enable a format for air gap bundles that supports the use of image digests. This air gap bundle format also ensures that identical image layers are not duplicated, resulting in a smaller air gap bundle size.
 
-You can enable or disable this air gap bundle format using the **Enable new air gap bundle format** toggle in the settings for any channel in the Vendor Portal. The **Enable new air gap bundle format** toggle is enabled by default.
+:::note
+This air gap bundle format is required for air gap installations with Replicated Embedded Cluster. Air gap builds fail for releases that include an Embedded Cluster Config when the channel does not use this format.
+:::
+
+You can enable or disable this air gap bundle format using the **Enable new air gap bundle format** toggle in the settings for any channel in the Vendor Portal. New channels have this toggle enabled by default in most accounts. Existing channels keep the setting that they were created with, so verify that the toggle is enabled before you build an air gap bundle.
 
 When you enable **Enable new air gap bundle format** on a channel, all air gap bundles that you build or rebuild on that channel use the updated air gap bundle format.
 

--- a/docs/vendor/releases-about.mdx
+++ b/docs/vendor/releases-about.mdx
@@ -53,7 +53,7 @@ The following describes each of the channel settings:
     * **Enable new airgap bundle format**: When enabled, air gap bundles built for releases promoted to the channel use a format that supports image digests. This air gap bundle format also ensures that identical image layers are not duplicated, resulting in a smaller air gap bundle size. For more information, see [Use Image Digests in Air Gap Installations](private-images-tags-digests#digests-air-gap) in _Use Image Tags and Digests_.
 
       :::note
-      The new air gap bundle format is supported for applications installed with KOTS v1.82.0 or later. 
+      The new air gap bundle format is required for air gap installations with Replicated Embedded Cluster. It is supported for applications installed with KOTS v1.82.0 or later.
       :::  
    
 ## About releases

--- a/docs/vendor/releases-creating-channels.md
+++ b/docs/vendor/releases-creating-channels.md
@@ -20,7 +20,7 @@ To create a channel:
 1. Enter a name and description for the channel.
 1. (Recommended) Enable semantic versioning on the channel if it is not enabled by default by turning on **Enable semantic versioning**. For more information about semantic versioning and defaults, see [Semantic Versioning](releases-about#semantic-versioning).
 
-1. (Recommended) Enable an air gap bundle format that supports image digests and deduplication of image layers, by turning on **Enable new air gap bundle format**. For more information, see [Use Image Tags and Digests](private-images-tags-digests).
+1. Enable an air gap bundle format that supports image digests and deduplication of image layers, by turning on **Enable new air gap bundle format**. This format is required for air gap installations with Replicated Embedded Cluster. For more information, see [Use Image Tags and Digests](private-images-tags-digests).
 
 1. Click **Create Channel**.
 

--- a/docs/vendor/replicated-onboarding-air-gap.mdx
+++ b/docs/vendor/replicated-onboarding-air-gap.mdx
@@ -144,7 +144,13 @@ To support air gap installations with Embedded Cluster v2:
 
 1. <CreateRelease/>
 
-1. In the [Vendor Portal](https://vendor.replicated.com), go to the channel where you promoted the release to build the air gap bundle. Do one of the following:
+1. In the [Vendor Portal](https://vendor.replicated.com), go to the channel where you promoted the release to build the air gap bundle.
+
+   :::note
+   Embedded Cluster requires the **Enable new air gap bundle format** channel setting. If the channel does not use this format, the air gap build fails. To check the setting, click the gear icon on the channel card to open **Edit channel settings**. See [Create and Edit Channels](/vendor/releases-creating-channels).
+   :::
+
+   Do one of the following:
      * If you enabled the **Automatically create airgap builds for newly promoted releases in this channel** setting for the channel, watch for the build status to complete.
      * If automatic air gap builds are not enabled, go to the **Release history** page for the channel and build the air gap bundle manually.
 


### PR DESCRIPTION
## What

States the Embedded Cluster requirement on the pages that explain the **Enable new air gap bundle format** channel setting, and adds a note to the air gap build step in both the EC v2 and EC v3 onboarding flows.

## Why

EC air gap bundles only work when the channel uses the new format. Both v2 and v3 depend on the docker registry format for the EC portion of the bundle, and the air gap build fails when the channel uses the legacy format.

This was documented nowhere. Every page that explains the toggle framed the only tradeoff as KOTS v1.82.0 compatibility, and the channel creation steps called turning it on "recommended", so a vendor reading the docs could reasonably conclude the legacy format was a supported choice for an EC app. In practice, no EC release on a legacy-format channel has produced a working air gap bundle.

This also corrects the claim that the toggle is enabled by default. That holds for new channels in most accounts, but existing channels keep the setting they were created with, which is how vendors end up on the legacy format without choosing it.

## Changes

- `docs/vendor/releases-creating-channels.md` — drops "(Recommended)" and states the EC requirement
- `docs/vendor/releases-about.mdx` — adds the requirement to the channel setting note
- `docs/vendor/private-images-tags-digests.md` — adds the requirement, and qualifies the "enabled by default" claim
- `docs/partials/embedded-cluster/v3/_support-air-gap-releases.mdx` — note on the air gap build step
- `docs/vendor/replicated-onboarding-air-gap.mdx` — same note on the EC v2 air gap build step

The Helm CLI section is deliberately unchanged, since the requirement is EC specific.

## Testing

`npm run build` succeeds. The broken anchors it reports are all pre-existing on other pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)