### PR TITLE
SC-138993 Document KOTS and kURL EP v2 install instructions 4/4

### DIFF
--- a/docs/vendor/enterprise-portal-v2-about.mdx
+++ b/docs/vendor/enterprise-portal-v2-about.mdx
@@ -12,7 +12,7 @@ Content is driven by entitlements and channel assignment, so each customer sees 
 
 ## What your customers can do
 
-- **Install and upgrade**: Step-by-step installation instructions for Helm and Embedded Cluster (Linux), with per-instance commands personalized to each customer's license and environment
+- **Install and upgrade**: Step-by-step installation instructions for Helm and Embedded Cluster (Linux), plus generated KOTS and kURL upgrade CLI commands. Vendors can add KOTS and kURL install pages.
 - **Automate installs and upgrades**: Service account API endpoints let customers create install profiles, fetch structured instructions, and download artifacts from CI/CD systems. For more information, see [Service account automation](/vendor/enterprise-portal-v2-service-account-automation).
 - **Manage instances**: View all deployed instances, check for available updates, and follow inline upgrade instructions
 - **Download install artifacts**: Download air gap bundles, Helm chart tarballs, and CLI tools directly from the portal, including versioned install and update artifacts for KOTS and kURL air gap instances. Available artifacts vary by install method and license entitlements
@@ -28,7 +28,7 @@ The new Enterprise Portal is a complete rebuild of the customer portal experienc
 
 ### New compared to the Classic Enterprise Portal
 
