### PR TITLE
docs: document remove-node then reset flow for EC v3 node removal

### DIFF
--- a/embedded-cluster/embedded-cluster-remove-node.mdx
+++ b/embedded-cluster/embedded-cluster-remove-node.mdx
@@ -21,12 +21,12 @@ Replace `node-name` with the Kubernetes node name to remove.
   <tr>
     <td>`--force`</td>
     <td></td>
-    <td>Force removal without additional confirmation.</td>
+    <td>Force removal of a controller node even if removing it breaks etcd quorum. This is dangerous and can leave the cluster inoperable.</td>
   </tr>
   <tr>
     <td>`--skip-drain`</td>
     <td></td>
-    <td>Skip draining workloads from the node before removal.</td>
+    <td>Skip draining workloads from the node before removal. Use this flag to remove a node that is already unreachable.</td>
   </tr>
   <tr>
     <td>`-h`, `--help`</td>

--- a/embedded-cluster/embedded-cluster-reset.mdx
+++ b/embedded-cluster/embedded-cluster-reset.mdx
@@ -19,7 +19,7 @@ sudo ./<app-slug> reset [flags]
   <tr>
     <td>`-f`, `--force`</td>
     <td></td>
-    <td>Ignore errors encountered when resetting the node.</td>
+    <td>Skip the confirmation prompt and continue past any errors encountered when resetting the node.</td>
   </tr>
   <tr>
     <td>`-h`, `--help`</td>

--- a/embedded-cluster/embedded-manage-nodes.mdx
+++ b/embedded-cluster/embedded-manage-nodes.mdx
@@ -163,7 +163,7 @@ To remove a node from a multi-node cluster, run the `remove-node` command from a
 Run the `remove-node` command from a controller node other than the node that you want to remove. The command performs the following steps:
 
 1. Drain workloads from the node so that they reschedule onto other nodes in the cluster
-1. For controller nodes, remove the node from the etcd cluster and delete the autopilot ControlNode object
+1. For controller nodes, remove the node from the etcd cluster
 1. Delete the node from Kubernetes
 
 The `reset` command removes Embedded Cluster and your application from the machine where it is run. This is useful for iteration, development, and when you make mistakes because you can reuse the machine instead of having to procure a new one.
@@ -195,7 +195,7 @@ To remove a node from a multi-node cluster:
     * `NODE_NAME` is the Kubernetes node name of the node to remove. To list the node names in the cluster, run `sudo ./APP_SLUG shell -c "kubectl get nodes"`.
 
     :::note
