### PR TITLE
Retire the KOTS v1.82.0 framing from the air gap bundle format docs

### DIFF
--- a/docs/vendor/private-images-tags-digests.md
+++ b/docs/vendor/private-images-tags-digests.md
@@ -21,7 +21,7 @@ The following table describes the use cases in which image tags and digests are 
     <td>Air Gap</td>
     <td>Supported by default for Replicated KOTS installations</td>
     <td>
-    <p>Supported for applications on KOTS v1.82.0 and later when the <b>Enable new air gap bundle format</b> toggle is enabled on the channel.</p>
+    <p>Supported when the <b>Enable new air gap bundle format</b> toggle is enabled on the channel.</p>
     <p>For more information, see <a href="#digests-air-gap">Using Image Digests in Air Gap Installations</a> below.</p>
     </td>
   </tr>
@@ -33,7 +33,7 @@ You can use image tags and image digests together in any case where both are sup
 
 ## Using image digests in air gap installations {#digests-air-gap}
 
-For applications installed with KOTS v1.82.0 or later, you can enable a format for air gap bundles that supports the use of image digests. This air gap bundle format also ensures that identical image layers are not duplicated, resulting in a smaller air gap bundle size.
+You can enable a format for air gap bundles that supports the use of image digests. This air gap bundle format also ensures that identical image layers are not duplicated, resulting in a smaller air gap bundle size.
 
 :::note
 This air gap bundle format is required for air gap installations with Replicated Embedded Cluster. Air gap builds fail for releases that include an Embedded Cluster Config when the channel does not use this format.
@@ -43,29 +43,10 @@ You can enable or disable this air gap bundle format using the **Enable new air 
 
 When you enable **Enable new air gap bundle format** on a channel, all air gap bundles that you build or rebuild on that channel use the updated air gap bundle format.
 
-If users on a version of KOTS earlier than v1.82.0 attempt to install or upgrade an application with an air gap bundle that uses the **Enable new air gap bundle format** format, then the Admin Console displays an error message when they attempt to upload the bundle.
-
 To enable the new air gap bundle format on a channel:
 
 1. In the Replicated [Vendor Portal](https://vendor.replicated.com/channels), go to the Channels page and click the edit icon in the top right of the channel where you want to use the new air gap bundle format.
 1. Enable the **Enable new air gap bundle format** toggle.
-1. (Recommended) To prevent users on a version of KOTS earlier than v1.82.0 from attempting to upgrade with an air gap bundle that uses the new air gap bundle format, set `minKotsVersion` to "1.82.0" in the Application custom resource manifest file.
-
-   `minKotsVersion` defines the minimum version of KOTS required by the application release. Including `minKotsVersion` displays a warning in the Admin Console when users attempt to install or upgrade the application if they are not on the specified minimum version or later. For more information, see [Setting Minimum and Target Versions for KOTS](packaging-kots-versions).
-
-   **Example**:
-
-   ```yaml
-   apiVersion: kots.io/v1beta1
-   kind: Application
-   metadata:
-     name: my-application
-   spec:
-     ...
-     minKotsVersion: "1.82.0"
-     ...
-   ```
-
 1. Test your changes:
    1. Save and promote the release to a development environment.
    1. On the channel where you enabled **Enable new air gap bundle format**, click **Release history**. On the Release History page, click **Build** next to the latest release to create an air gap bundle with the new format.
@@ -73,4 +54,4 @@ To enable the new air gap bundle format on a channel:
       ![Vendor portal release history page](../../static/images/airgap-download-bundle.png)
 
    1. Click **Download Airgap Bundle**.
-   1. Install or upgrade the application with version 1.82.0 or later of the Admin Console or the KOTS CLI. Upload the new air gap bundle to confirm that the installation or upgrade completes successfully.
+   1. Install or upgrade the application. Upload the new air gap bundle to confirm that the installation or upgrade completes successfully.

--- a/docs/vendor/releases-about.mdx
+++ b/docs/vendor/releases-about.mdx
@@ -53,7 +53,7 @@ The following describes each of the channel settings:
     * **Enable new airgap bundle format**: When enabled, air gap bundles built for releases promoted to the channel use a format that supports image digests. This air gap bundle format also ensures that identical image layers are not duplicated, resulting in a smaller air gap bundle size. For more information, see [Use Image Digests in Air Gap Installations](private-images-tags-digests#digests-air-gap) in _Use Image Tags and Digests_.
 
       :::note
-      The new air gap bundle format is required for air gap installations with Replicated Embedded Cluster. It is supported for applications installed with KOTS v1.82.0 or later.
+      The new air gap bundle format is required for air gap installations with Replicated Embedded Cluster.
       :::  
    
 ## About releases


### PR DESCRIPTION
## What

Removes the KOTS v1.82.0 qualifiers from the air gap bundle format documentation, and drops the recommendation to set `minKotsVersion` to `"1.82.0"`.

## Why

KOTS v1.82.0 shipped in **August 2022**. Presenting it as a live consideration makes the legacy air gap bundle format look like a supported choice with a real tradeoff, when the only reason to prefer it is supporting installs more than four years old.

This follows #4492, which documented that Embedded Cluster requires this format. That requirement is now the reason the setting matters, so the version framing is both stale and a distraction from it.

## Changes

`docs/vendor/private-images-tags-digests.md`

- Support table: drops the version qualifier from the air gap digests cell
- Section intro: drops "For applications installed with KOTS v1.82.0 or later"
- Removes the paragraph describing the Admin Console upload error on older KOTS
- Removes the "(Recommended)" step to set `minKotsVersion` to `"1.82.0"`, along with its explanation and YAML example. `minKotsVersion` itself remains documented in [Setting Minimum and Target Versions for KOTS](https://docs.replicated.com/vendor/packaging-kots-versions); only this specific recommendation goes away
- Final test step: drops the version requirement

`docs/vendor/releases-about.mdx`

- Simplifies the note added in #4492 so it states the Embedded Cluster requirement and nothing else

No other references to v1.82.0 remain outside release notes, which are historical and left alone.

## Testing

`npm run build` succeeds. No headings were removed, so no anchors changed. The two broken anchors the build reports near these pages are pre-existing and come from old release notes pointing at a page that does not exist on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)