### PR TITLE
docs: document the extra RBAC needed when an app ships the Replicated SDK

### DIFF
--- a/docs/enterprise/installing-general-requirements.mdx
+++ b/docs/enterprise/installing-general-requirements.mdx
@@ -245,6 +245,38 @@ In some cases, it is not possible to grant the user `* * *` permissions in the t
          resources: ["crontabs"]
          verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
        ```
+
+    1. If the application includes the Replicated SDK and the SDK is configured to use minimal RBAC, add the following rules to the Role in the YAML file that you created in the previous step:
+
+       ```yaml
+       rules:
+       - apiGroups: [""]
+         resources: ["serviceaccounts"]
+         verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+       - apiGroups: ["rbac.authorization.k8s.io"]
+         resources: ["roles", "rolebindings"]
+         verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+       - apiGroups: ["apps"]
+         resources: ["replicasets"]
+         verbs: ["get"]
+       ```
+
+       If status informers are not defined for the SDK, also add the following rules:
+
+       ```yaml
+       - apiGroups: ["apps"]
+         resources: ["replicasets"]
+         verbs: ["list", "watch"]
+       - apiGroups: ["discovery.k8s.io"]
+         resources: ["endpointslices"]
+         verbs: ["list"]
+       ```
+
+       If status informers are defined and any of them are Services or Ingresses, add the `endpointslices` rule only.
+
+       :::note
+       If the SDK is not configured to use minimal RBAC, or is configured to use a custom ClusterRole, then it cannot be installed with the minimum KOTS RBAC permissions. For more information, see [Customize RBAC for the SDK](/vendor/replicated-sdk-customizing#customize-rbac-for-the-sdk).
+       :::
     
     1. Run the following command to create the RBAC resources for KOTS in the namespace:
 

--- a/docs/vendor/packaging-rbac.md
+++ b/docs/vendor/packaging-rbac.md
@@ -89,6 +89,7 @@ In some cases, it is not possible to grant the user `* * *` permissions in the t
 If the user installing or upgrading KOTS cannot be granted `* * *` permissions in the namespace, then they can instead request the following:
 * The minimum RBAC permissions required by KOTS
 * RBAC permissions for any CustomResourceDefinitions (CRDs) that your application includes
+* RBAC permissions for any ServiceAccount, Role, or RoleBinding objects that your application's Helm charts create, including the Replicated SDK
 
 Installing with the minimum KOTS RBAC permissions also requires that the user manually creates a ServiceAccount, Role, and RoleBinding for KOTS, rather than allowing KOTS to automatically create a Role with `* * *` permissions.
 
@@ -101,6 +102,12 @@ The following limitations apply when using the `requireMinimalRBACPrivileges` or
 * **Existing clusters only**: The `requireMinimalRBACPrivileges` and `supportMinimalRBACPrivileges` options apply only to installations in existing clusters.
 
 * **Preflight checks**: When namespace-scoped access is enabled, preflight checks cannot read resources outside the namespace where KOTS is installed. The preflight checks continue to function, but return less data. For more information, see [Define Preflight Checks](/vendor/preflight-defining).
+
+* **Helm charts that include their own RBAC**: KOTS can only grant permissions that it holds itself. If your application's Helm charts create ServiceAccount, Role, or RoleBinding objects, then users installing with the minimum KOTS RBAC permissions must be granted permission to create those objects, as well as every permission that those objects request.
+
+   This applies to the Replicated SDK, which creates a ServiceAccount, Role, and RoleBinding by default. To keep the required permissions to a minimum, set `replicated.minimalRBAC` to `true` and define `replicated.statusInformers` in your Helm chart values.
+
+   If you do not set `replicated.minimalRBAC`, or if you configure the SDK with `replicated.clusterRole`, then these users cannot install the SDK at all. Without minimal RBAC, the SDK's Role requests `get`, `list`, and `watch` on all resources in the namespace. With a custom ClusterRole, KOTS must create a ClusterRoleBinding, which a namespace-scoped Role cannot authorize. In both cases the only alternative is for the user to create a ServiceAccount and provide it with `replicated.serviceAccountName`. For more information, see [Customize RBAC for the SDK](/vendor/replicated-sdk-customizing#customize-rbac-for-the-sdk).
 
 * **Velero namespace access for KOTS snapshots**: Velero is required for enabling backup and restore with the KOTS snapshots feature. Namespace-scoped RBAC does not grant access to the namespace where Velero is installed in the cluster. 
 

--- a/docs/vendor/replicated-sdk-customizing.mdx
+++ b/docs/vendor/replicated-sdk-customizing.mdx
@@ -157,9 +157,9 @@ replicated:
 ```
 
 :::note
-If any of your customers install your application with KOTS in an existing cluster using the minimum KOTS RBAC permissions, then `minimalRBAC` is required rather than optional. KOTS can only grant permissions that it holds itself, and it cannot grant the default SDK Role from a reduced set of permissions. Defining `statusInformers` reduces the required permissions further.
+This requirement applies only to installations with KOTS in an existing cluster. It does not apply to Helm installations or to Embedded Cluster installations.
 