-    If the node is unreachable, include the `--skip-drain` flag to skip draining workloads from the node. If the node's Kubernetes object is already gone, `remove-node` skips directly to the etcd and ControlNode cleanup.
+    If the node is unreachable, include the `--skip-drain` flag to skip draining workloads from the node. If the node's Kubernetes object is already gone, `remove-node` skips directly to the etcd cleanup.
     :::
 
 1. (Optional) Reset the machine that you removed so that you can reuse it. See [Reset a machine](#reset-a-node) in this document.

--- a/embedded-cluster/embedded-manage-nodes.mdx
+++ b/embedded-cluster/embedded-manage-nodes.mdx
@@ -122,7 +122,7 @@ To create a multi-node cluster with HA:
 
 * During installation with Embedded Cluster, follow the steps in the Embedded Cluster UI to join a total of three `controller` nodes to the cluster. For more information about joining nodes, see [Join nodes](#add-nodes) on this page.
 
-   Embedded Cluster automatically converts the installation to HA when three or more controller nodes are present. 
+   Embedded Cluster automatically converts the installation to HA when three or more controller nodes are present.
 
 ### Enable HA for an existing cluster {#enable-ha-existing}
 
@@ -215,9 +215,9 @@ To reset a node:
 
 ### Remove a multi-node cluster
 
-To remove an entire multi-node cluster, remove each node with `remove-node`, starting with the worker nodes and ending with the controller nodes. On the last remaining controller node, run `reset` directly, because there is no other controller left to run `remove-node` from. For more information, see [Remove a node from a multi-node cluster](#remove-a-node) in this document.
+To remove an entire multi-node cluster, remove each node with `remove-node`, starting with the worker nodes and ending with the controller nodes. On the last remaining controller node, run `reset` directly, because there is no other controller left to run `remove-node` from. Optionally, reset each machine that you remove so that you can reuse it. See [Reset a node](#reset-a-node) in this document.
 
-Optionally, reset each machine that you remove so that you can reuse it. See [Reset a node](#reset-a-node) in this document.
+For more information, see [Remove a node from a multi-node cluster](#remove-a-node) in this document.
 
 ### Limitations and best practices
 

--- a/embedded-cluster/embedded-manage-nodes.mdx
+++ b/embedded-cluster/embedded-manage-nodes.mdx
@@ -154,14 +154,11 @@ Where `APP_SLUG` is the unique slug for the application. All nodes should show `
 
 ## Remove nodes and reset machines
 
-This section describes how to remove individual nodes from a cluster using the Embedded Cluster [remove-node](embedded-cluster-remove-node) command. It also describes how to reset machines and delete an entire multi-node cluster using the [reset](embedded-cluster-reset) command.
+This section describes how to remove individual nodes from a cluster and how to delete an entire multi-node cluster using the Embedded Cluster [remove-node](embedded-cluster-remove-node) and [reset](embedded-cluster-reset) commands.
 
 ### About the `remove-node` and `reset` commands
 
-Removing a node from a multi-node cluster is a two-step process:
-
-1. From a controller node, run the `remove-node` command to remove the target node from the cluster.
-1. On the machine that you removed, run the `reset` command to remove Embedded Cluster and your application from that machine.
+To remove a node from a multi-node cluster, run the `remove-node` command from a controller node. Then, if you want to reuse the machine that you removed, run the `reset` command on it to remove Embedded Cluster and your application from that machine.
 
 Run the `remove-node` command from a controller node other than the node that you want to remove. The command performs the following steps:
 
@@ -192,7 +189,7 @@ Before you remove a node or delete a cluster, consider the following limitations
 
 * When resetting a single node or deleting a test environment, you can include the `--force` flag with the `reset` command to ignore any errors.
 
-* When removing a multi-node cluster, remove and reset the worker nodes before the controller nodes. For more information, see [Remove a multi-node cluster](#remove-a-multi-node-cluster) in this document.
+* When removing a multi-node cluster, remove the worker nodes before the controller nodes. For more information, see [Remove a multi-node cluster](#remove-a-multi-node-cluster) in this document.
 
 ### Remove a node from a multi-node cluster {#remove-a-node}
 
@@ -209,17 +206,11 @@ To remove a node from a multi-node cluster:
     * `APP_SLUG` is the unique slug for the application.
     * `NODE_NAME` is the Kubernetes node name of the node to remove. To list the node names in the cluster, run `sudo ./APP_SLUG shell -c "kubectl get nodes"`.
 
-1. SSH onto the machine that you removed and reset it:
-
-    ```bash
-    sudo ./APP_SLUG reset
-    ```
-
-1. Reboot the machine.
+1. (Optional) Reset the machine that you removed so that you can reuse it. See [Reset a node](#reset-a-node) in this document.
 
 ### Reset a node {#reset-a-node}
 
-For single-node installations, or for the last remaining controller node when deleting a multi-node cluster, run the `reset` command directly. For all other nodes in a multi-node cluster, first remove the node from the cluster. See [Remove a node from a multi-node cluster](#remove-a-node) in this document.
+For single-node installations, or for the last remaining controller node when deleting a multi-node cluster, run the `reset` command directly. For all other nodes in a multi-node cluster, first remove the node from the cluster by running `remove-node` from a controller node. See [Remove a node from a multi-node cluster](#remove-a-node) in this document.
 
 To reset a node:
 
@@ -236,14 +227,4 @@ To reset a node:
 
 ### Remove a multi-node cluster
 
-To remove a multi-node cluster:
-
-1. For each worker node in the cluster, run `remove-node` from a controller node, then run `reset` on the worker machine. See [Remove a node from a multi-node cluster](#remove-a-node) in this document.
-
-   :::note
-   The safety checks for the `reset` command prevent you from resetting a controller node that is still a member of the cluster's etcd.
-   :::
-
-1. After resetting all the worker nodes, remove and reset each controller node except the last one in the same way.
-
-1. On the last remaining controller node, run the `reset` command directly. See [Reset a node](#reset-a-node) in this document.
+To remove an entire multi-node cluster, remove each node with `remove-node`, starting with the worker nodes and ending with the controller nodes. On the last remaining controller node, run `reset` directly, because there is no other controller left to run `remove-node` from. For more information, see [Remove a node from a multi-node cluster](#remove-a-node) and [Reset a node](#reset-a-node) in this document.

--- a/embedded-cluster/embedded-manage-nodes.mdx
+++ b/embedded-cluster/embedded-manage-nodes.mdx
@@ -235,4 +235,4 @@ Before you remove a node or delete a cluster, consider the following limitations
 
 * When removing a multi-node cluster, remove the worker nodes before the controller nodes. For more information, see [Remove a multi-node cluster](#remove-a-multi-node-cluster) in this document.
 
-* If SeaweedFS is installed, follow the volume rebalancing procedures in the operator runbook after removing a node.
+* In air gap installations with high availability, SeaweedFS stores object storage data across nodes in the cluster. After removing a node, verify that all pods in the `seaweedfs` namespace are in a `Running` state before removing additional nodes.

--- a/embedded-cluster/embedded-manage-nodes.mdx
+++ b/embedded-cluster/embedded-manage-nodes.mdx
@@ -152,67 +152,98 @@ sudo ./APP_SLUG shell -c "kubectl get nodes"
 
 Where `APP_SLUG` is the unique slug for the application. All nodes should show `Ready` status before proceeding with the next reboot.
 
-## Reset nodes and remove clusters
+## Remove nodes and reset machines
 
-This section describes how to reset individual nodes and how to delete an entire multi-node cluster using the Embedded Cluster [reset](embedded-cluster-reset) command.
+This section describes how to remove individual nodes from a cluster using the Embedded Cluster [remove-node](embedded-cluster-remove-node) command. It also describes how to reset machines and delete an entire multi-node cluster using the [reset](embedded-cluster-reset) command.
 
-### About the `reset` command
+### About the `remove-node` and `reset` commands
 
-Resetting a node with Embedded Cluster removes the cluster and your application from that node. This is useful for iteration, development, and when you make mistakes because you can reuse the machine instead of having to procure a new one.
+Removing a node from a multi-node cluster is a two-step process:
+
+1. From a controller node, run the `remove-node` command to remove the target node from the cluster.
+1. On the machine that you removed, run the `reset` command to remove Embedded Cluster and your application from that machine.
+
+Run the `remove-node` command from a controller node other than the node that you want to remove. The command performs the following steps:
+
+1. Drain workloads from the node so that they reschedule onto other nodes in the cluster
+1. For controller nodes, remove the node from the etcd cluster
+1. Delete the node from Kubernetes
+
+The `reset` command removes Embedded Cluster and your application from the machine where it is run. This is useful for iteration, development, and when you make mistakes because you can reuse the machine instead of having to procure a new one.
 
 The `reset` command performs the following steps:
 
-1. Run safety checks. For example, `reset` does not remove a controller node when there are workers nodes available. And, it does not remove a node when the etcd cluster is unhealthy.
-1. Drain the node and evict all the Pods gracefully
-1. Delete the node from the cluster
+1. Run safety checks. For example, `reset` does not proceed on a controller node that is still a member of a multi-node cluster's etcd
+1. For worker nodes that are still in the cluster, drain the node and evict all the Pods gracefully
 1. Stop and reset k0s
 1. Remove all Embedded Cluster files
-1. Reboot the node
 
-For more information about the command, see [reset](embedded-cluster-reset).
+The `reset` command does not remove the node from the cluster. To reset a controller node in a multi-node cluster, first run `remove-node` from another controller node. If you run `reset` on a worker node without first running `remove-node` from a controller node, the node's workloads are drained, but the node remains in the cluster in a `NotReady` state until you remove it with `remove-node`.
+
+For more information about these commands, see [remove-node](embedded-cluster-remove-node) and [reset](embedded-cluster-reset).
 
 ### Limitations and best practices
 
-Before you reset a node or remove a cluster, consider the following limitations and best practices:
+Before you remove a node or delete a cluster, consider the following limitations and best practices:
 
 * When you reset a node, Embedded Cluster deletes OpenEBS PVCs on that node. Kubernetes automatically recreates only PVCs created as part of a StatefulSet on another node in the cluster. To recreate other PVCs, redeploy the application in the cluster.
 
-* If you need to reset one controller node in a three-node cluster, first join a fourth controller node to the cluster before removing the target node. This ensures that you maintain a minimum of three nodes for the Kubernetes control plane. You can add and remove worker nodes as needed because they do not have any control plane components.
+* If you need to remove one controller node in a three-node cluster, first join a fourth controller node to the cluster before removing the target node. This ensures that you maintain a minimum of three nodes for the Kubernetes control plane. You can add and remove worker nodes as needed because they do not have any control plane components.
 
 * When resetting a single node or deleting a test environment, you can include the `--force` flag with the `reset` command to ignore any errors.
 
-* When removing a multi-node cluster, run `reset` on each of the worker nodes first. Then, run `reset` on controller nodes. Controller nodes also remove themselves from etcd membership.
+* When removing a multi-node cluster, remove and reset the worker nodes before the controller nodes. For more information, see [Remove a multi-node cluster](#remove-a-multi-node-cluster) in this document.
+
+### Remove a node from a multi-node cluster {#remove-a-node}
+
+To remove a node from a multi-node cluster:
+
+1. SSH onto a controller node other than the node that you want to remove.
+
+1. Remove the target node from the cluster:
+
+    ```bash
+    sudo ./APP_SLUG remove-node NODE_NAME
+    ```
+    Where:
+    * `APP_SLUG` is the unique slug for the application.
+    * `NODE_NAME` is the Kubernetes node name of the node to remove. To list the node names in the cluster, run `sudo ./APP_SLUG shell -c "kubectl get nodes"`.
+
+1. SSH onto the machine that you removed and reset it:
+
+    ```bash
+    sudo ./APP_SLUG reset
+    ```
+
+1. Reboot the machine.
 
 ### Reset a node {#reset-a-node}
+
+For single-node installations, or for the last remaining controller node when deleting a multi-node cluster, run the `reset` command directly. For all other nodes in a multi-node cluster, first remove the node from the cluster. See [Remove a node from a multi-node cluster](#remove-a-node) in this document.
 
 To reset a node:
 
 1. SSH onto the node. Ensure that the Embedded Cluster binary is still available on the machine.
 
-1. Run the following command to remove the node and reboot the machine:
+1. Run the following command to reset the machine:
 
     ```bash
     sudo ./APP_SLUG reset
     ```
     Where `APP_SLUG` is the unique slug for the application.
 
+1. Reboot the machine.
+
 ### Remove a multi-node cluster
 
 To remove a multi-node cluster:
 
-1. SSH onto a worker node.
+1. For each worker node in the cluster, run `remove-node` from a controller node, then run `reset` on the worker machine. See [Remove a node from a multi-node cluster](#remove-a-node) in this document.
 
    :::note
-   The safety checks for the `reset` command prevent you from removing a controller node when there are still worker nodes available in the cluster.
+   The safety checks for the `reset` command prevent you from resetting a controller node that is still a member of the cluster's etcd.
    :::
 
-1. Remove the node and reboot the machine:
+1. After resetting all the worker nodes, remove and reset each controller node except the last one in the same way.
 
-   ```bash
-   sudo ./APP_SLUG reset
-   ```
-   Where `APP_SLUG` is the unique slug for the application.
-
-1. After removing all the worker nodes in the cluster, SSH onto a controller node and run the `reset` command to remove the node.
-
-1. Repeat the previous step on the remaining controller nodes in the cluster.
+1. On the last remaining controller node, run the `reset` command directly. See [Reset a node](#reset-a-node) in this document.

--- a/embedded-cluster/embedded-manage-nodes.mdx
+++ b/embedded-cluster/embedded-manage-nodes.mdx
@@ -163,7 +163,7 @@ To remove a node from a multi-node cluster, run the `remove-node` command from a
 Run the `remove-node` command from a controller node other than the node that you want to remove. The command performs the following steps:
 
 1. Drain workloads from the node so that they reschedule onto other nodes in the cluster
-1. For controller nodes, remove the node from the etcd cluster
+1. For controller nodes, remove the node from the etcd cluster and delete the autopilot ControlNode object
 1. Delete the node from Kubernetes
 
 The `reset` command removes Embedded Cluster and your application from the machine where it is run. This is useful for iteration, development, and when you make mistakes because you can reuse the machine instead of having to procure a new one.
@@ -194,13 +194,17 @@ To remove a node from a multi-node cluster:
     * `APP_SLUG` is the unique slug for the application.
     * `NODE_NAME` is the Kubernetes node name of the node to remove. To list the node names in the cluster, run `sudo ./APP_SLUG shell -c "kubectl get nodes"`.
 
-1. (Optional) Reset the machine that you removed so that you can reuse it. See [Reset a node](#reset-a-node) in this document.
+    :::note
+    If the node is unreachable, include the `--skip-drain` flag to skip draining workloads from the node. If the node's Kubernetes object is already gone, `remove-node` skips directly to the etcd and ControlNode cleanup.
+    :::
 
-### Reset a node {#reset-a-node}
+1. (Optional) Reset the machine that you removed so that you can reuse it. See [Reset a machine](#reset-a-node) in this document.
+
+### Reset a machine {#reset-a-node}
 
 For single-node installations, or for the last remaining controller node when deleting a multi-node cluster, run the `reset` command directly. For all other nodes in a multi-node cluster, first remove the node from the cluster by running `remove-node` from a controller node. See [Remove a node from a multi-node cluster](#remove-a-node) in this document.
 
-To reset a node:
+To reset a machine:
 
 1. SSH onto the node. Ensure that the Embedded Cluster binary is still available on the machine.
 
@@ -215,7 +219,7 @@ To reset a node:
 
 ### Remove a multi-node cluster
 
-To remove an entire multi-node cluster, remove each node with `remove-node`, starting with the worker nodes and ending with the controller nodes. On the last remaining controller node, run `reset` directly, because there is no other controller left to run `remove-node` from. Optionally, reset each machine that you remove so that you can reuse it. See [Reset a node](#reset-a-node) in this document.
+To remove an entire multi-node cluster, remove each node with `remove-node`, starting with the worker nodes and ending with the controller nodes. On the last remaining controller node, run `reset` directly, because there is no other controller left to run `remove-node` from. Optionally, reset each machine that you remove so that you can reuse it. See [Reset a machine](#reset-a-node) in this document.
 
 For more information, see [Remove a node from a multi-node cluster](#remove-a-node) in this document.
 
@@ -227,6 +231,8 @@ Before you remove a node or delete a cluster, consider the following limitations
 
 * If you need to remove one controller node in a three-node cluster, first join a fourth controller node to the cluster before removing the target node. This ensures that you maintain a minimum of three nodes for the Kubernetes control plane. You can add and remove worker nodes as needed because they do not have any control plane components.
 
-* When resetting a single node or deleting a test environment, you can include the `--force` flag with the `reset` command to ignore any errors.
+* When resetting a single node or deleting a test environment, you can include the `--force` flag with the `reset` command to skip the confirmation prompt and continue past any errors.
 
 * When removing a multi-node cluster, remove the worker nodes before the controller nodes. For more information, see [Remove a multi-node cluster](#remove-a-multi-node-cluster) in this document.
+
+* If SeaweedFS is installed, follow the volume rebalancing procedures in the operator runbook after removing a node.

--- a/embedded-cluster/embedded-manage-nodes.mdx
+++ b/embedded-cluster/embedded-manage-nodes.mdx
@@ -158,7 +158,7 @@ This section describes how to remove individual nodes from a cluster and how to 
 
 ### About the `remove-node` and `reset` commands
 
-To remove a node from a multi-node cluster, run the `remove-node` command from a controller node. Then, if you want to reuse the machine that you removed, run the `reset` command on it to remove Embedded Cluster and your application from that machine.
+To remove a node from a multi-node cluster, run the `remove-node` command from a controller node. Then, if you want to reuse the machine that you removed, run the `reset` command on it to remove Embedded Cluster from that machine.
 
 Run the `remove-node` command from a controller node other than the node that you want to remove. The command performs the following steps:
 
@@ -178,18 +178,6 @@ The `reset` command performs the following steps:
 The `reset` command does not remove the node from the cluster. To reset a controller node in a multi-node cluster, first run `remove-node` from another controller node. If you run `reset` on a worker node without first running `remove-node` from a controller node, the node's workloads are drained, but the node remains in the cluster in a `NotReady` state until you remove it with `remove-node`.
 
 For more information about these commands, see [remove-node](embedded-cluster-remove-node) and [reset](embedded-cluster-reset).
-
-### Limitations and best practices
-
-Before you remove a node or delete a cluster, consider the following limitations and best practices:
-
-* When you reset a node, Embedded Cluster deletes OpenEBS PVCs on that node. Kubernetes automatically recreates only PVCs created as part of a StatefulSet on another node in the cluster. To recreate other PVCs, redeploy the application in the cluster.
-
-* If you need to remove one controller node in a three-node cluster, first join a fourth controller node to the cluster before removing the target node. This ensures that you maintain a minimum of three nodes for the Kubernetes control plane. You can add and remove worker nodes as needed because they do not have any control plane components.
-
-* When resetting a single node or deleting a test environment, you can include the `--force` flag with the `reset` command to ignore any errors.
-
-* When removing a multi-node cluster, remove the worker nodes before the controller nodes. For more information, see [Remove a multi-node cluster](#remove-a-multi-node-cluster) in this document.
 
 ### Remove a node from a multi-node cluster {#remove-a-node}
 
@@ -227,4 +215,18 @@ To reset a node:
 
 ### Remove a multi-node cluster
 
-To remove an entire multi-node cluster, remove each node with `remove-node`, starting with the worker nodes and ending with the controller nodes. On the last remaining controller node, run `reset` directly, because there is no other controller left to run `remove-node` from. For more information, see [Remove a node from a multi-node cluster](#remove-a-node) and [Reset a node](#reset-a-node) in this document.
+To remove an entire multi-node cluster, remove each node with `remove-node`, starting with the worker nodes and ending with the controller nodes. On the last remaining controller node, run `reset` directly, because there is no other controller left to run `remove-node` from. For more information, see [Remove a node from a multi-node cluster](#remove-a-node) in this document.
+
+Optionally, reset each machine that you remove so that you can reuse it. See [Reset a node](#reset-a-node) in this document.
+
+### Limitations and best practices
+
+Before you remove a node or delete a cluster, consider the following limitations and best practices:
+
+* When you reset a node, Embedded Cluster deletes OpenEBS PVCs on that node. Kubernetes automatically recreates only PVCs created as part of a StatefulSet on another node in the cluster. To recreate other PVCs, redeploy the application in the cluster.
+
+* If you need to remove one controller node in a three-node cluster, first join a fourth controller node to the cluster before removing the target node. This ensures that you maintain a minimum of three nodes for the Kubernetes control plane. You can add and remove worker nodes as needed because they do not have any control plane components.
+
+* When resetting a single node or deleting a test environment, you can include the `--force` flag with the `reset` command to ignore any errors.
+
+* When removing a multi-node cluster, remove the worker nodes before the controller nodes. For more information, see [Remove a multi-node cluster](#remove-a-multi-node-cluster) in this document.

--- a/embedded-cluster/embedded-troubleshooting.mdx
+++ b/embedded-cluster/embedded-troubleshooting.mdx
@@ -90,7 +90,7 @@ To troubleshoot:
     ```
     Where `APP_SLUG` is the unique slug for the application. 
 
-    For more information, see [Reset a Node](embedded-manage-nodes#reset-a-node) in _Access and Manage Embedded Clusters_.
+    For more information, see [Reset a Machine](embedded-manage-nodes#reset-a-node) in _Access and Manage Embedded Clusters_.
 
 1. Re-install with Embedded Cluster.
 
@@ -156,7 +156,7 @@ Reasons can include:
        ```
        Where `APP_SLUG` is the unique slug for the application. 
 
-       For more information, see [Reset a Node](embedded-manage-nodes#reset-a-node) in _Access and Manage Embedded Clusters_.
+       For more information, see [Reset a Machine](embedded-manage-nodes#reset-a-node) in _Access and Manage Embedded Clusters_.
 
     1. Reinstall the application with different CIDRs using the `--cidr` flag:
 
@@ -191,7 +191,7 @@ Reasons can include:
        sudo ./APP_SLUG reset
        ```
        Where `APP_SLUG` is the unique slug for the application. 
-       For more information, see [Reset a Node](embedded-manage-nodes#reset-a-node) in _Access and Manage Embedded Clusters_.
+       For more information, see [Reset a Machine](embedded-manage-nodes#reset-a-node) in _Access and Manage Embedded Clusters_.
 
     1. Re-install with Embedded Cluster.
   </TabItem>


### PR DESCRIPTION
The reset command no longer deletes the node from the cluster. Node removal is now done with remove-node run
from a controller. Update the manage-nodes procedures to match.

Cleanups:
- Make `reset` an optional follow-up to `remove-node`, for reusing the machine
- Attribute multi-node cluster deletion to both commands, not `reset` alone
- Move the etcd safety-check note from the worker step to the controller step
- Condense "Remove a multi-node cluster" to a paragraph that links to the node procedures
- Say reset after `remove-node` removes only Embedded Cluster, since the app is already drained
- Move "Limitations and best practices" after the procedures
- End cluster removal with an optional reset of each machine for reuse

Preview (read entire section): https://deploy-preview-4499--replicated-docs-upgrade.netlify.app/embedded-cluster/v3/embedded-manage-nodes