### PR TITLE
Document EC v3 host configuration requirements and drop the private spec link

### DIFF
--- a/docs/partials/embedded-cluster/v3/_host-config-reqs.mdx
+++ b/docs/partials/embedded-cluster/v3/_host-config-reqs.mdx
@@ -1,0 +1,53 @@
+Embedded Cluster verifies the following host configuration with host preflight checks during installation. Configuring these values before you install avoids failed installations.
+
+#### Kernel modules
+
+The following kernel modules must be loaded or loadable:
+
+* `overlay`
+* `br_netfilter`
+* `nf_conntrack`
+
+The host must also have a usable netfilter backend. This means that either the `ip_tables` module, for legacy iptables, or the `nf_tables` module, for nftables, is available.
+
+#### Cgroup controllers
+
+The following cgroup controllers must be available:
+
+`cpu`, `cpuacct`, `cpuset`, `memory`, `devices`, `freezer`, and `pids`
+
+#### Required commands
+
+The `modprobe`, `mount`, and `umount` commands must be available on the host.
+
+#### Network parameters
+
+The following `sysctl` parameters must be set as shown. To change a parameter, add it to `/etc/sysctl.conf` and then run `sudo sysctl -p`.
+
+| Parameter | Required value |
+|---|---|
+| `net.ipv4.ip_forward` | `1` |
+| `net.ipv4.conf.all.forwarding` | `1` |
+| `net.ipv4.conf.default.forwarding` | `1` |
+| `net.bridge.bridge-nf-call-iptables` | `1` |
+| `net.ipv4.conf.all.arp_filter` | `0` |
+| `net.ipv4.conf.default.arp_filter` | `0` |
+| `net.ipv4.conf.all.arp_ignore` | `0` |
+| `net.ipv4.conf.default.arp_ignore` | `0` |
+| `net.ipv4.conf.all.rp_filter` | `2` for loose mode, or `0` to disable |
+| `net.ipv4.conf.default.rp_filter` | `2` for loose mode, or `0` to disable |
+
+Loose mode is preferred for reverse path filtering. Strict mode, which is the value `1`, drops pod traffic.
+
+#### Resource limits
+
+The following `sysctl` parameters must meet these minimums:
+
+| Parameter | Minimum value |
+|---|---|
+| `fs.inotify.max_user_instances` | `1024` |
+| `fs.inotify.max_user_watches` | `65536` |
+
+#### Hostname
+
+The hostname must be 54 characters or fewer. Internal component labels are derived from the node name, and a longer hostname exceeds the Kubernetes 63-character label limit, which prevents the cluster from starting.

--- a/docs/partials/embedded-cluster/v3/_host-config-reqs.mdx
+++ b/docs/partials/embedded-cluster/v3/_host-config-reqs.mdx
@@ -1,53 +1,53 @@
-Embedded Cluster verifies the following host configuration with host preflight checks during installation. Configuring these values before you install avoids failed installations.
+Embedded Cluster configures most of the required kernel settings itself at the start of installation, before the host preflight checks run. The preflight checks then verify the result and report anything that could not be applied.
 
-#### Kernel modules
+This means you do not need to set these values in advance. This section describes what Embedded Cluster changes on the host, which is often needed for security review, and what the host must provide for those changes to succeed.
 
-The following kernel modules must be loaded or loadable:
+#### Kernel settings that Embedded Cluster configures
 
-* `overlay`
-* `br_netfilter`
-* `nf_conntrack`
+Every change below is best effort. If one cannot be applied, installation continues and the host preflight checks report the problem.
 
-The host must also have a usable netfilter backend. This means that either the `ip_tables` module, for legacy iptables, or the `nf_tables` module, for nftables, is available.
+**Kernel modules.** Loaded immediately, and written to `/etc/modules-load.d/99-embedded-cluster.conf` so that they persist across reboots:
 
-#### Cgroup controllers
+`overlay`, `ip_tables`, `nf_tables`, `nft_compat`, `br_netfilter`, and `nf_conntrack`
 
-The following cgroup controllers must be available:
+**Network parameters.** Written to `/etc/sysctl.d/99-embedded-cluster.conf` and applied:
 
