### PR TITLE
Document Troubleshoot CLI provenance verification

### DIFF
--- a/docs/enterprise/cli-provenance-validating.md
+++ b/docs/enterprise/cli-provenance-validating.md
@@ -1,12 +1,12 @@
-# Validate Troubleshoot CLI provenance
+# Validate CLI provenance
 
-This topic describes how to use Cosign to verify keyless Supply Chain Levels for Software Artifacts (SLSA) provenance for Troubleshoot CLI release archives.
+This topic describes how to use Cosign to verify keyless Supply Chain Levels for Software Artifacts (SLSA) provenance for Replicated CLI release archives.
 
-## About Troubleshoot CLI provenance
+## About CLI provenance
 
-Troubleshoot releases provide the `preflight` and `support-bundle` CLIs for multiple operating systems and architectures. A release that supports CLI provenance verification includes a `troubleshoot_VERSION_provenance.sigstore.json` bundle. The bundle contains signed SLSA provenance for all `preflight` and `support-bundle` archives in that release.
+Replicated CLI releases can include a Sigstore bundle containing signed SLSA provenance. The provenance associates each release archive's digest with the workflow and release tag that produced it. The keyless signature uses a short-lived certificate issued through the build system's OpenID Connect (OIDC) identity.
 
-The provenance associates each archive's digest with the Troubleshoot release workflow and release tag that produced it. The keyless signature uses a short-lived certificate issued through the GitHub Actions OpenID Connect (OIDC) identity.
+To verify a CLI archive, download the archive and its Sigstore bundle from the same release. Then, use Cosign to confirm that the archive's digest is included in the signed provenance and that the expected workflow identity produced the attestation.
 
 For information about validating Replicated container images, see [Validate image provenance](/enterprise/image-provenance-validating). For information about validating SBOM signatures, see [Validate SBOM signatures](/enterprise/sbom-validating).
 