-This applies only to installations in existing clusters. It does not apply to Embedded Cluster installations, where KOTS has cluster-scoped access. For more information, see [Namespace-scoped RBAC Requirements](/enterprise/installing-general-requirements#namespace-scoped).
+If any of your customers install with the minimum KOTS RBAC permissions, then `minimalRBAC` is required rather than optional. KOTS can only grant permissions that it holds itself, and it cannot grant the default SDK Role from a reduced set of permissions. Defining `statusInformers` reduces the required permissions further. For more information, see [Namespace-scoped RBAC Requirements](/enterprise/installing-general-requirements#namespace-scoped).
 :::
 
 The permissions included in the Minimal RBAC role vary depending on if you defined custom _status informers_ for your application. See one of the following sections for more information:

--- a/docs/vendor/replicated-sdk-customizing.mdx
+++ b/docs/vendor/replicated-sdk-customizing.mdx
@@ -156,6 +156,12 @@ replicated:
   minimalRBAC: true
 ```
 
+:::note
+If any of your customers install your application with KOTS in an existing cluster using the minimum KOTS RBAC permissions, then `minimalRBAC` is required rather than optional. KOTS can only grant permissions that it holds itself, and it cannot grant the default SDK Role from a reduced set of permissions. Defining `statusInformers` reduces the required permissions further.
+
+This applies only to installations in existing clusters. It does not apply to Embedded Cluster installations, where KOTS has cluster-scoped access. For more information, see [Namespace-scoped RBAC Requirements](/enterprise/installing-general-requirements#namespace-scoped).
+:::
+
 The permissions included in the Minimal RBAC role vary depending on if you defined custom _status informers_ for your application. See one of the following sections for more information:
 * [Default Minimal RBAC Role Without Custom Status Informers](#default-no-status-informers)
 * [Default Minimal RBAC Role With Custom Status Informers](#default-status-informers)


### PR DESCRIPTION
## What

The published minimum KOTS RBAC permissions install KOTS successfully, but they are not sufficient to install an application whose Helm chart includes the Replicated SDK. A user who follows the current instructions ends up with a working Admin Console and a failing application install.

## Why

The SDK ships its own ServiceAccount, Role, and RoleBinding, which KOTS creates during installation. Two things go wrong with the currently published Role:

1. It grants `serviceaccounts`, `roles`, and `rolebindings` only `get`, so the create is refused outright.
2. Kubernetes prevents KOTS from granting permissions it does not hold itself, and the SDK's Role requests `apps/replicasets` and, in some configurations, `discovery.k8s.io/endpointslices`. Neither appears in our published Role.

This only affects users who install KOTS namespace-scoped **and** supply their own reduced Role with `--ensure-rbac=false`. Users who let KOTS create its own namespaced Role hold `* * *` in the namespace and are unaffected.

## Changes

**`enterprise/installing-general-requirements.mdx`** adds a step to the namespace-scoped procedure listing the additional rules. It is modeled on the existing CRD step and does not modify either of the existing rule blocks, so the copy-paste `rbac.yaml` path is unchanged. The step distinguishes the rules that are always required from those needed only when status informers are not defined, or when Service or Ingress informers are defined. It stays deliberately terse, since vendors adapt this page into their own installation instructions rather than end users reading it directly. The reasoning, and the two SDK configurations that cannot be installed this way at all, live on the vendor pages where the configuration choice is actually made.

**`vendor/packaging-rbac.md`** adds the vendor-facing half, which was missing entirely. The page told vendors that users on this path need extra permissions for CRDs, but said nothing about charts that create their own RBAC objects. Adds a bullet and a Limitations entry.

**`vendor/replicated-sdk-customizing.mdx`** notes that `minimalRBAC` is required rather than optional when a vendor's users install with the minimum KOTS RBAC permissions. The page previously presented it purely as an option for reducing SDK permissions.

## Verification

The rules were verified leave-one-out against a live API server, individually necessary and sufficient together. Each one was cross-checked against the SDK chart's `replicated-role.yaml` to confirm the conditional rules match the actual template gates.

Two deliberate refinements against the originally reported list. `replicasets` is `get` only in the always-required set, since the chart's unconditional block asks only for `get` and the `list`/`watch` verbs appear only under the no-status-informers path. And the conditional rules are split into two cases rather than one, because `endpointslices` is needed in more situations than `replicasets` `list`/`watch` is.

## What this does not cover

Both `replicated.minimalRBAC: false` and `replicated.clusterRole` remain unsupported on this install path, the second one categorically, since a namespaced Role can never authorize creating a ClusterRoleBinding. Both are now called out in the docs on the customer and vendor pages, with `replicated.serviceAccountName` as the alternative. This PR documents the constraint; it does not remove it.

Refs sc-139524