-`cpu`, `cpuacct`, `cpuset`, `memory`, `devices`, `freezer`, and `pids`
-
-#### Required commands
-
-The `modprobe`, `mount`, and `umount` commands must be available on the host.
-
-#### Network parameters
-
-The following `sysctl` parameters must be set as shown. To change a parameter, add it to `/etc/sysctl.conf` and then run `sudo sysctl -p`.
-
-| Parameter | Required value |
+| Parameter | Value |
 |---|---|
 | `net.ipv4.ip_forward` | `1` |
 | `net.ipv4.conf.all.forwarding` | `1` |
 | `net.ipv4.conf.default.forwarding` | `1` |
+| `net.ipv6.conf.all.forwarding` | `1` |
+| `net.ipv6.conf.default.forwarding` | `1` |
 | `net.bridge.bridge-nf-call-iptables` | `1` |
+| `net.bridge.bridge-nf-call-ip6tables` | `1` |
 | `net.ipv4.conf.all.arp_filter` | `0` |
 | `net.ipv4.conf.default.arp_filter` | `0` |
 | `net.ipv4.conf.all.arp_ignore` | `0` |
 | `net.ipv4.conf.default.arp_ignore` | `0` |
-| `net.ipv4.conf.all.rp_filter` | `2` for loose mode, or `0` to disable |
-| `net.ipv4.conf.default.rp_filter` | `2` for loose mode, or `0` to disable |
+| `net.ipv4.conf.all.rp_filter` | `2` |
+| `net.ipv4.conf.default.rp_filter` | `2` |
 
-Loose mode is preferred for reverse path filtering. Strict mode, which is the value `1`, drops pod traffic.
+Reverse path filtering is set to loose mode. Strict mode, which is the value `1`, drops pod traffic.
 
-#### Resource limits
-
-The following `sysctl` parameters must meet these minimums:
+**Resource limits.** Written to `/etc/sysctl.d/99-dynamic-embedded-cluster.conf`, and only for values that are currently lower on the host:
 
 | Parameter | Minimum value |
 |---|---|
 | `fs.inotify.max_user_instances` | `1024` |
 | `fs.inotify.max_user_watches` | `65536` |
 
-#### Hostname
+#### What the host must provide
 
-The hostname must be 54 characters or fewer. Internal component labels are derived from the node name, and a longer hostname exceeds the Kubernetes 63-character label limit, which prevents the cluster from starting.
+Embedded Cluster cannot supply the following, so the host must have them before you install:
+
+* The `modprobe` command. If it is missing, Embedded Cluster skips kernel module setup entirely.
+* The `sysctl` command. If it is missing, Embedded Cluster writes the network parameter file but cannot apply it until the host reboots, and does not set the inotify limits at all.
+* The `mount` and `umount` commands.
+* A kernel that provides the modules listed above. Embedded Cluster can load them, but cannot supply them on a kernel that was built without them.
+* The following cgroup controllers: `cpu`, `cpuacct`, `cpuset`, `memory`, `devices`, `freezer`, and `pids`.
+* A hostname of 54 characters or fewer. Internal component labels are derived from the node name, and a longer hostname exceeds the Kubernetes 63-character label limit, which prevents the cluster from starting.
+
+#### Hardened hosts
+
+On hosts that enforce their own kernel parameter policy, through configuration management or a file in `/etc/sysctl.d` that loads after the Embedded Cluster file, that policy can override these values after Embedded Cluster applies them. The host preflight checks report the resulting mismatch. Allow the values above in the host's policy rather than setting them by hand.