-- **KOTS and kURL support**: Serves KOTS and kURL customers directly in the portal, where they see their instances, browse versions, and download install and update artifacts. These customers previously used the separate Download Portal. For more information, see [KOTS and kURL customers](#kots-and-kurl-customers).
+- **KOTS and kURL support**: Serves KOTS and kURL customers directly in the portal. They can view instances, browse versions, follow generated upgrade CLI commands, and download air gap artifacts. Vendors can add dedicated KOTS and kURL install pages. These customers previously used the separate Download Portal. For more information, see [KOTS and kURL customers](#kots-and-kurl-customers).
 - **Content repo driven**: You manage all portal content (pages, navigation, branding) through a GitHub repo you control, not through Vendor Portal UI forms
 - **MDX components**: Interactive, customer-aware components (install commands, version selectors, upgrade paths) that adapt to each customer's license and instance state
 - **Versioned docs**: Each Git branch becomes a version in the customer's portal, with smart resolution that automatically finds the correct content for any release
@@ -39,7 +39,7 @@ The new Enterprise Portal is a complete rebuild of the customer portal experienc
 
 ### Additionally new compared to the Download Portal {#download-portal}
 
-Customers moving from the Download Portal gain the same content and automation capabilities, except for KOTS and kURL support, which the Download Portal already offered. The new Enterprise Portal also adds the following, which the Download Portal has no equivalent for:
+Customers moving from the Download Portal gain the same content and automation capabilities. The Download Portal already shared KOTS and kURL artifacts. The Enterprise Portal also generates KOTS and kURL install and upgrade CLI commands for customers. It also adds the following, which the Download Portal has no equivalent for:
 
 - **Accounts and teams**: Individual user sign-in through magic link, email invitation, or SAML SSO, replacing the Download Portal's shared password, plus multi-user team management
 - **Instance and update management**: The Instances & Updates page shows deployed instances, detects available updates, and provides inline upgrade steps. The Download Portal has no instance concept.
@@ -47,7 +47,6 @@ Customers moving from the Download Portal gain the same content and automation c
 
 ## Current limitations {#current-limitations}
 
-- The Enterprise Portal does not generate step-by-step install or upgrade instructions for KOTS or kURL installations. These are available only for Embedded Cluster and Helm CLI installations. KOTS and kURL customers with air gap enabled can instead download versioned install and update artifacts. These are available from the Instances & Updates page and from dedicated KOTS and kURL installer pages. For more information, see [KOTS and kURL customers](#kots-and-kurl-customers).
 - Air gap instance records do not appear until the customer creates one from the Instances & Updates page, either by manually entering instance information or by extracting details from an uploaded support bundle. Availability depends on the customer's license having the corresponding install type and air gap option enabled.
 - Security Center data (CVE reports and SBOMs) is available for Helm and Embedded Cluster installations only. Customers whose only instances are KOTS or kURL see an explanatory message instead of security data. Customers with a mix of instance types see Security Center data for their Helm and Embedded Cluster instances.
 - If you have many version branches and need to make a change across all versions, you must update each branch individually.

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -493,6 +493,8 @@ The default content template ships install pages for Embedded Cluster (`pages/in
 
    Customers must transfer `license.yaml` and the downloaded artifacts to the air gap environment before running the commands.
 
+   For KOTS, customers must replace `$YOUR_PRIVATE_REGISTRY` in the generated commands with their private registry hostname. This page has no registry hostname input, and the single-quoted placeholder does not expand as a shell variable.
+
    These pages have no in-page version dropdown. Existing installations keep their selected release. New installations use the release matching the rendered content version, or the latest matching release when no version matches.
 
    Gate these pages on the install-type entitlement and `isAirgapSupported`. Air gap step components use `step="download_assets"`, then `step="install_kots"` or `step="install_kurl"`.
@@ -505,9 +507,9 @@ The default content template ships install pages for Embedded Cluster (`pages/in
 
 **`<HelmUpdateAssets />`**: Renders Helm upgrade instructions. Props: `stepNumber`, `charts` (optional), `exclude` (optional).
 
-**`<KotsUpdateAssets />`**: Renders KOTS upgrade CLI commands for the customer's current instance. Online upgrades use `kubectl kots upstream upgrade --deploy`. Air gap upgrades include artifact downloads on the steps, then `push-images` and `upstream upgrade --airgap-bundle`. Props: `stepNumber`.
+**`<KotsUpdateAssets />`**: Renders KOTS upgrade CLI commands for the customer's current instance. Online upgrades use `kubectl kots upstream upgrade` with `--deploy-version-label` to deploy the selected version. Air gap upgrades include artifact downloads on the steps, then `push-images` and `upstream upgrade --airgap-bundle`. Props: `stepNumber`.
 
-**`<KurlUpdateAssets />`**: Renders kURL upgrade CLI commands for the customer's current instance. Online upgrades reuse the kURL installer command. Air gap upgrades include artifact downloads on the steps, then `upgrade.sh` and `kubectl kots upstream upgrade --airgap-bundle`. Props: `stepNumber`.
+**`<KurlUpdateAssets />`**: Renders kURL upgrade CLI commands for the customer's current instance. Online upgrades reuse the kURL installer command. Air gap upgrades include artifact downloads on the steps, then `install.sh` and `kubectl kots upstream upgrade --airgap-bundle`. Props: `stepNumber`.
 
 **`<UpgradePath>`**: Conditionally shows content based on the customer's current version. Lets you show different upgrade instructions depending on which version the customer is upgrading *from*.
 

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -327,7 +327,7 @@ These components render dynamic, customer-specific installation instructions bas
 <PendingInstallSelector method="linux" />
 ```
 
-Props: `method` (`"linux"` or `"helm"`, required), `network` (`"online"` or `"airgap"`, optional filter), `title` (optional, defaults to "Installations in progress"), `emptyText` (optional), `initialVisible` (optional, number of items to show before "Show all").
+Props: `method` (`"linux"`, `"helm"`, `"kots"`, or `"kurl"`, required), `network` (`"online"` or `"airgap"`, optional filter), `title` (optional, defaults to "Installations in progress"), `emptyText` (optional), `initialVisible` (optional, number of items to show before "Show all").
 
 **`<NewInstall>`**: Button to start a new installation. Creates a service account and generates credentials, which populate the install commands on the page.
 
@@ -335,7 +335,7 @@ Props: `method` (`"linux"` or `"helm"`, required), `network` (`"online"` or `"ai
 <NewInstall method="helm" />
 ```
 
-Props: `method` (`"linux"` or `"helm"`, required), `network` (`"online"` or `"airgap"`, optional, defaults to `"online"`), `label` (optional, defaults to "New installation").
+Props: `method` (`"linux"`, `"helm"`, `"kots"`, or `"kurl"`, required), `network` (`"online"` or `"airgap"`, optional, defaults to `"online"`), `label` (optional, defaults to "New installation").
 
 :::note
 The install commands on the page are personalized to the selected installation. If you switch installations or rename your instance, the commands update automatically.
@@ -355,7 +355,7 @@ Props: `installType` (`"linux"` or `"helm"`).
 <VersionSelector installType="helm" />
 ```
 
-Props: `installType` (`"linux"` or `"helm"`).
+Props: `installType` (`"linux"`, `"helm"`, `"kots"`, or `"kurl"`).
 
 **`<KubernetesDistribution />`**: Selector for the target Kubernetes distribution (EKS, GKE, AKS, etc.). No props.
 
@@ -373,9 +373,25 @@ When a customer selects limited or no registry access, `<HelmInstallAssets />` a
 
 When a customer selects limited or no registry access, `<HelmAirgapInstallAssets />` automatically includes browser download links for Helm chart tarballs. These links are also shown in the update flow for customers in the same registry mode.
 
-**`<KotsDownloadAssets />`**: Renders a KOTS downloads section with a version picker for the selected release. Downloadable artifacts include the KOTS CLI, the Admin Console bundle, and the application air gap bundle. Available when the customer's license has the KOTS install type with air gap enabled. Props: `stepNumber`.
+**`<KotsInstallAssets />`**: Renders the full online KOTS existing-cluster installation command sequence. The generated `kubectl kots install` command includes `--license-file ./license.yaml`. Props: `stepNumber` (optional, starting step number).
 
-**`<KurlDownloadAssets />`**: Renders a kURL downloads section with a version picker for the selected release. Downloadable artifacts include the kURL installer bundle and the application air gap bundle. Available when the customer's license has the kURL install type with air gap enabled. Props: `stepNumber`.
+**`<KurlInstallAssets />`**: Renders the full online kURL installation command sequence. Props: `stepNumber` (optional, starting step number).
+
+**`<KotsAirgapInstallAssets />`**: Renders KOTS air gap installation steps. The first step includes artifact download links. The following step includes `kubectl kots install` with `--license-file ./license.yaml` and `--airgap-bundle`. When a private registry hostname is available, the commands use that hostname in place of `$YOUR_PRIVATE_REGISTRY`. Props: `stepNumber`.
+
+**`<KurlAirgapInstallAssets />`**: Renders kURL air gap installation steps. The first step includes artifact download links. The following step extracts the installer, runs `install.sh airgap`, and runs `kubectl kots install` with `--license-file ./license.yaml`. Props: `stepNumber`.
+
+**`<KotsInstallStep>`**: Renders one online KOTS install step by name. Props: `step` (required), `stepNumber` (optional). Use `step="install_kots"`.
+
+**`<KurlInstallStep>`**: Renders one online kURL install step by name. Props: `step` (required), `stepNumber` (optional). Use `step="install_kurl"`.
+
+**`<KotsAirgapInstallStep>`**: Renders one KOTS air gap install step by name. Props: `step` (required), `stepNumber` (optional). Use `step="download_assets"` or `step="install_kots"`. `step="download"` is an alias for `download_assets`.
+
+**`<KurlAirgapInstallStep>`**: Renders one kURL air gap install step by name. Props: `step` (required), `stepNumber` (optional). Use `step="download_assets"` or `step="install_kurl"`.
+
+**`<KotsDownloadAssets />`**: Renders a KOTS downloads section with a version picker for the selected release. Downloadable artifacts include the KOTS CLI, the Admin Console bundle, and the application air gap bundle. Available when the customer's license has the KOTS install type with air gap enabled. This component does not render install commands. Props: `stepNumber`.
+
+**`<KurlDownloadAssets />`**: Renders a kURL downloads section with a version picker for the selected release. Downloadable artifacts include the kURL installer bundle and the application air gap bundle. Available when the customer's license has the kURL install type with air gap enabled. This component does not render install commands. Props: `stepNumber`.
 
 **`<InstanceName />`**: Prompts the customer to name their instance after installation. Renaming updates the service account name and refreshes the install commands on the page.
 
@@ -383,7 +399,7 @@ When a customer selects limited or no registry access, `<HelmAirgapInstallAssets
 <InstanceName />
 ```
 
-Props: `title` (optional, defaults to "Name Your Instance"), `method` (optional).
+Props: `title` (optional, defaults to "Name Your Instance"), `method` (optional, `"linux"`, `"helm"`, `"kots"`, or `"kurl"`).
 
 **`<AdminConsoleUrl />`**: Displays the admin console URL for Embedded Cluster installations. No props.
 
@@ -426,23 +442,29 @@ Props: `stepNumber`, `title`, `optional` (boolean).
 </Prerequisites>
 ```
 
-#### Adding KOTS or kURL installer pages
+#### Add KOTS or kURL installer pages
 
-KOTS and kURL instances already appear on the Instances & Updates page with no setup, where entitled customers can download versioned artifacts and create air gap instance records. This is rendered by the `<InstancesAndUpdates />` component, which ships in the default template. The dedicated installer pages described here are an optional addition that gives KOTS and kURL customers a download page of their own, the same as the Linux and Helm install pages.
+KOTS and kURL instances already appear on the Instances & Updates page with no setup. Entitled customers see generated CLI upgrade steps there, including air gap download links. The `<InstancesAndUpdates />` component in the default template renders this page.
 
-The default content template ships install pages for Embedded Cluster (`pages/installation/linux.md`) and Helm (`pages/installation/helm.md`), already listed in `toc.yaml`. It does not ship pages for KOTS or kURL. To give those customers a dedicated installer page, add one yourself using the `<KotsDownloadAssets />` or `<KurlDownloadAssets />` component.
+The default content template ships install pages for Embedded Cluster (`pages/installation/linux.md`) and Helm (`pages/installation/helm.md`), already listed in `toc.yaml`. It does not ship pages for KOTS or kURL. To give those customers a dedicated installer page, add one in your content repo.
 
-1. Create a page that embeds the component, for example `pages/installation/kots.md`:
+`<NetworkAvailability>` accepts only `"linux"` or `"helm"`. For KOTS and kURL, use the matching online or air gap components instead of a network toggle.
+
+1. Create a page that starts an install and renders the generated commands, for example `pages/installation/kots.md`:
 
    ```markdown
    # KOTS Installation
 
-   Download the artifacts for your licensed version below.
-
-   <KotsDownloadAssets stepNumber={1} />
+   <PendingInstallSelector method="kots" />
+   <NewInstall method="kots" />
+   <VersionSelector installType="kots" />
+   <KotsInstallAssets stepNumber={1} />
+   <InstanceName method="kots" />
    ```
 
-1. Add the page to `toc.yaml` under the Installation section, gated with `visible_when` so it only appears for customers whose license includes the KOTS install type with air gap enabled:
+   To author a single generated step instead of the full sequence, use `<KotsInstallStep step="install_kots" stepNumber={1} />`.
+
+1. Add the page to `toc.yaml` in the Installation section. Gate it with `visible_when` so it appears only for customers whose license includes that install type:
 
    ```yaml
    - title: KOTS
@@ -450,18 +472,23 @@ The default content template ships install pages for Embedded Cluster (`pages/in
      visible_when:
        entitlements:
          - isKotsInstallEnabled
-         - isAirgapSupported
    ```
 
-For kURL, use the `<KurlDownloadAssets />` component and gate the navigation item on `isKurlInstallEnabled` and `isAirgapSupported`.
+1. For kURL, use the same page shape with `method="kurl"` and `installType="kurl"`. Use `<KurlInstallAssets />` or `<KurlInstallStep step="install_kurl" />`. Gate the navigation item on `isKurlInstallEnabled`.
 
-The download components gate themselves on the same entitlements, so a customer who reaches the page without them sees nothing to download. Matching the `visible_when` conditions to the component keeps the navigation item hidden for those customers instead of showing them an empty page.
+1. For air gap pages, set `network="airgap"` on `<PendingInstallSelector>` and `<NewInstall>`. Use `<KotsAirgapInstallAssets />` or `<KurlAirgapInstallAssets />`. Gate those pages on the install-type entitlement and `isAirgapSupported`. Air gap step components use `step="download_assets"`, then `step="install_kots"` or `step="install_kurl"`.
+
+1. To keep a download-only air gap page, use `<KotsDownloadAssets />` or `<KurlDownloadAssets />` instead of the install-assets components. Gate download-only pages on the install-type entitlement and `isAirgapSupported`. The download components do not render install commands.
 
 ### Update components
 
 **`<LinuxUpdateAssets />`**: Renders Linux/Embedded Cluster upgrade instructions for the customer's current instance. For air gap upgrades, includes a registry hostname input for image relocation when the customer uses a private registry. Props: `stepNumber`.
 
 **`<HelmUpdateAssets />`**: Renders Helm upgrade instructions. Props: `stepNumber`, `charts` (optional), `exclude` (optional).
+
+**`<KotsUpdateAssets />`**: Renders KOTS upgrade CLI commands for the customer's current instance. Online upgrades use `kubectl kots upstream upgrade --deploy`. Air gap upgrades include artifact downloads on the steps, then `push-images` and `upstream upgrade --airgap-bundle`. Props: `stepNumber`.
+
+**`<KurlUpdateAssets />`**: Renders kURL upgrade CLI commands for the customer's current instance. Online upgrades reuse the kURL installer command. Air gap upgrades include artifact downloads on the steps, then `upgrade.sh` and `kubectl kots upstream upgrade --airgap-bundle`. Props: `stepNumber`.
 
 **`<UpgradePath>`**: Conditionally shows content based on the customer's current version. Lets you show different upgrade instructions depending on which version the customer is upgrading *from*.
 
@@ -526,7 +553,7 @@ Each of the four support bundle components renders the steps for one installatio
 
 **`<LicenseDownload />`**: Renders a button that lets customers download their license file. The button appears only for customers whose license enables Embedded Cluster, KOTS, or kURL installations, which are the installation methods that use a license file. Helm customers do not see it. No props.
 
-**`<InstancesAndUpdates />`**: Renders the full instances and updates management page inline. Helm and Embedded Cluster instances expand into inline upgrade instructions, while KOTS and kURL instances expand into a panel for downloading versioned install and update artifacts. No props.
+**`<InstancesAndUpdates />`**: Renders the full instances and updates management page inline. Helm, Embedded Cluster, KOTS, and kURL instances expand into inline upgrade CLI commands. For air gap KOTS and kURL, those steps include the artifact downloads. No props.
 
 ### Security components
 

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -347,7 +347,7 @@ The install commands on the page are personalized to the selected installation. 
 <NetworkAvailability installType="linux" />
 ```
 
-Props: `installType` (`"linux"` or `"helm"`).
+Props: `installType` (`"linux"`, `"helm"`, `"kots"`, or `"kurl"`).
 
 **`<VersionSelector>`**: Dropdown for selecting which release version to install.
 
@@ -359,7 +359,7 @@ Props: `installType` (`"linux"`, `"helm"`, `"kots"`, or `"kurl"`).
 
 **`<KubernetesDistribution />`**: Selector for the target Kubernetes distribution (EKS, GKE, AKS, etc.). No props.
 
-**`<RegistryAccess />`**: Displays registry credentials and pull secret configuration. No props.
+**`<RegistryAccess />`**: Selects registry access settings and accepts a private registry hostname. Props: `installType` (`"linux"`, `"helm"`, `"kots"`, or `"kurl"`, optional, defaults to `"helm"`). For Helm, KOTS, and kURL, the component appears only when the page's network selection is air gap.
 
 **`<LinuxInstallAssets />`**: Renders the full Linux/Embedded Cluster installation command sequence. Adapts to the customer's selected version and network availability. For air gap installations, includes an optional toggle for private registry image relocation. When enabled, the customer enters their registry hostname and the commands update to include image pull, tag, and push steps targeting that registry. Props: `stepNumber` (optional, starting step number).
 
@@ -388,6 +388,8 @@ When a customer selects limited or no registry access, `<HelmAirgapInstallAssets
 **`<KotsAirgapInstallStep>`**: Renders one KOTS air gap install step by name. Props: `step` (required), `stepNumber` (optional). Use `step="download_assets"` or `step="install_kots"`. `step="download"` is an alias for `download_assets`.
 
 **`<KurlAirgapInstallStep>`**: Renders one kURL air gap install step by name. Props: `step` (required), `stepNumber` (optional). Use `step="download_assets"` or `step="install_kurl"`.
+
+For all four KOTS and kURL step components, `step="install"` selects the corresponding `install_kots` or `install_kurl` step.
 
 **`<KotsDownloadAssets />`**: Renders a KOTS downloads section with a version picker for the selected release. Downloadable artifacts include the KOTS CLI, the Admin Console bundle, and the application air gap bundle. Available when the customer's license has the KOTS install type with air gap enabled. This component does not render install commands. Props: `stepNumber`.
 
@@ -448,7 +450,7 @@ KOTS and kURL instances already appear on the Instances & Updates page with no s
 
 The default content template ships install pages for Embedded Cluster (`pages/installation/linux.md`) and Helm (`pages/installation/helm.md`), already listed in `toc.yaml`. It does not ship pages for KOTS or kURL. To give those customers a dedicated installer page, add one in your content repo.
 
-`<NetworkAvailability>` accepts only `"linux"` or `"helm"`. For KOTS and kURL, use the matching online or air gap components instead of a network toggle.
+To let customers choose network availability, include `<NetworkAvailability>` and `<VersionSelector>` with the same `installType`, either `"kots"` or `"kurl"`. The following examples use separate online and air gap pages instead.
 
 1. Create a page that starts an install and renders the generated commands, for example `pages/installation/kots.md`:
 
@@ -479,7 +481,7 @@ The default content template ships install pages for Embedded Cluster (`pages/in
 
 1. For kURL, use the same page shape with `method="kurl"` and `installType="kurl"`. Use `<KurlInstallAssets />` or `<KurlInstallStep step="install_kurl" />`. Gate the navigation item on `isKurlInstallEnabled`.
 
-1. For air gap pages, set `network="airgap"` on `<PendingInstallSelector>` and `<NewInstall>`. Use `<KotsAirgapInstallAssets />` or `<KurlAirgapInstallAssets />`. Omit `<VersionSelector>`: without a supported network control, it changes the installation to online mode. For example:
+1. For air gap pages, set `network="airgap"` on `<PendingInstallSelector>` and `<NewInstall>`. Use `<KotsAirgapInstallAssets />` or `<KurlAirgapInstallAssets />`. Omit `<VersionSelector>` unless the page also includes a matching `<NetworkAvailability>` control. Without that control, the version selector changes the installation to online mode. For example:
 
    ```markdown
    # KOTS air gap installation
@@ -493,9 +495,9 @@ The default content template ships install pages for Embedded Cluster (`pages/in
 
    Customers must transfer `license.yaml` and the downloaded artifacts to the air gap environment before running the commands.
 
-   For KOTS, customers must replace `$YOUR_PRIVATE_REGISTRY` in the generated commands with their private registry hostname. This page has no registry hostname input, and the single-quoted placeholder does not expand as a shell variable.
+   For KOTS, customers must replace `$YOUR_PRIVATE_REGISTRY` in the generated commands with their private registry hostname. This example has no registry hostname input, and the single-quoted placeholder does not expand as a shell variable.
 
-   These pages have no in-page version dropdown. Existing installations keep their selected release. New installations use the release matching the rendered content version, or the latest matching release when no version matches.
+   This example has no in-page version dropdown. Existing installations keep their selected release. New installations use the release matching the rendered content version, or the latest matching release when no version matches.
 
    Gate these pages on the install-type entitlement and `isAirgapSupported`. Air gap step components use `step="download_assets"`, then `step="install_kots"` or `step="install_kurl"`.
 

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -335,7 +335,9 @@ Props: `method` (`"linux"`, `"helm"`, `"kots"`, or `"kurl"`, required), `network
 <NewInstall method="helm" />
 ```
 
-Props: `method` (`"linux"`, `"helm"`, `"kots"`, or `"kurl"`, required), `network` (`"online"` or `"airgap"`, optional, defaults to `"online"`), `label` (optional, defaults to "New installation").
+Props: `method` (`"linux"`, `"helm"`, `"kots"`, or `"kurl"`, required), `network` (`"online"` or `"airgap"`, optional), `label` (optional, defaults to "New installation").
+
+If you omit `network`, the default depends on the page's network selection: `"airgap"` for air gap, or `"online"` otherwise.
 
 :::note
 The install commands on the page are personalized to the selected installation. If you switch installations or rename your instance, the commands update automatically.

--- a/docs/vendor/enterprise-portal-v2-content.mdx
+++ b/docs/vendor/enterprise-portal-v2-content.mdx
@@ -455,12 +455,15 @@ The default content template ships install pages for Embedded Cluster (`pages/in
    ```markdown
    # KOTS Installation
 
-   <PendingInstallSelector method="kots" />
+   <PendingInstallSelector method="kots" network="online" />
    <NewInstall method="kots" />
    <VersionSelector installType="kots" />
+   <LicenseDownload />
    <KotsInstallAssets stepNumber={1} />
    <InstanceName method="kots" />
    ```
+
+   Customers must download the license for their installation and save it as `license.yaml` in the directory where they run the commands.
 
    To author a single generated step instead of the full sequence, use `<KotsInstallStep step="install_kots" stepNumber={1} />`.
 
@@ -476,7 +479,23 @@ The default content template ships install pages for Embedded Cluster (`pages/in
 
 1. For kURL, use the same page shape with `method="kurl"` and `installType="kurl"`. Use `<KurlInstallAssets />` or `<KurlInstallStep step="install_kurl" />`. Gate the navigation item on `isKurlInstallEnabled`.
 
-1. For air gap pages, set `network="airgap"` on `<PendingInstallSelector>` and `<NewInstall>`. Use `<KotsAirgapInstallAssets />` or `<KurlAirgapInstallAssets />`. Gate those pages on the install-type entitlement and `isAirgapSupported`. Air gap step components use `step="download_assets"`, then `step="install_kots"` or `step="install_kurl"`.
+1. For air gap pages, set `network="airgap"` on `<PendingInstallSelector>` and `<NewInstall>`. Use `<KotsAirgapInstallAssets />` or `<KurlAirgapInstallAssets />`. Omit `<VersionSelector>`: without a supported network control, it changes the installation to online mode. For example:
+
+   ```markdown
+   # KOTS air gap installation
+
+   <PendingInstallSelector method="kots" network="airgap" />
+   <NewInstall method="kots" network="airgap" />
+   <LicenseDownload />
+   <KotsAirgapInstallAssets stepNumber={1} />
+   <InstanceName method="kots" />
+   ```
+
+   Customers must transfer `license.yaml` and the downloaded artifacts to the air gap environment before running the commands.
+
+   These pages have no in-page version dropdown. Existing installations keep their selected release. New installations use the release matching the rendered content version, or the latest matching release when no version matches.
+
+   Gate these pages on the install-type entitlement and `isAirgapSupported`. Air gap step components use `step="download_assets"`, then `step="install_kots"` or `step="install_kurl"`.
 
 1. To keep a download-only air gap page, use `<KotsDownloadAssets />` or `<KurlDownloadAssets />` instead of the install-assets components. Gate download-only pages on the install-type entitlement and `isAirgapSupported`. The download components do not render install commands.
 

--- a/docs/vendor/enterprise-portal-v2-use.mdx
+++ b/docs/vendor/enterprise-portal-v2-use.mdx
@@ -80,11 +80,13 @@ For Embedded Cluster air gap installations, customers using a private registry c
 
 KOTS and kURL instances appear on the **Instances & Updates** page alongside Helm and Embedded Cluster instances, labeled **KOTS** or **kURL**. Each instance shows its current version and status.
 
-KOTS and kURL instance cards expand into a panel for downloading versioned artifacts. Customers select a release, either one newer than their current version or the current version when they are up to date. They then download that release's artifacts, such as the application air gap bundle, the Admin Console or installer bundle, and any available command-line tools.
+Instance cards expand into inline CLI upgrade steps. Customers select a target version and copy the generated commands. The portal generates CLI commands for these upgrades, not Admin Console instructions.
 
-The download panel appears only for customers whose license has the KOTS or kURL install type together with air gap enabled. If the customer's license has expired, the panel shows a renewal notice instead of the version picker.
+For online KOTS, the commands install the KOTS CLI and run `kubectl kots upstream upgrade`. For online kURL, the commands reuse the kURL installer from `kurl.sh`.
 
-When the vendor includes them, customers can also download the same artifacts from dedicated installer pages, one for KOTS and one for kURL. These pages offer the same version picker and downloads, with the same install-type and air gap gating as the instance card panel.
+For air gap KOTS and kURL, the expanded card includes artifact download links, then the CLI commands that apply those assets.
+
+Vendors can also add dedicated KOTS and kURL install pages in the content repo. Those pages render generated online install commands, including `kubectl kots install --license-file ./license.yaml` for KOTS. Air gap install pages include artifact download links. The default content template does not include these pages. For more information, see [Add KOTS or kURL installer pages](/vendor/enterprise-portal-v2-content#add-kots-or-kurl-installer-pages) in _Customize Portal Content_.
 
 Customers can create air gap instance records for KOTS and kURL the same way as for Helm and Embedded Cluster. They can enter instance information manually from the Instances & Updates page, or extract details from an uploaded support bundle. Availability depends on the customer's license having the corresponding install type and air gap option enabled.
 


### PR DESCRIPTION
## Summary

[SC-138993](https://app.shortcut.com/replicated/story/138993): document the default Enterprise Portal v2 KOTS install page (online/proxy generated commands, air gap procedure) and what vendors customize.

## Related PRs

1. [vandoor #10535](https://github.com/replicatedhq/vandoor/pull/10535) — ships `<WhenNetwork>`.
2. [enterprise-portal-content #6](https://github.com/replicatedhq/enterprise-portal-content/pull/6) — default `pages/installation/kots.md`.
3. **This PR** — vendor docs.

## Changes

- Invert KOTS/kURL docs: the default template ships those pages; document what they contain and what to customize.
- Document `<WhenNetwork>` (accepted modes `online`, `proxy`, `airgap`) and `<NetworkAvailability>` (online / proxy / air gap; optional `installType`).
- Instances & Updates: Helm and Embedded Cluster can expand into generated CLI upgrades. KOTS and kURL upgrades are performed in the Admin Console.
- Default KOTS page includes `<LicenseDownload />` for every network mode.

## Source PRs

- [WhenNetwork + install config: vandoor #10535](https://github.com/replicatedhq/vandoor/pull/10535)
- [Default KOTS page: enterprise-portal-content #6](https://github.com/replicatedhq/enterprise-portal-content/pull/6)
- [KOTS generators: vandoor #10465](https://github.com/replicatedhq/vandoor/pull/10465)
- [kURL generators: vandoor #10486](https://github.com/replicatedhq/vandoor/pull/10486)
- [Update generators and UI: vandoor #10501](https://github.com/replicatedhq/vandoor/pull/10501)
- [Install-authoring follow-up: vandoor #10512](https://github.com/replicatedhq/vandoor/pull/10512)

## Testing

- `npm run build`: passed, with existing missing-partial and broken-link/anchor warnings outside the changed pages.
- Vale: zero alerts on changed lines across all three files; pre-existing whole-file alerts remain.
- `git diff --check`: passed.

## Screenshots and verification

Served the production build locally and checked the changed pages. Actual KOTS/kURL installations and upgrades were not run.