@@ -14,7 +14,9 @@ For information about validating Replicated container images, see [Validate imag
 
 Before you perform this task, install [Cosign](https://github.com/sigstore/cosign) v3.1.3 or later.
 
-## Validate a CLI archive
+## Validate Troubleshoot CLI provenance
+
+Troubleshoot releases provide the `preflight` and `support-bundle` CLIs for multiple operating systems and architectures. A release that supports CLI provenance verification includes a `troubleshoot_VERSION_provenance.sigstore.json` bundle. The bundle contains signed SLSA provenance for all `preflight` and `support-bundle` archives in that release.
 
 To validate a Troubleshoot CLI archive:
 

--- a/docs/enterprise/cli-provenance-validating.md
+++ b/docs/enterprise/cli-provenance-validating.md
@@ -16,7 +16,7 @@ Before you perform this task, install [Cosign](https://github.com/sigstore/cosig
 
 ## Validate Troubleshoot CLI provenance
 
-Troubleshoot releases provide the `preflight` and `support-bundle` CLIs for multiple operating systems and architectures. CLI provenance is available for Troubleshoot release 0.135.0 and later. Each supported release includes a `troubleshoot_VERSION_provenance.sigstore.json` bundle containing signed SLSA provenance for all `preflight` and `support-bundle` archives in that release.
+Troubleshoot releases provide the `preflight` and `support-bundle` CLIs for multiple operating systems and architectures. CLI provenance is available for Troubleshoot release 0.134.1 and later. Each supported release includes a `troubleshoot_VERSION_provenance.sigstore.json` bundle containing signed SLSA provenance for all `preflight` and `support-bundle` archives in that release.
 
 To validate a Troubleshoot CLI archive:
 
@@ -26,7 +26,7 @@ To validate a Troubleshoot CLI archive:
 
 1. In the following command, replace:
 
-   - `VERSION` with the complete release tag, including the `v` prefix. For example, `v0.135.0`.
+   - `VERSION` with the complete release tag, including the `v` prefix. For example, `v0.134.1`.
    - `ARCHIVE` with the name of the downloaded archive. For example, `preflight_linux_amd64.tar.gz`.
 
 1. Run:

--- a/docs/enterprise/cli-provenance-validating.md
+++ b/docs/enterprise/cli-provenance-validating.md
@@ -16,7 +16,7 @@ Before you perform this task, install [Cosign](https://github.com/sigstore/cosig
 
 ## Validate Troubleshoot CLI provenance
 
-Troubleshoot releases provide the `preflight` and `support-bundle` CLIs for multiple operating systems and architectures. A release that supports CLI provenance verification includes a `troubleshoot_VERSION_provenance.sigstore.json` bundle. The bundle contains signed SLSA provenance for all `preflight` and `support-bundle` archives in that release.
+Troubleshoot releases provide the `preflight` and `support-bundle` CLIs for multiple operating systems and architectures. CLI provenance is available for Troubleshoot release 0.135.0 and later. Each supported release includes a `troubleshoot_VERSION_provenance.sigstore.json` bundle containing signed SLSA provenance for all `preflight` and `support-bundle` archives in that release.
 
 To validate a Troubleshoot CLI archive:
 

--- a/docs/enterprise/image-provenance-validating.md
+++ b/docs/enterprise/image-provenance-validating.md
@@ -2,7 +2,7 @@
 
 This topic describes how to verify the authenticity and integrity of Replicated container images, including Supply Chain Levels for Software Artifacts (SLSA) provenance, image signatures, and Software Bill of Materials (SBOM) attestations.
 
-For information about validating SLSA provenance for Troubleshoot CLI release archives, see [Validate Troubleshoot CLI provenance](/enterprise/troubleshoot-cli-provenance-validating).
+For information about validating SLSA provenance for CLI release archives, see [Validate CLI provenance](/enterprise/cli-provenance-validating).
 
 ## About SLSA and SBOMs
 

--- a/docs/enterprise/image-provenance-validating.md
+++ b/docs/enterprise/image-provenance-validating.md
@@ -2,6 +2,8 @@
 
 This topic describes how to verify the authenticity and integrity of Replicated container images, including Supply Chain Levels for Software Artifacts (SLSA) provenance, image signatures, and Software Bill of Materials (SBOM) attestations.
 
+For information about validating SLSA provenance for Troubleshoot CLI release archives, see [Validate Troubleshoot CLI provenance](/enterprise/troubleshoot-cli-provenance-validating).
+
 ## About SLSA and SBOMs
 
 [SLSA](https://slsa.dev/), pronounced "salsa," is a security framework that provides standards and controls designed to prevent tampering, improve integrity, and secure software packages and infrastructure. SLSA provenance provides information about an image's origin, creator, and build process.

--- a/docs/enterprise/troubleshoot-cli-provenance-validating.md
+++ b/docs/enterprise/troubleshoot-cli-provenance-validating.md
@@ -1,0 +1,43 @@
+# Validate Troubleshoot CLI provenance
+
+This topic describes how to use Cosign to verify keyless Supply Chain Levels for Software Artifacts (SLSA) provenance for Troubleshoot CLI release archives.
+
+## About Troubleshoot CLI provenance
+
+Troubleshoot releases provide the `preflight` and `support-bundle` CLIs for multiple operating systems and architectures. A release that supports CLI provenance verification includes a `troubleshoot_VERSION_provenance.sigstore.json` bundle. The bundle contains signed SLSA provenance for all `preflight` and `support-bundle` archives in that release.
+
+The provenance associates each archive's digest with the Troubleshoot release workflow and release tag that produced it. The keyless signature uses a short-lived certificate issued through the GitHub Actions OpenID Connect (OIDC) identity.
+
+For information about validating Replicated container images, see [Validate image provenance](/enterprise/image-provenance-validating). For information about validating SBOM signatures, see [Validate SBOM signatures](/enterprise/sbom-validating).
+
+## Prerequisite
+
+Before you perform this task, install [Cosign](https://github.com/sigstore/cosign) v3.1.3 or later.
+
+## Validate a CLI archive
+
+To validate a Troubleshoot CLI archive:
+
+1. Go to [Troubleshoot releases](https://github.com/replicatedhq/troubleshoot/releases) and select the release that you want to validate.
+
+1. Download one `preflight` or `support-bundle` archive and the `troubleshoot_VERSION_provenance.sigstore.json` bundle from the same release.
+
+1. In the following command, replace:
+
+   - `VERSION` with the complete release tag, including the `v` prefix. For example, `v0.135.0`.
+   - `ARCHIVE` with the name of the downloaded archive. For example, `preflight_linux_amd64.tar.gz`.
+
+1. Run:
+
+   ```bash
+   cosign verify-blob-attestation \
+     --bundle troubleshoot_VERSION_provenance.sigstore.json \
+     --type https://slsa.dev/provenance/v1 \
+     --certificate-identity "https://github.com/replicatedhq/troubleshoot/.github/workflows/release.yaml@refs/tags/VERSION" \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     ARCHIVE
+   ```
+
+Successful verification confirms that the archive's digest is included in the signed SLSA provenance. It also confirms that the expected Troubleshoot release workflow produced the attestation for the selected tag. Cosign verifies the signing certificate and transparency log information in the Sigstore bundle.
+
+Cosign returns a nonzero exit status if verification fails. Do not use the archive if verification fails.

--- a/sidebars.js
+++ b/sidebars.js
@@ -900,6 +900,7 @@ const sidebars = {
         },
         "enterprise/sbom-validating",
         "enterprise/image-provenance-validating",
+        "enterprise/troubleshoot-cli-provenance-validating",
         "vendor/vendor-password-integrity",
         "vendor/packaging-private-registry-security",
       ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -900,7 +900,7 @@ const sidebars = {
         },
         "enterprise/sbom-validating",
         "enterprise/image-provenance-validating",
-        "enterprise/troubleshoot-cli-provenance-validating",
+        "enterprise/cli-provenance-validating",
         "vendor/vendor-password-integrity",
         "vendor/packaging-private-registry-security",
       ],


### PR DESCRIPTION
## Summary

- add a Troubleshoot-specific page for verifying keyless SLSA provenance on `preflight` and `support-bundle` release archives beginning with version 0.134.1
- move the SBOM and image provenance pages from `/enterprise` to `/vendor` and add redirects for their published URLs
- repoint the existing Replicated SDK redirect directly to the relocated image provenance page
- update the security sidebar and cross-links for the vendor namespace
- clarify the provenance bundle `v` prefix, Windows `.zip` archives, placeholder substitution, and tested Cosign version

## Testing

- `npm run build`
- `git diff --check`
- `node --check sidebars.js`
- confirmed all three pages were generated under `/vendor`

The documentation build succeeds. It reports existing broken-link and broken-anchor warnings unrelated to these changes.