--- a/embedded-cluster/embedded-overview.mdx
+++ b/embedded-cluster/embedded-overview.mdx
@@ -73,13 +73,14 @@ For more information, see [About Instance and Event Data](/vendor/instance-insig
 ## Embedded Cluster host preflight checks {#about-host-preflight-checks}
 
 During installation, Embedded Cluster automatically runs a default set of _host preflight checks_. The default host preflight checks verify that the installation environment meets the requirements for Embedded Cluster, such as:
-* The system has sufficient disk space
-* The system has at least 2G of memory and 2 CPU cores
+* The system has sufficient disk space, memory, and CPU cores
+* Required kernel modules and network parameters are configured
+* The ports that Embedded Cluster uses are available
 * The system clock syncs
 
 If any of the Embedded Cluster host preflight checks fail, Embedded Cluster blocks installation and displays a message describing the failure.
 
-For the full default host preflight spec for Embedded Cluster, see [`preflight/embedded`](https://github.com/replicatedhq/ec/tree/f845ba382719a6218ebdca1e0e712452cb3483a4/pkg/preflight/embedded) in the `ec` repository in GitHub.
+The host preflight checks verify the requirements described in [Embedded Cluster installation requirements](installing-embedded-requirements). Ensure that the installation environment meets those requirements before you install.
 
 ### Limitations
 

--- a/embedded-cluster/installing-embedded-requirements.mdx
+++ b/embedded-cluster/installing-embedded-requirements.mdx
@@ -1,5 +1,6 @@
 import EmbeddedClusterRequirements from "../docs/partials/embedded-cluster/v3/_requirements.mdx"
 import EmbeddedClusterPortRequirements from "../docs/partials/embedded-cluster/v3/_port-reqs.mdx"
+import EmbeddedClusterHostConfig from "../docs/partials/embedded-cluster/v3/_host-config-reqs.mdx"
 import FirewallOpeningsIntro from "../docs/partials/install/_firewall-openings-intro.mdx"
 import FirewallOpeningsEc from "../docs/partials/install/_firewall-openings-embedded-cluster.mdx"
 
@@ -10,6 +11,10 @@ This topic lists the installation requirements for Replicated Embedded Cluster. 
 ## System requirements
 
 <EmbeddedClusterRequirements/>
+
+## Host configuration
+
+<EmbeddedClusterHostConfig/>
 
 ## Port requirements
 


### PR DESCRIPTION
Preview links
* https://deploy-preview-4500--replicated-docs-upgrade.netlify.app/embedded-cluster/v3/embedded-overview#about-host-preflight-checks
* https://deploy-preview-4500--replicated-docs-upgrade.netlify.app/embedded-cluster/v3/installing-embedded-requirements#host-configuration

## What

Replaces the broken "full host preflight spec" link on the Embedded Cluster v3 overview with a pointer to the requirements page, and adds a **Host configuration** section to that page covering what the link was standing in for.

## Why

The overview linked to `replicatedhq/ec`, which is private, so every vendor following that link got a 404. It was also pinned to a commit SHA rather than a branch, so it was frozen wherever that commit landed. It is the only link into that repo anywhere in the docs.

The link existed because vendors preparing hosts were hitting blockers one at a time, and handing them the raw spec was a faster answer than writing the requirements down. That was a bandaid. There was also a customization rationale carried over from kURL, where vendors needed the YAML to know what to override, but that does not apply here: the same page states that vendors cannot modify the default host preflight checks or supply their own spec.

Publishing the raw spec would not be a good replacement either. It is 73 checks across three files, most of which restate already-documented requirements in preflight syntax, and the check names expose internal component and runtime detail that Embedded Cluster otherwise keeps out of the vendor-facing surface.

## What was already covered

Mapping the spec against existing docs, most of it is not new:

- the 14 port-availability checks are fully covered by the existing port requirements
- memory, CPU, cgroups v2, disk write latency, data directory space and permissions, and root access are in the system requirements
- API and proxy registry access are the firewall section

## What was missing

The host configuration a sysadmin has to set before installing, which is what this PR adds:

- kernel modules (`overlay`, `br_netfilter`, `nf_conntrack`) and the netfilter backend
- cgroup controllers
- required commands (`modprobe`, `mount`, `umount`)
- network `sysctl` parameters with their required values, including IP forwarding, bridge netfilter, ARP filter and ignore, and reverse path filtering
- inotify limits
- the 54-character hostname limit

Values are taken directly from the host preflight spec, so the checks and the docs describe the same requirements.

## Changes

- `docs/partials/embedded-cluster/v3/_host-config-reqs.mdx` (new)
- `embedded-cluster/installing-embedded-requirements.mdx` — adds the section between system requirements and port requirements
- `embedded-cluster/embedded-overview.mdx` — replaces the link, and updates the summary of what the checks cover so it matches the real groups

## Testing

`npm run build` succeeds. No headings were added or removed on existing pages, so no anchors changed. The two broken anchors the build reports near these pages are pre-existing and come from release notes.

